### PR TITLE
Wallet state manager 2

### DIFF
--- a/miner-app/lib/features/miner/miner_dashboard_screen.dart
+++ b/miner-app/lib/features/miner/miner_dashboard_screen.dart
@@ -71,7 +71,6 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
           _walletBalance = 'Address not set';
           _walletAddress = null;
         });
-        // TODO: Implement navigation to rewards address setup screen
         print('Rewards address mnemonic not found. Redirecting to setup...');
         // Example Navigation (requires go_router setup)
         // context.go('/rewards_address_setup');
@@ -81,7 +80,6 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
         _walletBalance = 'Error fetching balance';
         _walletAddress = address;
       });
-      // TODO: Show a more user-friendly error message (e.g., Snackbar)
       print('Error fetching wallet balance: $e');
     }
   }
@@ -190,7 +188,6 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
                                   style: const TextStyle(fontSize: 14, color: Colors.black54, fontFamily: 'Fira Code'),
                                 ),
                               ),
-                            // TODO: Potentially add recent transactions or address here
                           ],
                         ),
                       ),
@@ -216,7 +213,6 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
                       (_miningStats.trim().isEmpty) ? 'No data' : _miningStats.replaceAll('\\n', '\n'),
                       style: const TextStyle(fontSize: 16),
                     ),
-                    // TODO: Format stats nicely, possibly with specific labels
                   ],
                 ),
               ),

--- a/miner-app/lib/features/setup/node_setup_screen.dart
+++ b/miner-app/lib/features/setup/node_setup_screen.dart
@@ -51,7 +51,6 @@ class _NodeSetupScreenState extends State<NodeSetupScreen> {
         _isExternalMinerInstalled = false;
         _isLoading = false;
       });
-      // TODO: Potentially show a user-friendly error message here
     }
   }
 
@@ -142,7 +141,6 @@ class _NodeSetupScreenState extends State<NodeSetupScreen> {
           _downloadProgressText = "Error: ${e.toString()}";
         });
       }
