### PR TITLE
Feat/update receive popover#53

### DIFF
--- a/quantus_sdk/lib/src/services/address_formatting_service.dart
+++ b/quantus_sdk/lib/src/services/address_formatting_service.dart
@@ -1,7 +1,35 @@
 import 'package:quantus_sdk/quantus_sdk.dart';
 
 class AddressFormattingService {
-  static String formatAddress(String address, {int prefix = 4, String ellipses = '...', int postFix = 4}) {
-    return address.shortenedCryptoAddress(prefix: prefix, ellipses: ellipses, postFix: postFix);
+  static String formatAddress(
+    String address, {
+    int prefix = 4,
+    String ellipses = '...',
+    int postFix = 4,
+  }) {
+    return address.shortenedCryptoAddress(
+      prefix: prefix,
+      ellipses: ellipses,
+      postFix: postFix,
+    );
+  }
+
+  static List<String> splitIntoChunks(String text, {int chunkSize = 5}) {
+    if (chunkSize <= 0) {
+      throw ArgumentError('Chunk size must be a positive integer.');
+    }
+    if (text.isEmpty) {
+      return [];
+    }
+
+    List<String> chunks = [];
+    for (int i = 0; i < text.length; i += chunkSize) {
+      int endIndex = i + chunkSize;
+      if (endIndex > text.length) {
+        endIndex = text.length;
+      }
+      chunks.add(text.substring(i, endIndex));
+    }
+    return chunks;
   }
 }


### PR DESCRIPTION
Related issue #53 

Finished update layout and add utility to formatting service.

The copy button now copy both address and checksum to clipboard.

Missing piece in this implementation is the wallet name and the crystal generation. Now it;s static. I don't know if we can already get the wallet name and/or custom crystal icon.

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/406795a2-85e1-4763-881d-9bd0a9147d25" />

