### PR TITLE
Timer hits zero fix

### DIFF
--- a/mobile-app/lib/features/components/transaction_list_item.dart
+++ b/mobile-app/lib/features/components/transaction_list_item.dart
@@ -55,17 +55,17 @@ class TransactionListItemState extends State<TransactionListItem> {
     if (widget.transaction.isReversibleScheduled) {
       final tx = widget.transaction as ReversibleTransferEvent;
       _remainingTime = tx.remainingTime;
-      if (_remainingTime!.isNegative) {
-        _remainingTime = Duration.zero;
-      }
       _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
         final tx = widget.transaction as ReversibleTransferEvent;
         final remaining = tx.remainingTime;
-        if (remaining > Duration.zero) {
+        if (remaining >= const Duration(seconds: 1)) {
           setState(() {
             _remainingTime = remaining;
           });
         } else {
+          setState(() {
+            _remainingTime = Duration.zero;
+          });
           timer.cancel();
         }
       });


### PR DESCRIPTION
When the timer hits 0, we want to show "Pending"

Added a set state before canceling timer. Before it would never set the state variable to actual zero, but it would be < 1 seconds so it would show 0. 