-      // TODO: Show a user-friendly error message indicating installation failed
       if (mounted) {
         ScaffoldMessenger.of(
           context,

--- a/miner-app/lib/features/setup/rewards_address_setup_screen.dart
+++ b/miner-app/lib/features/setup/rewards_address_setup_screen.dart
@@ -79,7 +79,6 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
 
       print('Seed securely stored.');
     } catch (e) {
-      // TODO: Handle error (e.g., show a Snackbar)
       print('Error generating mnemonic or storing seed: $e');
       setState(() {
         _currentStep = RewardsAddressSetupStep.notSet; // Go back to not set on error
@@ -96,7 +95,6 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
   void _importAddress() async {
     final mnemonic = _importController.text.trim();
     if (mnemonic.isEmpty) {
-      // TODO: Show an error to the user (e.g., Snackbar)
       print('Mnemonic/seed phrase cannot be empty.');
       return;
     }
@@ -115,7 +113,6 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
         _currentStep = RewardsAddressSetupStep.set; // Simulate success
       });
     } catch (e) {
-      // TODO: Handle error (e.g., show a Snackbar indicating invalid mnemonic)
       print('Error importing mnemonic or storing seed: $e');
       setState(() {
         _currentStep = RewardsAddressSetupStep.importExisting; // Stay on import screen on error
@@ -128,7 +125,6 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
       await _storage.write(key: 'rewards_address_mnemonic', value: mnemonic);
       print('Mnemonic securely stored.');
     } catch (e) {
-      // TODO: Handle error (e.g., show a Snackbar)
       print('Error securely storing seed: $e');
       // Depending on the severity and platform, you might want to show a critical error message.
       rethrow; // Rethrow to be caught by the calling function
@@ -263,7 +259,6 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
           ElevatedButton.icon(
             onPressed: () {
               Clipboard.setData(ClipboardData(text: _generatedMnemonic));
-              // TODO: Show a confirmation message (e.g., Snackbar)
               print('Mnemonic copied to clipboard');
             },
             icon: const Icon(Icons.copy),

--- a/mobile-app/lib/features/components/transaction_details_action_sheet.dart
+++ b/mobile-app/lib/features/components/transaction_details_action_sheet.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
-import 'package:quantus_sdk/src/services/human_readable_checksum_service.dart';
 
 class TransactionDetailsActionSheet extends StatelessWidget {
   final TransactionEvent transaction;

--- a/mobile-app/lib/features/components/transaction_list_item.dart
+++ b/mobile-app/lib/features/components/transaction_list_item.dart
@@ -22,6 +22,7 @@ class TransactionListItemState extends State<TransactionListItem> {
   Timer? _timer;
   Duration? _remainingTime;
   bool get isSent => widget.transaction.from == widget.currentWalletAddress;
+  bool get isPending => widget.transaction is PendingTransactionEvent;
   bool get isReversibleScheduled => widget.transaction.isScheduled;
   bool get isReversibleCancelled =>
       widget.transaction is ReversibleTransferEvent &&
@@ -137,6 +138,8 @@ class TransactionListItemState extends State<TransactionListItem> {
                             TextSpan(
                               text: isReversibleCancelled
                                   ? 'Cancelled'
+                                  : isSent && isPending
+                                  ? 'Sending'
                                   : isSent
                                   ? 'Sent'
                                   : 'Receive',

--- a/mobile-app/lib/features/components/transactions_list.dart
+++ b/mobile-app/lib/features/components/transactions_list.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/features/components/transaction_list_item.dart';
+
+class RecentTransactionsList extends StatelessWidget {
+  final List<TransactionEvent> transactions;
+  final String currentWalletAddress;
+  final bool Function(TransactionEvent)? filter;
+
+  const RecentTransactionsList({
+    super.key,
+    required this.transactions,
+    required this.currentWalletAddress,
+    this.filter,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final transactionsToShow = filter == null ? transactions : transactions.where(filter!).toList();
+
+    final scheduled = transactionsToShow
+        .whereType<ReversibleTransferEvent>()
+        .where((tx) => tx.status == ReversibleTransferStatus.SCHEDULED)
+        .toList();
+
+    final others = transactionsToShow.where((tx) {
+      if (tx is ReversibleTransferEvent) {
+        return tx.status != ReversibleTransferStatus.SCHEDULED;
+      }
+      return true;
+    }).toList();
+
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: ShapeDecoration(
+        color: const Color(0x3F000000), // black w/ alpha
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (transactionsToShow.isEmpty)
+            const Text(
+              'No transactions yet.',
+              style: TextStyle(color: Colors.white, fontFamily: 'Fira Code'),
+            )
+          else ...[
+            if (scheduled.isNotEmpty)
+              ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: scheduled.length,
+                itemBuilder: (context, index) {
+                  return TransactionListItem(transaction: scheduled[index], currentWalletAddress: currentWalletAddress);
+                },
+                separatorBuilder: (context, index) => const _Divider(),
+              ),
+            if (scheduled.isNotEmpty && others.isNotEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 12.0),
+                child: Divider(color: Colors.white, thickness: 1),
+              ),
+            if (others.isNotEmpty)
+              ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: others.length,
+                itemBuilder: (context, index) {
+                  return TransactionListItem(transaction: others[index], currentWalletAddress: currentWalletAddress);
+                },
+                separatorBuilder: (context, index) => const _Divider(),
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 7.0),
+      child: Divider(
+        color: Color(0x26FFFFFF), // white w/ alpha
+        height: 1,
+      ),
+    );
+  }
+}

--- a/mobile-app/lib/features/main/screens/send_progress_overlay.dart
+++ b/mobile-app/lib/features/main/screens/send_progress_overlay.dart
@@ -534,25 +534,6 @@ class SendConfirmationOverlayState extends State<SendConfirmationOverlay> {
               ),
             ),
             const SizedBox(height: 16),
-
-            // // View Transaction
-            // GestureDetector(
-            //   onTap: () {
-            //     // TODO: Implement view transaction logic - remove this probably
-            //   },
-            //   child: const Text(
-            //     'View Transaction',
-            //     textAlign: TextAlign.center,
-            //     style: TextStyle(
-            //       color: Color(0xFF16CECE),
-            //       fontSize: 12,
-            //       fontFamily: 'Fira Code',
-            //       fontWeight: FontWeight.w500,
-            //       decoration: TextDecoration.underline,
-            //       decorationColor: Color(0xFF16CECE),
-            //     ),
-            //   ),
-            // ),
           ],
         ),
         const SizedBox(height: 30),

--- a/mobile-app/lib/features/main/screens/send_progress_overlay.dart
+++ b/mobile-app/lib/features/main/screens/send_progress_overlay.dart
@@ -2,8 +2,10 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/features/main/screens/wallet_main.dart';
+import 'package:resonance_network_wallet/models/wallet_state_manager.dart';
 
 enum SendOverlayState { confirm, progress, complete }
 
@@ -66,6 +68,9 @@ class SendConfirmationOverlayState extends State<SendConfirmationOverlay> {
         throw Exception('Sender mnemonic not found. Please re-import your wallet.');
       }
 
+      // ignore: use_build_context_synchronously
+      final walletStateManager = Provider.of<WalletStateManager>(context, listen: false);
+
       debugPrint('Attempting balance transfer...');
       debugPrint('  Sender Seed: ${senderSeed.substring(0, 4)}...');
       debugPrint('  Recipient: ${widget.recipientAddress}');
@@ -74,9 +79,9 @@ class SendConfirmationOverlayState extends State<SendConfirmationOverlay> {
       debugPrint('  Reversible time: ${widget.reversibleTimeSeconds}');
 
       if (widget.reversibleTimeSeconds <= 0) {
-        await BalancesService().balanceTransfer(senderSeed, widget.recipientAddress, widget.amount);
+        await walletStateManager.balanceTransfer(senderSeed, widget.recipientAddress, widget.amount);
       } else {
-        await ReversibleTransfersService().scheduleReversibleTransferWithDelaySeconds(
+        await walletStateManager.scheduleReversibleTransferWithDelaySeconds(
           senderSeed: senderSeed,
           recipientAddress: widget.recipientAddress,
           amount: widget.amount,

--- a/mobile-app/lib/features/main/screens/send_progress_overlay.dart
+++ b/mobile-app/lib/features/main/screens/send_progress_overlay.dart
@@ -524,7 +524,7 @@ class SendConfirmationOverlayState extends State<SendConfirmationOverlay> {
 
             // Reversible for
             Text(
-              'Reversible for: ${_formatReversibleTime()}',
+              widget.reversibleTimeSeconds > 0 ? 'Reversible for: ${_formatReversibleTime()}' : '',
               textAlign: TextAlign.center,
               style: const TextStyle(
                 color: Colors.white,
@@ -535,24 +535,24 @@ class SendConfirmationOverlayState extends State<SendConfirmationOverlay> {
             ),
             const SizedBox(height: 16),
 
-            // View Transaction
-            GestureDetector(
-              onTap: () {
-                // TODO: Implement view transaction logic
-              },
-              child: const Text(
-                'View Transaction',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Color(0xFF16CECE),
-                  fontSize: 12,
-                  fontFamily: 'Fira Code',
-                  fontWeight: FontWeight.w500,
-                  decoration: TextDecoration.underline,
-                  decorationColor: Color(0xFF16CECE),
-                ),
-              ),
-            ),
+            // // View Transaction
+            // GestureDetector(
+            //   onTap: () {
+            //     // TODO: Implement view transaction logic - remove this probably
+            //   },
+            //   child: const Text(
+            //     'View Transaction',
+            //     textAlign: TextAlign.center,
+            //     style: TextStyle(
+            //       color: Color(0xFF16CECE),
+            //       fontSize: 12,
+            //       fontFamily: 'Fira Code',
+            //       fontWeight: FontWeight.w500,
+            //       decoration: TextDecoration.underline,
+            //       decorationColor: Color(0xFF16CECE),
+            //     ),
+            //   ),
+            // ),
           ],
         ),
         const SizedBox(height: 30),

--- a/mobile-app/lib/features/main/screens/send_progress_overlay.dart
+++ b/mobile-app/lib/features/main/screens/send_progress_overlay.dart
@@ -79,13 +79,14 @@ class SendConfirmationOverlayState extends State<SendConfirmationOverlay> {
       debugPrint('  Reversible time: ${widget.reversibleTimeSeconds}');
 
       if (widget.reversibleTimeSeconds <= 0) {
-        await walletStateManager.balanceTransfer(senderSeed, widget.recipientAddress, widget.amount);
+        await walletStateManager.balanceTransfer(senderSeed, widget.recipientAddress, widget.amount, widget.fee);
       } else {
         await walletStateManager.scheduleReversibleTransferWithDelaySeconds(
           senderSeed: senderSeed,
           recipientAddress: widget.recipientAddress,
           amount: widget.amount,
           delaySeconds: widget.reversibleTimeSeconds,
+          feeEstimate: widget.fee,
         );
       }
 

--- a/mobile-app/lib/features/main/screens/send_screen.dart
+++ b/mobile-app/lib/features/main/screens/send_screen.dart
@@ -322,99 +322,121 @@ class SendScreenState extends State<SendScreen> {
             ),
             const SizedBox(height: 40),
 
-            // Time picker labels
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 20),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  Text(
-                    'Days',
-                    style: TextStyle(color: Color(0xFFD9D9D9), fontSize: 16, fontFamily: 'Fira Code'),
-                  ),
-                  Text(
-                    'Hours',
-                    style: TextStyle(color: Color(0xFFD9D9D9), fontSize: 16, fontFamily: 'Fira Code'),
-                  ),
-                  Text(
-                    'Minutes',
-                    style: TextStyle(color: Color(0xFFD9D9D9), fontSize: 16, fontFamily: 'Fira Code'),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
-
             // Time pickers
             Expanded(
               child: Row(
                 children: [
-                  // Days picker
+                  // Days
                   Expanded(
-                    child: CupertinoPicker(
-                      scrollController: FixedExtentScrollController(initialItem: selectedDays),
-                      itemExtent: 40,
-                      onSelectedItemChanged: (index) => selectedDays = index,
-                      children: List.generate(
-                        8,
-                        (index) => Center(
-                          child: Text(
-                            index.toString().padLeft(2, '0'),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 28,
-                              fontFamily: 'Fira Code',
-                              fontWeight: FontWeight.w600,
-                            ),
+                    child: Column(
+                      children: [
+                        const Text(
+                          'Days',
+                          style: TextStyle(color: Color(0xFFD9D9D9), fontSize: 16, fontFamily: 'Fira Code'),
+                        ),
+                        const SizedBox(height: 8),
+                        Expanded(
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: CupertinoPicker(
+                                  scrollController: FixedExtentScrollController(initialItem: selectedDays),
+                                  itemExtent: 40,
+                                  onSelectedItemChanged: (index) => selectedDays = index,
+                                  children: List.generate(
+                                    8,
+                                    (index) => Center(
+                                      child: Text(
+                                        index.toString().padLeft(2, '0'),
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 28,
+                                          fontFamily: 'Fira Code',
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const Text(':', style: TextStyle(color: Colors.white, fontSize: 28)),
+                            ],
                           ),
                         ),
-                      ),
+                      ],
                     ),
                   ),
-                  const Text(':', style: TextStyle(color: Colors.white, fontSize: 20)),
-                  // Hours picker
+                  // Hours
                   Expanded(
-                    child: CupertinoPicker(
-                      scrollController: FixedExtentScrollController(initialItem: selectedHours),
-                      itemExtent: 40,
-                      onSelectedItemChanged: (index) => selectedHours = index,
-                      children: List.generate(
-                        24,
-                        (index) => Center(
-                          child: Text(
-                            index.toString().padLeft(2, '0'),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 28,
-                              fontFamily: 'Fira Code',
-                              fontWeight: FontWeight.w600,
-                            ),
+                    child: Column(
+                      children: [
+                        const Text(
+                          'Hours',
+                          style: TextStyle(color: Color(0xFFD9D9D9), fontSize: 16, fontFamily: 'Fira Code'),
+                        ),
+                        const SizedBox(height: 8),
+                        Expanded(
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: CupertinoPicker(
+                                  scrollController: FixedExtentScrollController(initialItem: selectedHours),
+                                  itemExtent: 40,
+                                  onSelectedItemChanged: (index) => selectedHours = index,
+                                  children: List.generate(
+                                    24,
+                                    (index) => Center(
+                                      child: Text(
+                                        index.toString().padLeft(2, '0'),
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 28,
+                                          fontFamily: 'Fira Code',
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const Text(':', style: TextStyle(color: Colors.white, fontSize: 28)),
+                            ],
                           ),
                         ),
-                      ),
+                      ],
                     ),
                   ),
-                  const Text(':', style: TextStyle(color: Colors.white, fontSize: 20)),
-                  // Minutes picker
+                  // Minutes
                   Expanded(
-                    child: CupertinoPicker(
-                      scrollController: FixedExtentScrollController(initialItem: selectedMinutes),
-                      itemExtent: 40,
-                      onSelectedItemChanged: (index) => selectedMinutes = index,
-                      children: List.generate(
-                        60,
-                        (index) => Center(
-                          child: Text(
-                            index.toString().padLeft(2, '0'),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 28,
-                              fontFamily: 'Fira Code',
-                              fontWeight: FontWeight.w600,
+                    child: Column(
+                      children: [
+                        const Text(
+                          'Minutes',
+                          style: TextStyle(color: Color(0xFFD9D9D9), fontSize: 16, fontFamily: 'Fira Code'),
+                        ),
+                        const SizedBox(height: 8),
+                        Expanded(
+                          child: CupertinoPicker(
+                            scrollController: FixedExtentScrollController(initialItem: selectedMinutes),
+                            itemExtent: 40,
+                            onSelectedItemChanged: (index) => selectedMinutes = index,
+                            children: List.generate(
+                              60,
+                              (index) => Center(
+                                child: Text(
+                                  index.toString().padLeft(2, '0'),
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 28,
+                                    fontFamily: 'Fira Code',
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                      ),
+                      ],
                     ),
                   ),
                 ],

--- a/mobile-app/lib/features/main/screens/transactions_screen.dart
+++ b/mobile-app/lib/features/main/screens/transactions_screen.dart
@@ -2,18 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:quantus_sdk/src/models/sorted_transactions.dart';
 import 'package:resonance_network_wallet/features/components/transaction_list_item.dart';
+import 'package:resonance_network_wallet/models/wallet_state_manager.dart'; // Ensure import
 
 class TransactionsScreen extends StatefulWidget {
-  final String initialAccountId;
+  final WalletStateManager manager;
 
-  const TransactionsScreen({super.key, required this.initialAccountId});
+  const TransactionsScreen({super.key, required this.manager});
 
   @override
   State<TransactionsScreen> createState() => _TransactionsScreenState();
 }
 
 class _TransactionsScreenState extends State<TransactionsScreen> {
-  final ChainHistoryService _chainHistoryService = ChainHistoryService();
   final ScrollController _scrollController = ScrollController();
 
   SortedTransactionsList? _transactions;
@@ -26,66 +26,52 @@ class _TransactionsScreenState extends State<TransactionsScreen> {
   @override
   void initState() {
     super.initState();
-    _fetchInitialTransactions();
+    widget.manager.addListener(_updateState);
+    _updateState(); // Set initial state from manager
     _scrollController.addListener(_onScroll);
   }
 
   @override
   void dispose() {
+    widget.manager.removeListener(_updateState);
     _scrollController.dispose();
     super.dispose();
   }
 
-  Future<void> _fetchInitialTransactions() async {
+  void _updateState() {
     setState(() {
-      _isLoading = true;
-      _error = null;
+      _isLoading = widget.manager.txData.isLoading;
+      _error = widget.manager.txData.error;
+      _transactions = widget.manager.txData.data;
+      if (_transactions != null && _offset == 0) {
+        // On initial/refresh, update pagination info
+        _offset = _transactions!.otherTransfers.length;
+        _hasMore = _transactions!.otherTransfers.length == _limit;
+      }
     });
-    try {
-      final result = await _chainHistoryService.fetchAllTransactionTypes(
-        accountId: widget.initialAccountId,
-        limit: _limit,
-        offset: 0,
-      );
-      setState(() {
-        _transactions = result;
-        _hasMore = result.otherTransfers.length == _limit;
-        _offset = result.otherTransfers.length;
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _isLoading = false;
-        _error = 'Failed to load transactions.';
-      });
-    }
   }
 
   Future<void> _fetchMoreTransactions() async {
     if (!_hasMore || _isLoading) return;
 
-    setState(() {
-      _isLoading = true;
-    });
+    final oldLength = _transactions?.otherTransfers.length ?? 0;
+    final accountId = widget.manager.walletData.data!.accountId;
 
-    try {
-      final result = await _chainHistoryService.fetchAllTransactionTypes(
-        accountId: widget.initialAccountId,
-        limit: _limit,
-        offset: _offset,
-      );
-      setState(() {
-        _transactions!.otherTransfers.addAll(result.otherTransfers);
-        _hasMore = result.otherTransfers.length == _limit;
-        _offset += result.otherTransfers.length;
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _isLoading = false;
-        // Optionally show an error for loading more
-      });
-    }
+    await widget.manager.loadMoreTransactions(accountId: accountId, limit: _limit, offset: _offset);
+
+    // No need for setState; listener will trigger _updateState
+    // But calculate hasMore/offset here if needed (listener updates _transactions)
+    final added = _transactions!.otherTransfers.length - oldLength;
+    _offset += added;
+    _hasMore = added == _limit;
+  }
+
+  Future<void> _refreshTransactions() async {
+    _offset = 0;
+    _hasMore = true;
+    _error = null;
+    await widget.manager.refreshTransactions();
+    // Listener will handle UI update
   }
 
   void _onScroll() {
@@ -126,14 +112,14 @@ class _TransactionsScreenState extends State<TransactionsScreen> {
         child: Text(_error!, style: const TextStyle(color: Colors.red)),
       );
     }
-    if (_transactions!.combined.isEmpty) {
+    if (_transactions?.combined.isEmpty ?? true) {
       return const Center(
         child: Text('No transactions found.', style: TextStyle(color: Colors.white)),
       );
     }
 
     return RefreshIndicator(
-      onRefresh: _fetchInitialTransactions,
+      onRefresh: _refreshTransactions,
       child: ListView(
         controller: _scrollController,
         children: [
@@ -141,10 +127,10 @@ class _TransactionsScreenState extends State<TransactionsScreen> {
             padding: const EdgeInsets.all(16.0),
             child: RecentTransactionsList(
               transactions: _transactions!.combined,
-              currentWalletAddress: widget.initialAccountId,
+              currentWalletAddress: widget.manager.walletData.data!.accountId,
             ),
           ),
-          if (_hasMore)
+          if (_isLoading && _hasMore)
             const Padding(
               padding: EdgeInsets.all(8.0),
               child: Center(child: CircularProgressIndicator()),

--- a/mobile-app/lib/features/main/screens/transactions_screen.dart
+++ b/mobile-app/lib/features/main/screens/transactions_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
-import 'package:quantus_sdk/src/models/sorted_transactions.dart';
-import 'package:resonance_network_wallet/features/components/transaction_list_item.dart';
+import 'package:resonance_network_wallet/features/components/transactions_list.dart';
 import 'package:resonance_network_wallet/models/wallet_state_manager.dart'; // Ensure import
 
 class TransactionsScreen extends StatefulWidget {

--- a/mobile-app/lib/features/main/screens/wallet_main.dart
+++ b/mobile-app/lib/features/main/screens/wallet_main.dart
@@ -24,12 +24,6 @@ class _WalletMainState extends State<WalletMain> {
   final SubstrateService _substrateService = SubstrateService();
   final ScrollController _scrollController = ScrollController();
 
-  // Pagination state
-  int _offset = 0;
-  bool _hasMore = true;
-  bool _isLoadingMore = false;
-  static const int _transactionsPerPage = 20;
-
   @override
   void initState() {
     super.initState();
@@ -43,20 +37,6 @@ class _WalletMainState extends State<WalletMain> {
   void dispose() {
     _scrollController.dispose();
     super.dispose();
-  }
-
-  Future<void> _loadMoreTransactions(WalletStateManager walletStateManager) async {
-    final _accountId = walletStateManager.walletData.data?.accountId;
-    if (!_hasMore || _isLoadingMore || walletStateManager.txData.isLoading || _accountId == null) return;
-
-    setState(() {
-      _isLoadingMore = true;
-    });
-    await walletStateManager.loadMoreTransactions(accountId: _accountId, limit: _transactionsPerPage, offset: _offset);
-    setState(() {
-      _isLoadingMore = false;
-      _offset = walletStateManager.combinedTransactions.length;
-    });
   }
 
   // Helper to format the address (now just returns the full address)
@@ -119,7 +99,7 @@ class _WalletMainState extends State<WalletMain> {
   }
 
   Widget _buildHistorySection(WalletStateManager walletStateManager) {
-    final _accountId = walletStateManager.walletData.data?.accountId;
+    final accountId = walletStateManager.walletData.data?.accountId;
     if (walletStateManager.txData.isLoading) {
       return Container(
         width: 321,
@@ -179,7 +159,7 @@ class _WalletMainState extends State<WalletMain> {
         ),
         RecentTransactionsList(
           transactions: walletStateManager.combinedTransactions.take(5).toList(),
-          currentWalletAddress: _accountId!,
+          currentWalletAddress: accountId!,
         ),
         if (true)
           Padding(
@@ -233,9 +213,9 @@ class _WalletMainState extends State<WalletMain> {
     final balanceLoader = walletStateManager.walletData;
 
     if (balanceLoader.isLoading) {
-      return Scaffold(
-        backgroundColor: const Color(0xFF0E0E0E),
-        body: const Center(child: CircularProgressIndicator(color: Colors.white)),
+      return const Scaffold(
+        backgroundColor: Color(0xFF0E0E0E),
+        body: Center(child: CircularProgressIndicator(color: Colors.white)),
       );
     }
 
@@ -300,7 +280,7 @@ class _WalletMainState extends State<WalletMain> {
 
     final walletData = balanceLoader.data!;
     final displayAddress = _formatAddress(walletData.accountId);
-    final _accountId = walletStateManager.walletData.data?.accountId;
+    final accountId = walletStateManager.walletData.data?.accountId;
 
     return Scaffold(
       backgroundColor: const Color(0xFF0E0E0E),
@@ -333,11 +313,11 @@ class _WalletMainState extends State<WalletMain> {
                             IconButton(
                               icon: SvgPicture.asset('assets/wallet_icon.svg', width: 24, height: 24),
                               onPressed: () {
-                                if (_accountId != null) {
+                                if (accountId != null) {
                                   Navigator.push(
                                     context,
                                     MaterialPageRoute(
-                                      builder: (context) => AccountProfilePage(currentAccountId: _accountId),
+                                      builder: (context) => AccountProfilePage(currentAccountId: accountId),
                                     ),
                                   );
                                 }
@@ -351,8 +331,8 @@ class _WalletMainState extends State<WalletMain> {
                           children: [
                             InkWell(
                               onTap: () {
-                                if (_accountId != null) {
-                                  Clipboard.setData(ClipboardData(text: _accountId));
+                                if (accountId != null) {
+                                  Clipboard.setData(ClipboardData(text: accountId));
                                   showTopSnackBar(context, title: 'Copied!', message: 'Account ID copied to clipboard');
                                 }
                               },

--- a/mobile-app/lib/features/main/screens/wallet_main.dart
+++ b/mobile-app/lib/features/main/screens/wallet_main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:resonance_network_wallet/features/components/transaction_list_item.dart';
 import 'package:resonance_network_wallet/features/components/snackbar_helper.dart';
-import 'dart:io';
 import 'dart:async';
 import 'package:resonance_network_wallet/features/main/screens/account_profile.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
@@ -10,7 +9,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:resonance_network_wallet/features/main/screens/receive_screen.dart';
 import 'package:resonance_network_wallet/features/main/screens/transactions_screen.dart';
 import 'package:resonance_network_wallet/features/main/screens/welcome_screen.dart';
-import 'package:resonance_network_wallet/models/wallet_data.dart';
 import 'package:resonance_network_wallet/models/wallet_state_manager.dart';
 
 class WalletMain extends StatefulWidget {

--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -1,10 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:resonance_network_wallet/features/main/screens/app.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/models/wallet_state_manager.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SubstrateService().initialize();
   await QuantusSdk.init();
-  runApp(const ResonanceWalletApp());
+
+  final settingsService = SettingsService();
+  final chainHistoryService = ChainHistoryService();
+  final substrateService = SubstrateService();
+
+  runApp(
+    ChangeNotifierProvider(
+      create: (context) => WalletStateManager(chainHistoryService, settingsService, substrateService),
+      child: const ResonanceWalletApp(),
+    ),
+  );
 }

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -29,7 +29,7 @@ class PendingTransactionEvent extends TransactionEvent {
     this.txId,
     this.status = ReversibleTransferStatus.SCHEDULED, // Default for reversible
     this.scheduledAtTime, // Set optimistically if reversible
-    this.fee,
+    required this.fee,
     super.extrinsicHash,
     super.blockNumber = 0, // Initial 0, update on inclusion
     this.error,

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -13,8 +13,7 @@ class PendingTransactionEvent extends TransactionEvent {
   final bool isReversible;
   String? txId; // Nullable, set later for reversible
   final ReversibleTransferStatus? status; // Optional, for reversible
-  final DateTime?
-  scheduledAt; // Optional, null for non-reversible (reversible duration inferred as scheduledAt - timestamp)
+  DateTime? scheduledAt; // Optional, null for non-reversible (reversible duration inferred as scheduledAt - timestamp)
   BigInt? fee; // Optional, for transfers
   String? error;
 

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -2,9 +2,7 @@
 import 'package:quantus_sdk/quantus_sdk.dart';
 
 class PendingTransactionEvent extends TransactionEvent {
-  @override
   TransactionState transactionState;
-  @override
   final bool isReversible;
   String? txId; // Nullable, set later for reversible
   final ReversibleTransferStatus? status; // Optional, for reversible
@@ -12,9 +10,7 @@ class PendingTransactionEvent extends TransactionEvent {
   BigInt? fee; // Optional, for transfers
   String? error;
 
-  @override
   DateTime get scheduledAt => scheduledAtTime ?? DateTime.now();
-  @override
   bool get isScheduled => isReversible;
 
   PendingTransactionEvent({

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -1,23 +1,21 @@
 // New PendingTransactionEvent class (single type, mirroring TransactionEvent with reversible fields optional)
 import 'package:quantus_sdk/quantus_sdk.dart';
 
-enum TransactionState {
-  created,
-  ready,
-  broadcast,
-  inBlock,
-  inHistory,
-  failed, // For errors
-}
-
 class PendingTransactionEvent extends TransactionEvent {
-  TransactionState state;
+  @override
+  TransactionState transactionState;
+  @override
   final bool isReversible;
   String? txId; // Nullable, set later for reversible
   final ReversibleTransferStatus? status; // Optional, for reversible
-  DateTime? scheduledAt; // Optional, null for non-reversible (reversible duration inferred as scheduledAt - timestamp)
+  DateTime? scheduledAtTime;
   BigInt? fee; // Optional, for transfers
   String? error;
+
+  @override
+  DateTime get scheduledAt => scheduledAtTime ?? DateTime.now();
+  @override
+  bool get isScheduled => isReversible;
 
   PendingTransactionEvent({
     required String tempId, // Generate temp ID at creation
@@ -25,34 +23,19 @@ class PendingTransactionEvent extends TransactionEvent {
     required super.to,
     required super.amount,
     required super.timestamp,
-    this.state = TransactionState.created,
+    this.transactionState = TransactionState.created,
     this.isReversible = false,
     this.txId,
     this.status = ReversibleTransferStatus.SCHEDULED, // Default for reversible
-    this.scheduledAt, // Set optimistically if reversible
+    this.scheduledAtTime, // Set optimistically if reversible
     this.fee,
     super.extrinsicHash,
     super.blockNumber = 0, // Initial 0, update on inclusion
     this.error,
   }) : super(id: tempId);
 
-  // Helper to infer reversible duration (0 for non-reversible)
-  Duration get reversibleDuration {
-    if (!isReversible || scheduledAt == null) return Duration.zero;
-    return scheduledAt!.difference(timestamp);
-  }
-
-  // Update from submission events (e.g., set extrinsicHash, txId if reversible)
-  void updateFromSubmission({String? extrinsicHash, String? txId, int? blockNumber}) {
-    this.extrinsicHash = extrinsicHash ?? this.extrinsicHash;
-    if (isReversible) {
-      this.txId = txId ?? this.txId;
-    }
-    this.blockNumber = blockNumber ?? this.blockNumber;
-  }
-
   @override
   String toString() {
-    return 'PendingTransactionEvent{id: $id, from: $from, to: $to, amount: $amount, timestamp: $timestamp, state: $state, isReversible: $isReversible, txId: $txId, status: $status, scheduledAt: $scheduledAt, fee: $fee, extrinsicHash: $extrinsicHash, blockNumber: $blockNumber, error: $error}';
+    return 'PendingTransactionEvent{id: $id, from: $from, to: $to, amount: $amount, timestamp: $timestamp, state: $transactionState, isReversible: $isReversible, txId: $txId, status: $status, scheduledAt: $scheduledAt, fee: $fee, extrinsicHash: $extrinsicHash, blockNumber: $blockNumber, error: $error}';
   }
 }

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -2,9 +2,11 @@
 import 'package:quantus_sdk/quantus_sdk.dart';
 
 enum TransactionState {
-  sent,
-  includedInBlock,
-  includedInHistory,
+  created,
+  ready,
+  broadcast,
+  inBlock,
+  inHistory,
   failed, // For errors
 }
 
@@ -23,7 +25,7 @@ class PendingTransactionEvent extends TransactionEvent {
     required super.to,
     required super.amount,
     required super.timestamp,
-    this.state = TransactionState.sent,
+    this.state = TransactionState.created,
     this.isReversible = false,
     this.txId,
     this.status = ReversibleTransferStatus.SCHEDULED, // Default for reversible

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -1,0 +1,57 @@
+// New PendingTransactionEvent class (single type, mirroring TransactionEvent with reversible fields optional)
+import 'package:quantus_sdk/quantus_sdk.dart';
+
+enum TransactionState {
+  sent,
+  includedInBlock,
+  includedInHistory,
+  failed, // For errors
+}
+
+class PendingTransactionEvent extends TransactionEvent {
+  TransactionState state;
+  final bool isReversible;
+  String? txId; // Nullable, set later for reversible
+  final ReversibleTransferStatus? status; // Optional, for reversible
+  final DateTime?
+  scheduledAt; // Optional, null for non-reversible (reversible duration inferred as scheduledAt - timestamp)
+  BigInt? fee; // Optional, for transfers
+  String? error;
+
+  PendingTransactionEvent({
+    required String tempId, // Generate temp ID at creation
+    required super.from,
+    required super.to,
+    required super.amount,
+    required super.timestamp,
+    this.state = TransactionState.sent,
+    this.isReversible = false,
+    this.txId,
+    this.status = ReversibleTransferStatus.SCHEDULED, // Default for reversible
+    this.scheduledAt, // Set optimistically if reversible
+    this.fee,
+    super.extrinsicHash,
+    super.blockNumber = 0, // Initial 0, update on inclusion
+    this.error,
+  }) : super(id: tempId);
+
+  // Helper to infer reversible duration (0 for non-reversible)
+  Duration get reversibleDuration {
+    if (!isReversible || scheduledAt == null) return Duration.zero;
+    return scheduledAt!.difference(timestamp);
+  }
+
+  // Update from submission events (e.g., set extrinsicHash, txId if reversible)
+  void updateFromSubmission({String? extrinsicHash, String? txId, int? blockNumber}) {
+    this.extrinsicHash = extrinsicHash ?? this.extrinsicHash;
+    if (isReversible) {
+      this.txId = txId ?? this.txId;
+    }
+    this.blockNumber = blockNumber ?? this.blockNumber;
+  }
+
+  @override
+  String toString() {
+    return 'PendingTransactionEvent{id: $id, from: $from, to: $to, amount: $amount, timestamp: $timestamp, state: $state, isReversible: $isReversible, txId: $txId, status: $status, scheduledAt: $scheduledAt, fee: $fee, extrinsicHash: $extrinsicHash, blockNumber: $blockNumber, error: $error}';
+  }
+}

--- a/mobile-app/lib/models/pending_transfer_event.dart
+++ b/mobile-app/lib/models/pending_transfer_event.dart
@@ -23,6 +23,7 @@ class PendingTransactionEvent extends TransactionEvent {
     required super.to,
     required super.amount,
     required super.timestamp,
+    super.blockHash,
     this.transactionState = TransactionState.created,
     this.isReversible = false,
     this.txId,

--- a/mobile-app/lib/models/wallet_data.dart
+++ b/mobile-app/lib/models/wallet_data.dart
@@ -1,0 +1,7 @@
+class WalletData {
+  final String accountId;
+  final String walletName;
+  final BigInt balance;
+
+  WalletData({required this.accountId, required this.walletName, required this.balance});
+}

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -95,9 +95,8 @@ class WalletStateManager with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> refreshTransactions() async {
-    txData = LoadingState(loadData: _fetchTransactionHistory());
-    await txData.load();
+  Future<void> refreshTransactions({bool quiet = false}) async {
+    await txData.load(quiet: quiet);
     updatePendingTransactions();
     notifyListeners();
   }
@@ -308,7 +307,7 @@ class WalletStateManager with ChangeNotifier {
     _historyPollTimer = Timer.periodic(pollInterval, (timer) async {
       try {
         print('polling history');
-        await refreshTransactions();
+        await refreshTransactions(quiet: true);
         if (pendingTransactions.isEmpty) {
           print('no more pending tx, ending history polling');
           _historyPollTimer?.cancel();

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -1,0 +1,80 @@
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/models/wallet_data.dart';
+import 'package:flutter/foundation.dart'; // Added for ChangeNotifier
+
+class LoadingState<T> {
+  T? data;
+  bool isLoading;
+  String? error;
+  Future<T> loadData;
+
+  bool get hasData => data != null;
+  bool get hasError => error != null;
+
+  LoadingState({this.data, this.isLoading = false, this.error, required this.loadData});
+
+  Future<LoadingState<T>> load() async {
+    isLoading = true;
+    try {
+      data = await loadData;
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      isLoading = false;
+    }
+    return this;
+  }
+}
+
+class WalletStateManager with ChangeNotifier {
+  final SettingsService _settingsService;
+  final ChainHistoryService _chainHistoryService;
+  final SubstrateService _substrateService;
+
+  late LoadingState<SortedTransactionsList?> txData;
+  late LoadingState<WalletData?> walletData;
+
+  WalletStateManager(this._chainHistoryService, this._settingsService, this._substrateService) {
+    txData = LoadingState(loadData: _fetchTransactionHistory());
+    walletData = LoadingState(loadData: _fetchBalance());
+  }
+
+  Future<SortedTransactionsList?> _fetchTransactionHistory() async {
+    final accountId = await _settingsService.getAccountId();
+    final result = await _chainHistoryService.fetchAllTransactionTypes(accountId: accountId!, limit: 20, offset: 0);
+    return result;
+  }
+
+  Future<WalletData?> _fetchBalance() async {
+    const Duration networkTimeout = Duration(seconds: 15);
+    final accountId = await _settingsService.getAccountId();
+    final balance = await _substrateService.queryBalance(accountId!).timeout(networkTimeout);
+    return WalletData(accountId: accountId, walletName: '', balance: balance);
+  }
+
+  Future<void> load() async {
+    await Future.wait([txData.load(), walletData.load()]);
+    notifyListeners();
+  }
+
+  Future<void> refreshTransactions() async {
+    txData = LoadingState(loadData: _fetchTransactionHistory());
+    await txData.load();
+    notifyListeners();
+  }
+
+  Future<void> loadMoreTransactions({required String accountId, required int limit, required int offset}) async {
+    final result = await _chainHistoryService.fetchAllTransactionTypes(
+      accountId: accountId,
+      limit: limit,
+      offset: offset,
+    );
+    if (txData.data == null) {
+      txData.data = result;
+    } else {
+      txData.data!.otherTransfers.addAll(result.otherTransfers);
+      // Add similar for other transaction types if present in SortedTransactionsList (e.g., reversibleTransfers.addAll(result.reversibleTransfers);)
+    }
+    notifyListeners();
+  }
+}

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -311,7 +311,7 @@ class WalletStateManager with ChangeNotifier {
     _historyPollTimer = Timer.periodic(pollInterval, (timer) async {
       try {
         print('polling history');
-        await refreshTransactions(quiet: true);
+        await load(quiet: true);
         if (pendingTransactions.isEmpty) {
           print('no more pending tx, ending history polling');
           _historyPollTimer?.cancel();

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -179,18 +179,9 @@ class WalletStateManager with ChangeNotifier {
     notifyListeners();
   }
 
-  // TODO: this should update the state of the pending transfer to one of
-  // * ready
-  // * broadcast
-  // * in block
-  // * failed
-  void updatePending(String PendingID, String Status) {}
-
   void _startPolling() {
     _pollingTimer = Timer.periodic(const Duration(seconds: 10), (timer) async {
       if (pendingTransactions.isEmpty) return;
-      // TODO see if we need this - we need to get the history as long as we have pending tx, and resolve them.
-
       notifyListeners();
     });
   }

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/models/wallet_data.dart';
-import 'package:flutter/foundation.dart'; // Added for ChangeNotifier
+import 'package:resonance_network_wallet/models/pending_transfer_event.dart';
 
 class LoadingState<T> {
   T? data;
@@ -34,9 +36,19 @@ class WalletStateManager with ChangeNotifier {
   late LoadingState<SortedTransactionsList?> txData;
   late LoadingState<WalletData?> walletData;
 
+  List<PendingTransactionEvent> pendingTransactions = [];
+  Timer? _pollingTimer;
+
   WalletStateManager(this._chainHistoryService, this._settingsService, this._substrateService) {
     txData = LoadingState(loadData: _fetchTransactionHistory());
     walletData = LoadingState(loadData: _fetchBalance());
+    _startPolling();
+  }
+
+  @override
+  void dispose() {
+    _pollingTimer?.cancel();
+    super.dispose();
   }
 
   Future<SortedTransactionsList?> _fetchTransactionHistory() async {
@@ -50,6 +62,29 @@ class WalletStateManager with ChangeNotifier {
     final accountId = await _settingsService.getAccountId();
     final balance = await _substrateService.queryBalance(accountId!).timeout(networkTimeout);
     return WalletData(accountId: accountId, walletName: '', balance: balance);
+  }
+
+  BigInt get estimatedBalance {
+    if (!walletData.hasData) return BigInt.zero;
+    BigInt base = walletData.data!.balance;
+    for (var tx in pendingTransactions) {
+      if (tx.state != TransactionState.includedInHistory && tx.state != TransactionState.failed) {
+        final adjustment = (tx.from == walletData.data!.accountId) ? -tx.amount : tx.amount;
+        base += adjustment;
+      }
+    }
+    return base;
+  }
+
+  List<TransactionEvent> get combinedTransactions {
+    final fetched = txData.data?.combined ?? [];
+    final all = [...fetched, ...pendingTransactions];
+    all.sort((a, b) {
+      final tsA = a.timestamp;
+      final tsB = b.timestamp;
+      return tsB.compareTo(tsA);
+    });
+    return all;
   }
 
   Future<void> load() async {
@@ -73,8 +108,86 @@ class WalletStateManager with ChangeNotifier {
       txData.data = result;
     } else {
       txData.data!.otherTransfers.addAll(result.otherTransfers);
-      // Add similar for other transaction types if present in SortedTransactionsList (e.g., reversibleTransfers.addAll(result.reversibleTransfers);)
     }
     notifyListeners();
+  }
+
+  Future<PendingTransactionEvent> addPendingTransaction({
+    required String from,
+    required String to,
+    required BigInt amount,
+    bool isOutgoing = true,
+    bool isReversible = false,
+    BigInt? fee,
+  }) async {
+    final tempId = 'pending_${DateTime.now().millisecondsSinceEpoch}';
+    final timestamp = DateTime.now();
+    final pending = PendingTransactionEvent(
+      tempId: tempId,
+      from: from,
+      to: to,
+      amount: amount,
+      timestamp: timestamp,
+      isReversible: isReversible,
+      fee: fee ?? BigInt.zero,
+    );
+    if (isReversible) {
+      pending.scheduledAt = timestamp.add(const Duration(hours: 24));
+    }
+    pendingTransactions.add(pending);
+    notifyListeners();
+    return pending;
+  }
+
+  void _startPolling() {
+    _pollingTimer = Timer.periodic(const Duration(seconds: 10), (timer) async {
+      if (pendingTransactions.isEmpty) return;
+
+      for (var tx in List.from(pendingTransactions)) {
+        await _updateTxState(tx);
+      }
+      notifyListeners();
+    });
+  }
+
+  Future<void> _updateTxState(PendingTransactionEvent tx) async {
+    try {
+      final inclusionStatus = await _substrateService.checkTxInclusion(tx.extrinsicHash ?? '');
+      if (inclusionStatus.included) {
+        tx.state = TransactionState.includedInBlock;
+        tx.blockNumber = inclusionStatus.blockNumber;
+        if (tx.isReversible && tx.txId == null) {
+          tx.txId = _parseTxIdFromEvents(inclusionStatus.events);
+        }
+      }
+
+      if (tx.state == TransactionState.includedInBlock) {
+        final historyItem = await _chainHistoryService.fetchTxById(tx.txId ?? tx.extrinsicHash ?? '');
+        if (historyItem != null) {
+          tx.state = TransactionState.includedInHistory;
+          if (historyItem is ReversibleTransferEvent) {
+            txData.data?.combined.add(historyItem);
+          } else if (historyItem is TransferEvent) {
+            txData.data?.combined.add(historyItem);
+          }
+          pendingTransactions.remove(tx);
+          walletData = LoadingState(loadData: _fetchBalance());
+          await walletData.load();
+        }
+      }
+    } catch (e) {
+      tx.state = TransactionState.failed;
+      tx.error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  String? _parseTxIdFromEvents(List<dynamic> events) {
+    for (var event in events) {
+      if (event['type'] == 'ReversibleTransfer' && event['action'] == 'created') {
+        return event['txId'] as String?;
+      }
+    }
+    return null;
   }
 }

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
       url: https://github.com/Quantus-Network/human-checkphrase.git
       path: dart
   provider: ^6.1.5
+  polkadart: ^0.7.1
 
 dev_dependencies:
   flutter_test:

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
     git:
       url: https://github.com/Quantus-Network/human-checkphrase.git
       path: dart
+  provider: ^6.1.5
 
 dev_dependencies:
   flutter_test:

--- a/mobile-app/test/unit/number_formatting_service_test.dart
+++ b/mobile-app/test/unit/number_formatting_service_test.dart
@@ -23,9 +23,9 @@ void main() {
         expect(service.formatBalance(balance, maxDecimals: 5), '1.2345'); // No trailing zeros
       });
 
-      test('formats balance with more decimals than max (rounds display)', () {
+      test('formats balance with more decimals than max (truncates display)', () {
         final balance = BigInt.parse('1234567800000'); // 1.2345678
-        expect(service.formatBalance(balance, maxDecimals: 4), '1.2346');
+        expect(service.formatBalance(balance, maxDecimals: 4), '1.2345');
         expect(service.formatBalance(balance, maxDecimals: 2), '1.23');
         expect(service.formatBalance(balance, maxDecimals: 0), '1');
       });

--- a/quantus_sdk/lib/quantus_sdk.dart
+++ b/quantus_sdk/lib/quantus_sdk.dart
@@ -25,6 +25,7 @@ export 'src/models/event_type.dart';
 export 'src/extensions/string_extensions.dart';
 export 'src/services/address_formatting_service.dart';
 export 'src/models/sorted_transactions.dart';
+export 'src/models/transaction_state.dart';
 
 class QuantusSdk {
   /// Initialise the SDK (loads Rust FFI, etc).

--- a/quantus_sdk/lib/quantus_sdk.dart
+++ b/quantus_sdk/lib/quantus_sdk.dart
@@ -9,7 +9,7 @@ export 'src/constants/app_constants.dart';
 export 'src/extensions/color_extensions.dart';
 export 'src/extensions/keypair_extensions.dart';
 // note we have to hide some things here because they're exported by substrate service
-// should probably expise all of crypto.dart through substrateservice instead TODO...
+// should probably expise all of crypto.dart through substrateservice instead
 export 'src/rust/api/crypto.dart' hide crystalAlice, crystalCharlie, crystalBob;
 export 'src/services/balances_service.dart';
 export 'src/services/chain_history_service.dart';

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -8,8 +8,9 @@ abstract class TransactionEvent {
   final String to;
   final BigInt amount;
   final DateTime timestamp;
-  String? extrinsicHash;
   int blockNumber;
+  String? extrinsicHash;
+  String? blockHash;
 
   bool get isReversible => false;
   bool get isScheduled => false;
@@ -24,6 +25,7 @@ abstract class TransactionEvent {
     required this.timestamp,
     this.extrinsicHash,
     required this.blockNumber,
+    this.blockHash,
   });
 
   @override
@@ -45,11 +47,13 @@ class TransferEvent extends TransactionEvent {
     required this.fee,
     super.extrinsicHash,
     required super.blockNumber,
+    required super.blockHash,
   });
 
   factory TransferEvent.fromJson(Map<String, dynamic> json) {
     final block = json['block'] as Map<String, dynamic>?;
     final blockHeight = block?['height'] as int? ?? 0;
+    final blockHash = block?['hash'] as String? ?? '';
     return TransferEvent(
       id: json['id'] as String,
       from: json['from']?['id'] as String? ?? '',
@@ -59,6 +63,7 @@ class TransferEvent extends TransactionEvent {
       fee: json['fee'] != null ? BigInt.parse(json['fee'] as String) : BigInt.zero,
       extrinsicHash: json['extrinsicHash'] as String?,
       blockNumber: blockHeight,
+      blockHash: blockHash,
     );
   }
 
@@ -89,11 +94,13 @@ class ReversibleTransferEvent extends TransactionEvent {
     required this.scheduledAt,
     super.extrinsicHash,
     required super.blockNumber,
+    required super.blockHash,
   });
 
   factory ReversibleTransferEvent.fromJson(Map<String, dynamic> json) {
     final block = json['block'] as Map<String, dynamic>;
     final blockHeight = block['height'] as int;
+    final blockHash = block['hash'] as String? ?? '';
     return ReversibleTransferEvent(
       id: json['id'] as String,
       from: json['from']?['id'] as String? ?? '',
@@ -105,6 +112,7 @@ class ReversibleTransferEvent extends TransactionEvent {
       scheduledAt: DateTime.parse(json['scheduledAt'] as String),
       extrinsicHash: json['extrinsicHash'] as String?,
       blockNumber: blockHeight,
+      blockHash: blockHash,
     );
   }
 

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -7,8 +7,8 @@ abstract class TransactionEvent {
   final String to;
   final BigInt amount;
   final DateTime timestamp;
-  final String? extrinsicHash;
-  final int blockNumber;
+  String? extrinsicHash;
+  int blockNumber;
 
   TransactionEvent({
     required this.id,

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -1,5 +1,4 @@
 import 'package:quantus_sdk/src/models/reversible_transfer_status.dart';
-import 'package:quantus_sdk/src/models/transaction_state.dart';
 
 // Base class for different transaction types
 abstract class TransactionEvent {
@@ -11,11 +10,6 @@ abstract class TransactionEvent {
   int blockNumber;
   String? extrinsicHash;
   String? blockHash;
-
-  bool get isReversible => false;
-  bool get isScheduled => false;
-  DateTime get scheduledAt => DateTime.now();
-  TransactionState get transactionState => TransactionState.inHistory;
 
   TransactionEvent({
     required this.id,
@@ -76,11 +70,8 @@ class TransferEvent extends TransactionEvent {
 class ReversibleTransferEvent extends TransactionEvent {
   final String txId;
   final ReversibleTransferStatus status;
-  @override
   final DateTime scheduledAt;
-  @override
   bool get isReversible => true;
-  @override
   bool get isScheduled => status == ReversibleTransferStatus.SCHEDULED;
 
   ReversibleTransferEvent({
@@ -101,6 +92,8 @@ class ReversibleTransferEvent extends TransactionEvent {
     final block = json['block'] as Map<String, dynamic>;
     final blockHeight = block['height'] as int;
     final blockHash = block['hash'] as String? ?? '';
+
+    print('scheduled event parser ${DateTime.parse(json['scheduledAt'] as String)}');
     return ReversibleTransferEvent(
       id: json['id'] as String,
       from: json['from']?['id'] as String? ?? '',

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -1,4 +1,5 @@
 import 'package:quantus_sdk/src/models/reversible_transfer_status.dart';
+import 'package:quantus_sdk/src/models/transaction_state.dart';
 
 // Base class for different transaction types
 abstract class TransactionEvent {
@@ -9,6 +10,11 @@ abstract class TransactionEvent {
   final DateTime timestamp;
   String? extrinsicHash;
   int blockNumber;
+
+  bool get isReversible => false;
+  bool get isScheduled => false;
+  DateTime get scheduledAt => DateTime.now();
+  TransactionState get transactionState => TransactionState.inHistory;
 
   TransactionEvent({
     required this.id,
@@ -65,7 +71,12 @@ class TransferEvent extends TransactionEvent {
 class ReversibleTransferEvent extends TransactionEvent {
   final String txId;
   final ReversibleTransferStatus status;
+  @override
   final DateTime scheduledAt;
+  @override
+  bool get isReversible => true;
+  @override
+  bool get isScheduled => status == ReversibleTransferStatus.SCHEDULED;
 
   ReversibleTransferEvent({
     required super.id,

--- a/quantus_sdk/lib/src/models/transaction_state.dart
+++ b/quantus_sdk/lib/src/models/transaction_state.dart
@@ -1,0 +1,10 @@
+// Different states an asyncronous transaction can be in.
+
+enum TransactionState {
+  created,
+  ready,
+  broadcast,
+  inBlock,
+  inHistory,
+  failed, // For errors
+}

--- a/quantus_sdk/lib/src/services/balances_service.dart
+++ b/quantus_sdk/lib/src/services/balances_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:polkadart/polkadart.dart';
 import 'package:quantus_sdk/generated/resonance/resonance.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
@@ -12,7 +14,7 @@ class BalancesService {
 
   final SubstrateService _substrateService = SubstrateService();
 
-  Future<String> balanceTransfer(
+  Future<StreamSubscription<ExtrinsicStatus>> balanceTransfer(
     String senderSeed,
     String targetAddress,
     BigInt amount,

--- a/quantus_sdk/lib/src/services/balances_service.dart
+++ b/quantus_sdk/lib/src/services/balances_service.dart
@@ -23,9 +23,7 @@ class BalancesService {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
       final multiDest = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: targetAddress));
-
       final runtimeCall = resonanceApi.tx.balances.transferKeepAlive(dest: multiDest, value: amount);
-
       // Submit the extrinsic and return its result
       return await _substrateService.submitExtrinsic(
         senderSeed,

--- a/quantus_sdk/lib/src/services/balances_service.dart
+++ b/quantus_sdk/lib/src/services/balances_service.dart
@@ -1,3 +1,4 @@
+import 'package:polkadart/polkadart.dart';
 import 'package:quantus_sdk/generated/resonance/resonance.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:quantus_sdk/generated/resonance/types/sp_runtime/multiaddress/multi_address.dart' as multi_address;
@@ -11,7 +12,12 @@ class BalancesService {
 
   final SubstrateService _substrateService = SubstrateService();
 
-  Future<String> balanceTransfer(String senderSeed, String targetAddress, BigInt amount) async {
+  Future<String> balanceTransfer(
+    String senderSeed,
+    String targetAddress,
+    BigInt amount,
+    void Function(ExtrinsicStatus)? onStatus,
+  ) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
       final multiDest = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: targetAddress));
@@ -22,9 +28,11 @@ class BalancesService {
       return await _substrateService.submitExtrinsic(
         senderSeed,
         runtimeCall,
-        onStatus: (data) async {
-          print('type: ${data.type}, value: ${data.value}');
-        },
+        onStatus:
+            onStatus ??
+            (data) async {
+              print('type: ${data.type}, value: ${data.value}');
+            },
       );
     } catch (e, stackTrace) {
       print('Failed to transfer balance: $e');

--- a/quantus_sdk/lib/src/services/chain_history_service.dart
+++ b/quantus_sdk/lib/src/services/chain_history_service.dart
@@ -62,6 +62,7 @@ query ScheduledTransfersByAccount($account: String!) {
       status
       block {
         height
+        hash
       }
       extrinsicHash
       timestamp
@@ -117,6 +118,7 @@ query EventsByAccount($account: String!, $limit: Int!, $offset: Int!) {
       }
       block {
         height
+        hash
       }
       extrinsicHash
       timestamp
@@ -137,6 +139,7 @@ query EventsByAccount($account: String!, $limit: Int!, $offset: Int!) {
       status
       block {
         height
+        hash
       }
       extrinsicHash
       timestamp

--- a/quantus_sdk/lib/src/services/number_formatting_service.dart
+++ b/quantus_sdk/lib/src/services/number_formatting_service.dart
@@ -13,7 +13,7 @@ class NumberFormattingService {
   /// user-readable string with a specified number of decimal places.
   ///
   /// Example: 1234500000000 -> "1.2345" (with maxDecimals = 4)
-  String formatBalance(BigInt balance, {int maxDecimals = 4}) {
+  String formatBalance(BigInt balance, {int maxDecimals = 6}) {
     if (balance == BigInt.zero) {
       return '0';
     }

--- a/quantus_sdk/lib/src/services/number_formatting_service.dart
+++ b/quantus_sdk/lib/src/services/number_formatting_service.dart
@@ -20,10 +20,9 @@ class NumberFormattingService {
 
     // 1. Perform division to get the precise decimal value.
     final decimalBalance = (Decimal.fromBigInt(balance) / scaleFactorDecimal).toDecimal(
-      scaleOnInfinitePrecision: maxDecimals * 3, // Note: We never have an infinite number of decimals because we divide by powers of 10. 
+      scaleOnInfinitePrecision:
+          maxDecimals * 3, // Note: We never have an infinite number of decimals because we divide by powers of 10.
     );
-
-    print('decimal balance: $decimalBalance');
 
     // 2. Convert to a string for manipulation.
     String asString = decimalBalance.toString();
@@ -36,7 +35,6 @@ class NumberFormattingService {
         asString = asString.substring(0, dotIndex + maxDecimals + 1);
       }
     }
-    print('asString: $asString');
 
     // 4. Remove any trailing zeros from the fractional part for a clean look.
     if (asString.contains('.')) {

--- a/quantus_sdk/lib/src/services/number_formatting_service.dart
+++ b/quantus_sdk/lib/src/services/number_formatting_service.dart
@@ -1,7 +1,6 @@
 // Keep for potential future use (grouping)
 import 'package:decimal/decimal.dart';
 import 'package:flutter/foundation.dart';
-import 'package:intl/intl.dart';
 import 'package:quantus_sdk/quantus_sdk.dart'; // For debugPrint
 
 class NumberFormattingService {

--- a/quantus_sdk/lib/src/services/recovery_service.dart
+++ b/quantus_sdk/lib/src/services/recovery_service.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:typed_data';
+import 'package:polkadart/primitives/primitives.dart';
 import 'package:quantus_sdk/generated/resonance/resonance.dart';
 import 'package:quantus_sdk/generated/resonance/types/sp_runtime/multiaddress/multi_address.dart' as multi_address;
 import 'package:quantus_sdk/generated/resonance/types/pallet_recovery/recovery_config.dart';
@@ -17,7 +19,7 @@ class RecoveryService {
 
   /// Create a recovery configuration for an account
   /// This makes the account recoverable by trusted friends
-  Future<String> createRecoveryConfig({
+  Future<StreamSubscription<ExtrinsicStatus>> createRecoveryConfig({
     required String senderSeed,
     required List<String> friendAddresses,
     required int threshold,
@@ -42,7 +44,10 @@ class RecoveryService {
   }
 
   /// Initiate recovery process for a lost account
-  Future<String> initiateRecovery({required String rescuerSeed, required String lostAccountAddress}) async {
+  Future<StreamSubscription<ExtrinsicStatus>> initiateRecovery({
+    required String rescuerSeed,
+    required String lostAccountAddress,
+  }) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
       final lostAccount = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: lostAccountAddress));
@@ -58,7 +63,7 @@ class RecoveryService {
   }
 
   /// Vouch for an active recovery process (called by friends)
-  Future<String> vouchForRecovery({
+  Future<StreamSubscription<ExtrinsicStatus>> vouchForRecovery({
     required String friendSeed,
     required String lostAccountAddress,
     required String rescuerAddress,
@@ -79,7 +84,10 @@ class RecoveryService {
   }
 
   /// Claim recovery of a lost account (called by rescuer after threshold is met)
-  Future<String> claimRecovery({required String rescuerSeed, required String lostAccountAddress}) async {
+  Future<StreamSubscription<ExtrinsicStatus>> claimRecovery({
+    required String rescuerSeed,
+    required String lostAccountAddress,
+  }) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
       final lostAccount = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: lostAccountAddress));
@@ -95,7 +103,10 @@ class RecoveryService {
   }
 
   /// Close an active recovery process (called by the lost account owner)
-  Future<String> closeRecovery({required String lostAccountSeed, required String rescuerAddress}) async {
+  Future<StreamSubscription<ExtrinsicStatus>> closeRecovery({
+    required String lostAccountSeed,
+    required String rescuerAddress,
+  }) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
       final rescuer = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: rescuerAddress));
@@ -111,7 +122,7 @@ class RecoveryService {
   }
 
   /// Remove recovery configuration from account
-  Future<String> removeRecoveryConfig({required String senderSeed}) async {
+  Future<StreamSubscription<ExtrinsicStatus>> removeRecoveryConfig({required String senderSeed}) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
 
@@ -126,7 +137,7 @@ class RecoveryService {
   }
 
   /// Call a function as a recovered account (proxy call)
-  Future<String> callAsRecovered({
+  Future<StreamSubscription<ExtrinsicStatus>> callAsRecovered({
     required String rescuerSeed,
     required String recoveredAccountAddress,
     required RuntimeCall call,
@@ -148,7 +159,10 @@ class RecoveryService {
   }
 
   /// Cancel the ability to use a recovered account
-  Future<String> cancelRecovered({required String rescuerSeed, required String recoveredAccountAddress}) async {
+  Future<StreamSubscription<ExtrinsicStatus>> cancelRecovered({
+    required String rescuerSeed,
+    required String recoveredAccountAddress,
+  }) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
       final recoveredAccount = const multi_address.$MultiAddress().id(
@@ -275,7 +289,7 @@ class RecoveryService {
   }
 
   /// Convenience method to transfer balance as recovered account
-  Future<String> transferAsRecovered({
+  Future<StreamSubscription<ExtrinsicStatus>> transferAsRecovered({
     required String rescuerSeed,
     required String recoveredAccountAddress,
     required String recipientAddress,

--- a/quantus_sdk/lib/src/services/reversible_transfers_service.dart
+++ b/quantus_sdk/lib/src/services/reversible_transfers_service.dart
@@ -1,3 +1,4 @@
+import 'package:polkadart/polkadart.dart';
 import 'package:quantus_sdk/generated/resonance/resonance.dart';
 import 'package:quantus_sdk/generated/resonance/types/pallet_reversible_transfers/high_security_account_data.dart';
 import 'package:quantus_sdk/generated/resonance/types/sp_runtime/multiaddress/multi_address.dart' as multi_address;
@@ -74,6 +75,7 @@ class ReversibleTransfersService {
     required String recipientAddress,
     required BigInt amount,
     required BlockNumberOrTimestamp delay,
+    void Function(ExtrinsicStatus)? onStatus,
   }) async {
     try {
       final resonanceApi = Resonance(_substrateService.provider!);
@@ -87,7 +89,7 @@ class ReversibleTransfersService {
       );
 
       // Submit the transaction using substrate service
-      return await _substrateService.submitExtrinsic(senderSeed, call);
+      return await _substrateService.submitExtrinsic(senderSeed, call, onStatus);
     } catch (e) {
       throw Exception('Failed to schedule reversible transfer with delay: $e');
     }
@@ -99,6 +101,7 @@ class ReversibleTransfersService {
     required String recipientAddress,
     required BigInt amount,
     required int delaySeconds,
+    void Function(ExtrinsicStatus)? onStatus,
   }) async {
     // convert seconds to milliseconds for runtime
     final delay = Timestamp(BigInt.from(delaySeconds) * BigInt.from(1000));
@@ -107,6 +110,7 @@ class ReversibleTransfersService {
       recipientAddress: recipientAddress,
       amount: amount,
       delay: delay,
+      onStatus: onStatus,
     );
   }
 

--- a/quantus_sdk/lib/src/services/reversible_transfers_service.dart
+++ b/quantus_sdk/lib/src/services/reversible_transfers_service.dart
@@ -78,7 +78,7 @@ class ReversibleTransfersService {
     required BigInt amount,
     required BlockNumberOrTimestamp delay,
     void Function(ExtrinsicStatus)? onStatus,
-  }) async {
+  }) {
     final resonanceApi = Resonance(_substrateService.provider!);
     final multiDest = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: recipientAddress));
 
@@ -99,7 +99,7 @@ class ReversibleTransfersService {
     required BigInt amount,
     required int delaySeconds,
     void Function(ExtrinsicStatus)? onStatus,
-  }) async {
+  }) {
     // convert seconds to milliseconds for runtime
     final delay = Timestamp(BigInt.from(delaySeconds) * BigInt.from(1000));
     return scheduleReversibleTransferWithDelay(

--- a/quantus_sdk/lib/src/services/reversible_transfers_service.dart
+++ b/quantus_sdk/lib/src/services/reversible_transfers_service.dart
@@ -72,33 +72,28 @@ class ReversibleTransfersService {
   }
 
   /// Schedule a reversible transfer with custom delay (ad hoc transfer)
-  Future<Future<StreamSubscription<ExtrinsicStatus>>> scheduleReversibleTransferWithDelay({
+  Future<StreamSubscription<ExtrinsicStatus>> scheduleReversibleTransferWithDelay({
     required String senderSeed,
     required String recipientAddress,
     required BigInt amount,
     required BlockNumberOrTimestamp delay,
     void Function(ExtrinsicStatus)? onStatus,
   }) async {
-    try {
-      final resonanceApi = Resonance(_substrateService.provider!);
-      final multiDest = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: recipientAddress));
+    final resonanceApi = Resonance(_substrateService.provider!);
+    final multiDest = const multi_address.$MultiAddress().id(crypto.ss58ToAccountId(s: recipientAddress));
 
-      // Create the call
-      final call = resonanceApi.tx.reversibleTransfers.scheduleTransferWithDelay(
-        dest: multiDest,
-        amount: amount,
-        delay: delay,
-      );
+    final call = resonanceApi.tx.reversibleTransfers.scheduleTransferWithDelay(
+      dest: multiDest,
+      amount: amount,
+      delay: delay,
+    );
 
-      // Submit the transaction using substrate service
-      return _substrateService.submitExtrinsic(senderSeed, call, onStatus: onStatus);
-    } catch (e) {
-      throw Exception('Failed to schedule reversible transfer with delay: $e');
-    }
+    // Submit the transaction using substrate service
+    return _substrateService.submitExtrinsic(senderSeed, call, onStatus: onStatus);
   }
 
   /// Schedule a reversible transfer with custom delay in seconds
-  Future<Future<Future<StreamSubscription<ExtrinsicStatus>>>> scheduleReversibleTransferWithDelaySeconds({
+  Future<StreamSubscription<ExtrinsicStatus>> scheduleReversibleTransferWithDelaySeconds({
     required String senderSeed,
     required String recipientAddress,
     required BigInt amount,

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:ss58/ss58.dart';
@@ -74,16 +73,6 @@ class SettingsService {
 
   Future<String?> getMnemonic() async {
     await _ensureInitialized();
-
-    // TODO remove this at launch
-    if (_prefs.getString('mnemonic') != null) {
-      debugPrint('mnemonic found in prefs - transferring to secure storage');
-      final m = _prefs.getString('mnemonic')!;
-      await setMnemonic(m);
-      await _prefs.remove('mnemonic');
-      return m;
-    }
-
     return await _secureStorage.read(key: 'mnemonic');
   }
 

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -298,7 +298,7 @@ class SubstrateService {
     return senderWallet;
   }
 
-  Future<String> submitExtrinsic(
+  Future<StreamSubscription<ExtrinsicStatus>> submitExtrinsic(
     String senderSeed,
     RuntimeCall call, {
     void Function(ExtrinsicStatus)? onStatus,
@@ -352,8 +352,7 @@ class SubstrateService {
           tip: 0,
         ).encodeResonance(resonanceApi.registry, ResonanceSignatureType.resonance);
 
-        await _authorApi!.submitAndWatchExtrinsic(extrinsic, onStatus ?? (data) {});
-        return '0';
+        return _authorApi!.submitAndWatchExtrinsic(extrinsic, onStatus ?? (data) {});
       } catch (e) {
         retryCount++;
         if (retryCount >= maxRetries) {


### PR DESCRIPTION
- Ephemeral balances and transactions
- Handling state changes of tx in background
- Polling history and balance once tx is in block
- Cancel stream subscription after inBlock
- Handle reversible transfers


Cleanup tasks added as issues since this is already so big:
#49 
#50 
Load more transfers on scroll on tx screen - this could be a different PR -> use different PR for this. See #51 


Fix #33 