### PR TITLE
Add account discovery

### DIFF
--- a/miner-app/lib/features/miner/miner_dashboard_screen.dart
+++ b/miner-app/lib/features/miner/miner_dashboard_screen.dart
@@ -53,7 +53,7 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
       if (mnemonic != null) {
         // Derive keypair from mnemonic using SubstrateService (exported by quantus_sdk)
         // ignore: deprecated_member_use
-        final keypair = SubstrateService().dilithiumKeypairFromMnemonic(
+        final keypair = SubstrateService().nonHDdilithiumKeypairFromMnemonic(
           mnemonic,
         );
         // Use toAccountId function to get the SS58 address (exported by quantus_sdk)

--- a/miner-app/lib/features/setup/rewards_address_setup_screen.dart
+++ b/miner-app/lib/features/setup/rewards_address_setup_screen.dart
@@ -111,7 +111,7 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
     try {
       // Derive seed from mnemonic and securely store it
       // ignore: deprecated_member_use
-      SubstrateService().dilithiumKeypairFromMnemonic(
+      SubstrateService().nonHDdilithiumKeypairFromMnemonic(
         mnemonic,
       ); // Validate mnemonic by trying to derive keypair
       await _securelyStoreMnemonic(mnemonic);

--- a/mobile-app/lib/features/main/screens/create_wallet_and_backup_screen.dart
+++ b/mobile-app/lib/features/main/screens/create_wallet_and_backup_screen.dart
@@ -75,12 +75,7 @@ class CreateWalletAndBackupScreenState
       if (accounts.isEmpty) {
         final key = HdWalletService().keyPairAtIndex(_mnemonic, 0);
         await _settingsService.addAccount(
-          Account(
-            index: 0,
-            name: 'Account 1',
-            accountId: key.ss58Address,
-            uiPosition: 0,
-          ),
+          Account(index: 0, name: 'Account 1', accountId: key.ss58Address),
         );
       }
 

--- a/mobile-app/lib/features/main/screens/create_wallet_and_backup_screen.dart
+++ b/mobile-app/lib/features/main/screens/create_wallet_and_backup_screen.dart
@@ -70,11 +70,19 @@ class CreateWalletAndBackupScreenState
     }
 
     try {
-      final key = HdWalletService().keyPairAtIndex(_mnemonic, 0);
       await _settingsService.setMnemonic(_mnemonic);
-      await _settingsService.addAccount(
-        Account(index: 0, name: 'Account 1', accountId: key.ss58Address),
-      );
+      final accounts = await _settingsService.getAccounts();
+      if (accounts.isEmpty) {
+        final key = HdWalletService().keyPairAtIndex(_mnemonic, 0);
+        await _settingsService.addAccount(
+          Account(
+            index: 0,
+            name: 'Account 1',
+            accountId: key.ss58Address,
+            uiPosition: 0,
+          ),
+        );
+      }
 
       if (mounted) {
         Navigator.pushAndRemoveUntil(

--- a/mobile-app/lib/features/main/screens/import_wallet_screen.dart
+++ b/mobile-app/lib/features/main/screens/import_wallet_screen.dart
@@ -14,8 +14,35 @@ class ImportWalletScreen extends StatefulWidget {
 class ImportWalletScreenState extends State<ImportWalletScreen> {
   final TextEditingController _mnemonicController = TextEditingController();
   bool _isLoading = false;
+  bool _isDiscovering = false;
   String _errorMessage = '';
   final SettingsService _settingsService = SettingsService();
+  final AccountDiscoveryService _accountDiscoveryService =
+      AccountDiscoveryService(HdWalletService(), SubstrateService());
+
+  Future<void> _discoverAccounts(String mnemonic) async {
+    if (!mounted) return;
+    setState(() {
+      _isDiscovering = true;
+    });
+
+    try {
+      final discoveredAccounts = await _accountDiscoveryService
+          .discoverAccounts(mnemonic: mnemonic);
+
+      for (final account in discoveredAccounts) {
+        await _settingsService.addAccount(account);
+      }
+    } catch (e) {
+      debugPrint('Error discovering accounts: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDiscovering = false;
+        });
+      }
+    }
+  }
 
   Future<void> _importWallet() async {
     setState(() {
@@ -44,8 +71,15 @@ class ImportWalletScreenState extends State<ImportWalletScreen> {
       final key = HdWalletService().keyPairAtIndex(mnemonic, 0);
       await _settingsService.setMnemonic(mnemonic);
       await _settingsService.addAccount(
-        Account(index: 0, name: 'Account 1', accountId: key.ss58Address),
+        Account(
+          index: 0,
+          name: 'Account 1',
+          accountId: key.ss58Address,
+          uiPosition: 0,
+        ),
       );
+
+      await _discoverAccounts(mnemonic);
 
       if (context.mounted && mounted) {
         Navigator.pushAndRemoveUntil(
@@ -239,11 +273,26 @@ class ImportWalletScreenState extends State<ImportWalletScreen> {
                     ),
                   ),
                 const Spacer(), // Add Spacer to push the button down
-                GradientActionButton(
-                  label: 'Import Wallet',
-                  onPressed: _importWallet,
-                  isLoading: _isLoading,
-                ),
+                if (_isDiscovering)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 50.0),
+                    child: Column(
+                      children: [
+                        CircularProgressIndicator(color: Colors.white),
+                        SizedBox(height: 16),
+                        Text(
+                          'Discovering existing accounts...',
+                          style: TextStyle(color: Colors.white70),
+                        ),
+                      ],
+                    ),
+                  )
+                else
+                  GradientActionButton(
+                    label: 'Import Wallet',
+                    onPressed: _importWallet,
+                    isLoading: _isLoading,
+                  ),
                 const SizedBox(
                   height: 24,
                 ), // Consistent bottom padding like CreateWalletScreen

--- a/mobile-app/lib/features/main/screens/import_wallet_screen.dart
+++ b/mobile-app/lib/features/main/screens/import_wallet_screen.dart
@@ -71,12 +71,7 @@ class ImportWalletScreenState extends State<ImportWalletScreen> {
       final key = HdWalletService().keyPairAtIndex(mnemonic, 0);
       await _settingsService.setMnemonic(mnemonic);
       await _settingsService.addAccount(
-        Account(
-          index: 0,
-          name: 'Account 1',
-          accountId: key.ss58Address,
-          uiPosition: 0,
-        ),
+        Account(index: 0, name: 'Account 1', accountId: key.ss58Address),
       );
 
       await _discoverAccounts(mnemonic);

--- a/quantus_sdk/lib/quantus_sdk.dart
+++ b/quantus_sdk/lib/quantus_sdk.dart
@@ -11,6 +11,7 @@ export 'src/extensions/color_extensions.dart';
 export 'src/extensions/decimal_input_filter.dart';
 export 'src/extensions/keypair_extensions.dart';
 export 'src/extensions/string_extensions.dart';
+// UI-related exports
 export 'src/models/account.dart';
 export 'src/models/event_type.dart';
 export 'src/models/reversible_transfer_status.dart';
@@ -20,11 +21,12 @@ export 'src/models/transaction_state.dart';
 // note we have to hide some things here because they're exported by substrate service
 // should probably expise all of crypto.dart through substrateservice instead
 export 'src/rust/api/crypto.dart' hide crystalAlice, crystalCharlie, crystalBob;
+export 'src/services/account_discovery_service.dart';
 export 'src/services/accounts_service.dart';
 export 'src/services/address_formatting_service.dart';
-export 'src/services/datetime_formatting_service.dart';
 export 'src/services/balances_service.dart';
 export 'src/services/chain_history_service.dart';
+export 'src/services/datetime_formatting_service.dart';
 export 'src/services/hd_wallet_service.dart';
 export 'src/services/human_readable_checksum_service.dart';
 export 'src/services/number_formatting_service.dart';

--- a/quantus_sdk/lib/src/models/account.dart
+++ b/quantus_sdk/lib/src/models/account.dart
@@ -5,12 +5,12 @@ class Account {
   final int index; // derivation index
   final String name;
   final String accountId; // address
-  // balance will be fetched from the chain and not stored here.
-
+  final int uiPosition; // UI position
   const Account({
     required this.index,
     required this.name,
     required this.accountId,
+    required this.uiPosition,
   });
 
   factory Account.fromJson(Map<String, dynamic> json) {
@@ -18,18 +18,30 @@ class Account {
       index: json['index'] as int,
       name: json['name'] as String,
       accountId: json['accountId'] as String,
+      uiPosition: json['uiPosition'] as int? ?? json['index'] as int,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {'index': index, 'name': name, 'accountId': accountId};
+    return {
+      'index': index,
+      'name': name,
+      'accountId': accountId,
+      'uiPosition': uiPosition,
+    };
   }
 
-  Account copyWith({int? index, String? name, String? accountId}) {
+  Account copyWith({
+    int? index,
+    String? name,
+    String? accountId,
+    int? uiPosition,
+  }) {
     return Account(
       index: index ?? this.index,
       name: name ?? this.name,
       accountId: accountId ?? this.accountId,
+      uiPosition: uiPosition ?? this.uiPosition,
     );
   }
 }

--- a/quantus_sdk/lib/src/models/account.dart
+++ b/quantus_sdk/lib/src/models/account.dart
@@ -5,12 +5,10 @@ class Account {
   final int index; // derivation index
   final String name;
   final String accountId; // address
-  final int uiPosition; // UI position
   const Account({
     required this.index,
     required this.name,
     required this.accountId,
-    required this.uiPosition,
   });
 
   factory Account.fromJson(Map<String, dynamic> json) {
@@ -18,17 +16,11 @@ class Account {
       index: json['index'] as int,
       name: json['name'] as String,
       accountId: json['accountId'] as String,
-      uiPosition: json['uiPosition'] as int? ?? json['index'] as int,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'index': index,
-      'name': name,
-      'accountId': accountId,
-      'uiPosition': uiPosition,
-    };
+    return {'index': index, 'name': name, 'accountId': accountId};
   }
 
   Account copyWith({
@@ -41,7 +33,6 @@ class Account {
       index: index ?? this.index,
       name: name ?? this.name,
       accountId: accountId ?? this.accountId,
-      uiPosition: uiPosition ?? this.uiPosition,
     );
   }
 }

--- a/quantus_sdk/lib/src/services/account_discovery_service.dart
+++ b/quantus_sdk/lib/src/services/account_discovery_service.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:quantus_sdk/src/constants/app_constants.dart';
+import 'package:quantus_sdk/src/extensions/keypair_extensions.dart';
+import 'package:quantus_sdk/src/models/account.dart';
+import 'package:quantus_sdk/src/services/hd_wallet_service.dart';
+import 'package:quantus_sdk/src/services/substrate_service.dart';
+
+class AccountDiscoveryService {
+  final HdWalletService _hdWalletService;
+  final SubstrateService _substrateService;
+  final String _graphQlEndpoint = AppConstants.graphQlEndpoint;
+
+  AccountDiscoveryService(this._hdWalletService, this._substrateService);
+
+  static const String _accountsQuery = r'''
+    query AccountsQuery($ids: [String!]) {
+      accounts(where: {id_in: $ids}) {
+        id
+      }
+    }
+  ''';
+
+  Future<List<Account>> discoverAccounts({
+    required String mnemonic,
+    int count = 20,
+  }) async {
+    final allPossibleAccounts = <Account>[];
+
+    // Add raw account
+    final rawKeyPair = _substrateService.nonHDdilithiumKeypairFromMnemonic(
+      mnemonic,
+    );
+    final rawAccount = Account(
+      index: -1, //  indicator for a raw account
+      name: 'Primary Account',
+      accountId: rawKeyPair.ss58Address,
+      uiPosition: -1,
+    );
+    allPossibleAccounts.add(rawAccount);
+
+    // Add HD accounts
+    for (var i = 0; i < count; i++) {
+      final keyPair = _hdWalletService.keyPairAtIndex(mnemonic, i);
+      final account = Account(
+        index: i,
+        name: 'Account ${i + 1}',
+        accountId: keyPair.ss58Address,
+        uiPosition: i,
+      );
+      allPossibleAccounts.add(account);
+    }
+
+    final accountIds = allPossibleAccounts.map((a) => a.accountId).toList();
+
+    final Uri uri = Uri.parse('$_graphQlEndpoint/graphql');
+    final Map<String, dynamic> requestBody = {
+      'query': _accountsQuery,
+      'variables': {'ids': accountIds},
+    };
+
+    print("discovering accounts: $accountIds");
+
+    try {
+      final response = await http.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(requestBody),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception(
+          'GraphQL request failed with status: ${response.statusCode}. Body: ${response.body}',
+        );
+      }
+
+      final Map<String, dynamic> responseBody = jsonDecode(response.body);
+      if (responseBody['errors'] != null) {
+        throw Exception('GraphQL errors: ${responseBody['errors']}');
+      }
+
+      final List<dynamic>? foundAccountsData =
+          responseBody['data']?['accounts'];
+
+      print("found accounts data: $foundAccountsData");
+
+      if (foundAccountsData == null) {
+        return [];
+      }
+
+      final foundAccountIds = foundAccountsData
+          .map((a) => a['id'] as String)
+          .toSet();
+
+      print("found accounts: $foundAccountIds");
+
+      return allPossibleAccounts
+          .where((account) => foundAccountIds.contains(account.accountId))
+          .toList();
+    } catch (e, stackTrace) {
+      print('Error discovering accounts: $e');
+      print(stackTrace);
+      rethrow;
+    }
+  }
+}

--- a/quantus_sdk/lib/src/services/account_discovery_service.dart
+++ b/quantus_sdk/lib/src/services/account_discovery_service.dart
@@ -36,7 +36,6 @@ class AccountDiscoveryService {
       index: -1, //  indicator for a raw account
       name: 'Primary Account',
       accountId: rawKeyPair.ss58Address,
-      uiPosition: -1,
     );
     allPossibleAccounts.add(rawAccount);
 
@@ -47,7 +46,6 @@ class AccountDiscoveryService {
         index: i,
         name: 'Account ${i + 1}',
         accountId: keyPair.ss58Address,
-        uiPosition: i,
       );
       allPossibleAccounts.add(account);
     }
@@ -59,8 +57,6 @@ class AccountDiscoveryService {
       'query': _accountsQuery,
       'variables': {'ids': accountIds},
     };
-
-    print("discovering accounts: $accountIds");
 
     try {
       final response = await http.post(
@@ -83,8 +79,6 @@ class AccountDiscoveryService {
       final List<dynamic>? foundAccountsData =
           responseBody['data']?['accounts'];
 
-      print("found accounts data: $foundAccountsData");
-
       if (foundAccountsData == null) {
         return [];
       }
@@ -92,8 +86,6 @@ class AccountDiscoveryService {
       final foundAccountIds = foundAccountsData
           .map((a) => a['id'] as String)
           .toSet();
-
-      print("found accounts: $foundAccountIds");
 
       return allPossibleAccounts
           .where((account) => foundAccountIds.contains(account.accountId))

--- a/quantus_sdk/lib/src/services/accounts_service.dart
+++ b/quantus_sdk/lib/src/services/accounts_service.dart
@@ -28,7 +28,6 @@ class AccountsService {
       index: nextIndex,
       name: 'Account ${nextIndex + 1}', // Default name
       accountId: keypair.ss58Address,
-      uiPosition: nextIndex,
     );
     return newAccount;
   }

--- a/quantus_sdk/lib/src/services/accounts_service.dart
+++ b/quantus_sdk/lib/src/services/accounts_service.dart
@@ -28,6 +28,7 @@ class AccountsService {
       index: nextIndex,
       name: 'Account ${nextIndex + 1}', // Default name
       accountId: keypair.ss58Address,
+      uiPosition: nextIndex,
     );
     return newAccount;
   }

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -46,7 +46,6 @@ class SettingsService {
         index: 0,
         name: oldWalletName,
         accountId: oldAccountId,
-        uiPosition: 0,
       );
       await saveAccounts([account]);
       await setActiveAccount(account);

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -33,8 +33,9 @@ class SettingsService {
   Future<List<Account>> getAccounts() async {
     final accountsJson = _prefs.getString(_accountsKey);
     if (accountsJson != null) {
-      final List<dynamic> decoded = jsonDecode(accountsJson);
-      return decoded.map((e) => Account.fromJson(e)).toList();
+      final decoded = jsonDecode(accountsJson) as List<dynamic>;
+      return decoded.map((e) => Account.fromJson(e)).toList()
+        ..sort((a, b) => a.index.compareTo(b.index));
     }
 
     // Migration for existing single-account users
@@ -45,6 +46,7 @@ class SettingsService {
         index: 0,
         name: oldWalletName,
         accountId: oldAccountId,
+        uiPosition: 0,
       );
       await saveAccounts([account]);
       await setActiveAccount(account);

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -291,16 +291,10 @@ class SubstrateService {
     return result;
   }
 
-  @Deprecated('Use Account.getKeypair() instead')
-  crypto.Keypair dilithiumKeypairFromMnemonic(String senderSeed) {
-    // This method is now simplified to support legacy calls or testing.
-    // It defaults to deriving the key for account index 0.
-    // For specific accounts, use HdWalletService().keyPairAtIndex(mnemonic, index).
-    if (senderSeed.startsWith('//')) {
-      // Handle test seeds
-      return crypto.generateKeypair(mnemonicStr: senderSeed);
-    }
-    return HdWalletService().keyPairAtIndex(senderSeed, 0);
+  // Legacy method - supports CLI addresses and Miner App
+  // The mobile app should use @HdWalletService for everything.
+  crypto.Keypair nonHDdilithiumKeypairFromMnemonic(String senderSeed) {
+    return crypto.generateKeypair(mnemonicStr: senderSeed);
   }
 
   Future<StreamSubscription<ExtrinsicStatus>> submitExtrinsic(

--- a/quantus_sdk/run_tests.sh
+++ b/quantus_sdk/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Get the directory of the script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Ensuring Rust library is up to date..."
+"$DIR/test/build_library.sh"
+
+echo "Running Flutter tests..."
+(cd "$DIR" && flutter test)

--- a/quantus_sdk/test/build_library.sh
+++ b/quantus_sdk/test/build_library.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+echo "Building Rust library for local development and testing..."
+(cd rust && cargo build --release)
+echo "Rust library built successfully." 

--- a/quantus_sdk/test/generate_keys_test.dart
+++ b/quantus_sdk/test/generate_keys_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
     await QuantusSdk.init();
   });
 
@@ -28,7 +30,7 @@ void main() {
       // Verify account ID format (should be a valid SS58 address)
       expect(accountId, isNotEmpty);
       expect(
-        accountId.startsWith('5'),
+        accountId.startsWith('qz'),
         isTrue,
       ); // SS58 addresses typically start with '5'
 
@@ -47,6 +49,20 @@ void main() {
       );
 
       expect(isValid, isTrue);
+    });
+
+    test('Test CLI compatibility with known value', () {
+      // This is a valid BIP39 mnemonic phrase - DO NOT use for real wallets
+      const testMnemonic =
+          'ten tone sniff segment glance worth defense delay december boring catch thrive noodle radar exhibit dish whale hub couch audit usual certain dance clever';
+
+      // Generate keypair from mnemonic
+      final keypair = generateKeypair(mnemonicStr: testMnemonic);
+      // Convert to account ID
+      final accountId = toAccountId(obj: keypair);
+
+      // Verify account ID format (should be a valid SS58 address)
+      expect(accountId, 'qzo18PGwLjXx8GzKtPDqh5Qver9tHS2MDZPthyTyXnMRGW6Uz');
     });
 
     test('should generate different keypairs for different mnemonics', () {

--- a/quantus_sdk/test/services/settings_service_test.dart
+++ b/quantus_sdk/test/services/settings_service_test.dart
@@ -7,9 +7,24 @@ void main() {
     late SettingsService settingsService;
 
     // Accounts for testing
-    const account1 = Account(index: 0, name: 'Account 1', accountId: 'id_1');
-    const account2 = Account(index: 1, name: 'Account 2', accountId: 'id_2');
-    const account3 = Account(index: 2, name: 'Account 3', accountId: 'id_3');
+    const account1 = Account(
+      index: 0,
+      name: 'Account 1',
+      accountId: 'id_1',
+      uiPosition: 0,
+    );
+    const account2 = Account(
+      index: 1,
+      name: 'Account 2',
+      accountId: 'id_2',
+      uiPosition: 1,
+    );
+    const account3 = Account(
+      index: 2,
+      name: 'Account 3',
+      accountId: 'id_3',
+      uiPosition: 2,
+    );
 
     setUp(() async {
       // Set up mock values for SharedPreferences
@@ -20,7 +35,10 @@ void main() {
 
     test('Migration: should migrate from old single-account format', () async {
       // Arrange: Set up old format keys
-      SharedPreferences.setMockInitialValues({'account_id': 'old_id', 'wallet_name': 'Old Wallet'});
+      SharedPreferences.setMockInitialValues({
+        'account_id': 'old_id',
+        'wallet_name': 'Old Wallet',
+      });
       settingsService = SettingsService();
       await settingsService.initialize();
 
@@ -46,7 +64,13 @@ void main() {
       // Act & Assert
       expect(
         () async => await settingsService.getAccounts(),
-        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('Wallet is logged out'))),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Wallet is logged out'),
+          ),
+        ),
       );
     });
 
@@ -68,8 +92,16 @@ void main() {
 
       // Act & Assert
       expect(
-        () async => await settingsService.addAccount(account1.copyWith(accountId: 'new_id')),
-        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('Account already exists'))),
+        () async => await settingsService.addAccount(
+          account1.copyWith(accountId: 'new_id'),
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Account already exists'),
+          ),
+        ),
       );
     });
 
@@ -86,17 +118,20 @@ void main() {
       expect(accounts.first.name, 'Updated Name');
     });
 
-    test('setActiveAccount and getActiveAccount should work correctly', () async {
-      // Arrange
-      await settingsService.saveAccounts([account1, account2]);
+    test(
+      'setActiveAccount and getActiveAccount should work correctly',
+      () async {
+        // Arrange
+        await settingsService.saveAccounts([account1, account2]);
 
-      // Act
-      await settingsService.setActiveAccount(account2);
-      final activeAccount = await settingsService.getActiveAccount();
+        // Act
+        await settingsService.setActiveAccount(account2);
+        final activeAccount = await settingsService.getActiveAccount();
 
-      // Assert
-      expect(activeAccount.accountId, account2.accountId);
-    });
+        // Assert
+        expect(activeAccount.accountId, account2.accountId);
+      },
+    );
 
     test('setActiveAccount should throw for a non-existent account', () async {
       // Arrange
@@ -105,7 +140,13 @@ void main() {
       // Act & Assert
       expect(
         () async => await settingsService.setActiveAccount(account2),
-        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('Account index does not exist'))),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Account index does not exist'),
+          ),
+        ),
       );
     });
 
@@ -129,27 +170,39 @@ void main() {
       // Act & Assert
       expect(
         () async => await settingsService.removeAccount(account1),
-        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('Cant remove last account'))),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Cant remove last account'),
+          ),
+        ),
       );
     });
 
-    test('removeAccount should change active account if active is removed', () async {
-      // Arrange
-      await settingsService.saveAccounts([account1, account2, account3]);
-      await settingsService.setActiveAccount(account2);
+    test(
+      'removeAccount should change active account if active is removed',
+      () async {
+        // Arrange
+        await settingsService.saveAccounts([account1, account2, account3]);
+        await settingsService.setActiveAccount(account2);
 
-      // Act
-      await settingsService.removeAccount(account2);
-      final activeAccount = await settingsService.getActiveAccount();
+        // Act
+        await settingsService.removeAccount(account2);
+        final activeAccount = await settingsService.getActiveAccount();
 
-      // Assert
-      // It should fall back to the first account in the remaining list
-      expect(activeAccount.accountId, account1.accountId);
-    });
+        // Assert
+        // It should fall back to the first account in the remaining list
+        expect(activeAccount.accountId, account1.accountId);
+      },
+    );
 
     test('getNextFreeAccountIndex should return correct next index', () async {
       // Arrange
-      await settingsService.saveAccounts([account1, account3]); // Indices 0 and 2
+      await settingsService.saveAccounts([
+        account1,
+        account3,
+      ]); // Indices 0 and 2
 
       // Act
       final nextIndex = await settingsService.getNextFreeAccountIndex();

--- a/quantus_sdk/test/services/settings_service_test.dart
+++ b/quantus_sdk/test/services/settings_service_test.dart
@@ -11,19 +11,16 @@ void main() {
       index: 0,
       name: 'Account 1',
       accountId: 'id_1',
-      uiPosition: 0,
     );
     const account2 = Account(
       index: 1,
       name: 'Account 2',
       accountId: 'id_2',
-      uiPosition: 1,
     );
     const account3 = Account(
       index: 2,
       name: 'Account 3',
       accountId: 'id_3',
-      uiPosition: 2,
     );
 
     setUp(() async {


### PR DESCRIPTION
## Overview

This PR solves the issue that miner accounts can't see what's in their wallet

## Solution
Added a feature we need anyway, account discovery. When a user imports a wallet, we check if there's any existing wallets with balances based on HD key derivation. 

## Limitations

Currently only checks the first 20, we can easily add more later, or have this in settings to search for unlimited accounts. 

Or else users who just keep creating new accounts using the create button, will also find their own accounts back one by one. 

## Code changes

- Account UI position prep for allowing users to move accounts around. Right now accounts are sorted by index, but index is the HD generation key so it's an internal value that can't be changed. 
- Fix up unit tests to align with CLI generated old accounts - make sure we generate the same account addresses as CLI from mnemonic. 
- Add old account method to account discovery