### PR TITLE
fixes the issue where reversible remaining time never shows up

### DIFF
--- a/mobile-app/lib/features/components/transactions_list.dart
+++ b/mobile-app/lib/features/components/transactions_list.dart
@@ -54,8 +54,10 @@ class RecentTransactionsList extends StatelessWidget {
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: scheduled.length,
                 itemBuilder: (context, index) {
+                  final transaction = scheduled[index];
                   return TransactionListItem(
-                    transaction: scheduled[index],
+                    key: ValueKey(transaction.id),
+                    transaction: transaction,
                     currentWalletAddress: currentWalletAddress,
                   );
                 },
@@ -72,8 +74,10 @@ class RecentTransactionsList extends StatelessWidget {
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: others.length,
                 itemBuilder: (context, index) {
+                  final transaction = others[index];
                   return TransactionListItem(
-                    transaction: others[index],
+                    key: ValueKey(transaction.id),
+                    transaction: transaction,
                     currentWalletAddress: currentWalletAddress,
                   );
                 },


### PR DESCRIPTION
added widget key so flutter can correctly update changed values

timer is back

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-07-22 at 22 39 39" src="https://github.com/user-attachments/assets/ccc1bd9b-2092-4e2b-91a3-2e1d89e22692" />

