### PR TITLE
New account text fix

### DIFF
--- a/mobile-app/lib/features/components/transaction_action_sheet.dart
+++ b/mobile-app/lib/features/components/transaction_action_sheet.dart
@@ -1,5 +1,5 @@
-import 'dart:ui';
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -25,8 +25,8 @@ enum _SheetState { initial, confirmCancel, cancelled }
 
 class _TransactionActionSheetState extends State<TransactionActionSheet> {
   _SheetState _sheetState = _SheetState.initial;
-  late Timer _timer;
-  late Duration _remainingTime;
+  Timer? _timer;
+  Duration? _remainingTime;
   bool _isCancelling = false;
   String? _errorMessage;
 
@@ -45,7 +45,7 @@ class _TransactionActionSheetState extends State<TransactionActionSheet> {
   void initState() {
     super.initState();
     _remainingTime = widget.transaction.scheduledAt.difference(DateTime.now());
-    if (_remainingTime.isNegative) {
+    if (_remainingTime != null && _remainingTime!.isNegative) {
       _remainingTime = Duration.zero;
     }
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
@@ -54,10 +54,10 @@ class _TransactionActionSheetState extends State<TransactionActionSheet> {
         return;
       }
       setState(() {
-        if (_remainingTime > Duration.zero) {
-          _remainingTime = _remainingTime - const Duration(seconds: 1);
+        if (_remainingTime != null && _remainingTime! > Duration.zero) {
+          _remainingTime = _remainingTime! - const Duration(seconds: 1);
         } else {
-          _timer.cancel();
+          timer.cancel();
           // Maybe close the sheet or show a different state when timer ends.
           // For now, just stopping the timer.
         }
@@ -67,7 +67,7 @@ class _TransactionActionSheetState extends State<TransactionActionSheet> {
 
   @override
   void dispose() {
-    _timer.cancel();
+    _timer?.cancel();
     super.dispose();
   }
 
@@ -160,7 +160,7 @@ class _TransactionActionSheetState extends State<TransactionActionSheet> {
         const Divider(color: Colors.white, thickness: 1),
 
         const SizedBox(height: 12),
-        ReversibleTimer(remainingTime: _remainingTime),
+        ReversibleTimer(remainingTime: _remainingTime ?? Duration.zero),
         const SizedBox(height: 12),
 
         const Padding(

--- a/mobile-app/lib/features/components/transaction_details_action_sheet.dart
+++ b/mobile-app/lib/features/components/transaction_details_action_sheet.dart
@@ -1,5 +1,5 @@
-import 'dart:ui';
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -28,8 +28,8 @@ class TransactionDetailsActionSheet extends StatefulWidget {
 
 class _TransactionDetailsActionSheetState
     extends State<TransactionDetailsActionSheet> {
-  late Timer _timer;
-  late Duration _remainingTime;
+  Timer? _timer;
+  Duration? _remainingTime;
   Future<String> get _checksumFuture {
     final address = isSender ? widget.transaction.to : widget.transaction.from;
 
@@ -82,15 +82,15 @@ class _TransactionDetailsActionSheetState
     if (isReversibleScheduled) {
       final tx = widget.transaction as ReversibleTransferEvent;
       _remainingTime = tx.scheduledAt.difference(DateTime.now());
-      if (_remainingTime.isNegative) {
+      if (_remainingTime != null && _remainingTime!.isNegative) {
         _remainingTime = Duration.zero;
       }
       _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
         setState(() {
-          if (_remainingTime > Duration.zero) {
-            _remainingTime = _remainingTime - const Duration(seconds: 1);
+          if (_remainingTime != null && _remainingTime! > Duration.zero) {
+            _remainingTime = _remainingTime! - const Duration(seconds: 1);
           } else {
-            _timer.cancel();
+            timer.cancel();
           }
         });
       });
@@ -99,7 +99,7 @@ class _TransactionDetailsActionSheetState
 
   @override
   void dispose() {
-    _timer.cancel();
+    _timer?.cancel();
     super.dispose();
   }
 
@@ -406,7 +406,7 @@ class _TransactionDetailsActionSheetState
           ),
         ),
         if (!isSender && isReversibleScheduled)
-          ReversibleTimer(remainingTime: _remainingTime),
+          ReversibleTimer(remainingTime: _remainingTime ?? Duration.zero),
         FutureBuilder(
           future: _checksumFuture,
           builder: (context, snapshot) {

--- a/mobile-app/lib/features/components/transaction_list_item.dart
+++ b/mobile-app/lib/features/components/transaction_list_item.dart
@@ -23,8 +23,8 @@ class TransactionListItem extends StatefulWidget {
 }
 
 class TransactionListItemState extends State<TransactionListItem> {
-  late Timer _timer;
-  late Duration _remainingTime;
+  Timer? _timer;
+  Duration? _remainingTime;
   bool get isSent => widget.transaction.from == widget.currentWalletAddress;
   bool get isPending =>
       widget.transaction is PendingTransactionEvent || isReversibleScheduled;
@@ -59,15 +59,15 @@ class TransactionListItemState extends State<TransactionListItem> {
     if (isReversibleScheduled) {
       final tx = widget.transaction as ReversibleTransferEvent;
       _remainingTime = tx.scheduledAt.difference(DateTime.now());
-      if (_remainingTime.isNegative) {
+      if (_remainingTime!.isNegative) {
         _remainingTime = Duration.zero;
       }
       _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
         setState(() {
-          if (_remainingTime > Duration.zero) {
-            _remainingTime = _remainingTime - const Duration(seconds: 1);
+          if (_remainingTime != null && _remainingTime! > Duration.zero) {
+            _remainingTime = _remainingTime! - const Duration(seconds: 1);
           } else {
-            _timer.cancel();
+            timer.cancel();
           }
         });
       });
@@ -76,7 +76,7 @@ class TransactionListItemState extends State<TransactionListItem> {
 
   @override
   void dispose() {
-    _timer.cancel();
+    _timer?.cancel();
     super.dispose();
   }
 
@@ -249,10 +249,10 @@ class TransactionListItemState extends State<TransactionListItem> {
       final tx = widget.transaction as ReversibleTransferEvent;
       switch (tx.status) {
         case ReversibleTransferStatus.SCHEDULED:
-          if (_remainingTime > Duration.zero) {
+          if (_remainingTime != null && _remainingTime! > Duration.zero) {
             return _TimerDisplay(
               duration: DatetimeFormattingService.formatDuration(
-                _remainingTime,
+                _remainingTime!,
               ).formatted,
               isSending: widget.transaction.from == widget.currentWalletAddress,
             );

--- a/mobile-app/lib/features/main/screens/create_account_screen.dart
+++ b/mobile-app/lib/features/main/screens/create_account_screen.dart
@@ -275,7 +275,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
         const SizedBox(height: 16),
         SizedBox(
           width: 311,
-          height: 20, // Set a fixed height to avoid layout jump
+          height: 50, // Set a fixed height to avoid layout jump
           child: FutureBuilder<String>(
             future: _checksumFuture,
             builder: (context, snapshot) {


### PR DESCRIPTION
Fixes #97 

- Changed timers back to optional because I got an exception on logout. This was not the main fix but it happend while testing so I changed it back. 
- Fixed layout issue with the future text - this text is set to a fixed height which caused the y to be cut off. Increased height and also allowing for 2 rows in case the text is too long. 

(demo text data in this screenshot, we don't have these in our word list...)

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-07-24 at 20 31 54" src="https://github.com/user-attachments/assets/e6fa1bcb-e37b-48b8-9489-f7044de5c240" />
