### PR TITLE
Retry transactions a few times - fixes #96

### DIFF
--- a/mobile-app/lib/features/components/notification_card.dart
+++ b/mobile-app/lib/features/components/notification_card.dart
@@ -167,7 +167,6 @@ class _NotificationCardState extends State<NotificationCard>
     final notification = widget.notification;
 
     return GestureDetector(
-      // TODO: fix rendering when using swipe to not be buggy build
       onHorizontalDragUpdate: (details) {
         _handleSwipeUpdate(details.delta.dx);
       },

--- a/mobile-app/lib/features/main/screens/notifications_screen.dart
+++ b/mobile-app/lib/features/main/screens/notifications_screen.dart
@@ -85,7 +85,6 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                   Item(id: '4', label: 'His Accounts'),
                 ],
                 onChanged: (selectedItem) {
-                  // TODO: Handle account selection
                   print('Selected account: ${selectedItem?.label}');
                 },
               ),

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -227,8 +227,9 @@ class WalletStateManager with ChangeNotifier {
     Account account,
     String targetAddress,
     BigInt amount,
-    BigInt feeEstimate,
-  ) async {
+    BigInt feeEstimate, {
+    int maxRetries = 3,
+  }) async {
     final pending = createPendingTransaction(
       from: _senderAddressFromAccount(account),
       to: targetAddress,
@@ -271,25 +272,38 @@ class WalletStateManager with ChangeNotifier {
       }
     }
 
-    try {
-      subscription = await BalancesService().balanceTransfer(
-        account,
-        targetAddress,
-        amount,
-        onStatus,
-      );
-      print('Subscribed to stream for ${pending.id} $subscription');
-    } catch (e, stackTrace) {
-      updatePendingTransaction(
-        pending.id,
-        TransactionState.failed,
-        error: e.toString(),
-      );
-      print('Failed to transfer balance: $e');
-      print('Failed to transfer balance: $stackTrace');
-      throw Exception('Failed to transfer balance: $e');
+    int attempts = 0;
+    while (attempts < maxRetries) {
+      print("attempt $attempts");
+      try {
+        subscription = await BalancesService().balanceTransfer(
+          account,
+          targetAddress,
+          amount,
+          onStatus,
+        );
+        print('Subscribed to stream for ${pending.id} $subscription');
+        return pending.id;
+      } catch (e, stackTrace) {
+        attempts++;
+        if (attempts >= maxRetries) {
+          updatePendingTransaction(
+            pending.id,
+            TransactionState.failed,
+            error: e.toString(),
+          );
+          print('Failed to transfer balance after $maxRetries attempts: $e');
+          print('Stack trace: $stackTrace');
+          throw Exception(
+            'Failed to transfer balance after $maxRetries attempts: $e',
+          );
+        } else {
+          print('Transfer attempt $attempts failed: $e. Retrying...');
+        }
+      }
     }
-    return pending.id;
+    // This line should never be reached, but added for completeness
+    throw Exception('Unexpected error in balanceTransfer retry logic');
   }
 
   Future<void> scheduleReversibleTransferWithDelaySeconds({
@@ -298,6 +312,7 @@ class WalletStateManager with ChangeNotifier {
     required BigInt amount,
     required int delaySeconds,
     required BigInt feeEstimate,
+    int maxRetries = 3,
   }) async {
     final pending = createPendingTransaction(
       from: _senderAddressFromAccount(account),
@@ -340,26 +355,43 @@ class WalletStateManager with ChangeNotifier {
       }
     }
 
-    try {
-      subscription = await ReversibleTransfersService()
-          .scheduleReversibleTransferWithDelaySeconds(
-            account: account,
-            recipientAddress: recipientAddress,
-            amount: amount,
-            delaySeconds: delaySeconds,
-            onStatus: onStatus,
+    int attempts = 0;
+    while (attempts < maxRetries) {
+      try {
+        subscription = await ReversibleTransfersService()
+            .scheduleReversibleTransferWithDelaySeconds(
+              account: account,
+              recipientAddress: recipientAddress,
+              amount: amount,
+              delaySeconds: delaySeconds,
+              onStatus: onStatus,
+            );
+        print('Subscribed to rev stream for ${pending.id} $subscription');
+        return;
+      } catch (e, stackTrace) {
+        attempts++;
+        if (attempts >= maxRetries) {
+          updatePendingTransaction(
+            pending.id,
+            TransactionState.failed,
+            error: e.toString(),
           );
-      print('Subscribed to rev stream for ${pending.id} $subscription');
-    } catch (e, stackTrace) {
-      updatePendingTransaction(
-        pending.id,
-        TransactionState.failed,
-        error: e.toString(),
-      );
-      print('Failed to send reversible: $e');
-      print('Failed to send reversible: $stackTrace');
-      throw Exception('Failed to send reversible transfer: $e');
+          print('Failed to send reversible after $maxRetries attempts: $e');
+          print('Stack trace: $stackTrace');
+          throw Exception(
+            'Failed to send reversible transfer after $maxRetries attempts: $e',
+          );
+        } else {
+          print(
+            'Reversible transfer attempt $attempts failed: $e. Retrying...',
+          );
+        }
+      }
     }
+    // This line should never be reached, but added for completeness
+    throw Exception(
+      'Unexpected error in scheduleReversibleTransferWithDelaySeconds retry logic',
+    );
   }
 
   void updatePendingTransaction(

--- a/mobile-app/lib/models/wallet_state_manager.dart
+++ b/mobile-app/lib/models/wallet_state_manager.dart
@@ -274,7 +274,6 @@ class WalletStateManager with ChangeNotifier {
 
     int attempts = 0;
     while (attempts < maxRetries) {
-      print("attempt $attempts");
       try {
         subscription = await BalancesService().balanceTransfer(
           account,
@@ -390,7 +389,8 @@ class WalletStateManager with ChangeNotifier {
     }
     // This line should never be reached, but added for completeness
     throw Exception(
-      'Unexpected error in scheduleReversibleTransferWithDelaySeconds retry logic',
+      'Unexpected error in scheduleReversibleTransferWithDelaySeconds'
+      ' retry logic',
     );
   }
 

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -368,9 +368,11 @@ class SubstrateService {
     ])).result.replaceAll('0x', '');
     final encodedCall = call.encode();
 
+    print("submit extrinsic");
     int retryCount = 0;
     while (retryCount < maxRetries) {
       try {
+        print("retrying $retryCount");
         final block = await _provider!.send('chain_getBlock', []);
         final blockNumber = int.parse(
           block.result['block']['header']['number'],
@@ -401,6 +403,9 @@ class SubstrateService {
           keypair: senderWallet,
           message: payload,
         );
+        // for testing failed transactions - use the bad signature.
+        // var badSignature = Uint8List(signature.length); // 0 list
+
         final signatureWithPublicKeyBytes = _combineSignatureAndPubkey(
           signature,
           senderWallet.publicKey,

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -368,11 +368,9 @@ class SubstrateService {
     ])).result.replaceAll('0x', '');
     final encodedCall = call.encode();
 
-    print("submit extrinsic");
     int retryCount = 0;
     while (retryCount < maxRetries) {
       try {
-        print("retrying $retryCount");
         final block = await _provider!.send('chain_getBlock', []);
         final blockNumber = int.parse(
           block.result['block']['header']['number'],


### PR DESCRIPTION
Fix for #96 

Human Error: When implementing async wallet, I accidentally broke the retry logic, as we return a stream future now. 

Fix:Handle errors where they occur