### PR TITLE
Fix max button

### DIFF
--- a/mobile-app/lib/features/main/screens/send/send_screen.dart
+++ b/mobile-app/lib/features/main/screens/send/send_screen.dart
@@ -260,7 +260,10 @@ class SendScreenState extends State<SendScreen> {
     }
 
     try {
-      BigInt estimatedFee = await getNetworkFeeForAmount(recipient, _amount);
+      BigInt estimatedFee = await getNetworkFeeForAmount(
+        recipient,
+        _maxBalance,
+      );
 
       final maxSendableAmount = _maxBalance - estimatedFee;
 

--- a/mobile-app/lib/features/main/screens/send/send_screen.dart
+++ b/mobile-app/lib/features/main/screens/send/send_screen.dart
@@ -68,6 +68,7 @@ class SendScreenState extends State<SendScreen> {
   Future<void> _saveReversibleTimeSetting(int seconds) async {
     try {
       await _settingsService.setReversibleTimeSeconds(seconds);
+      _fetchNetworkFee();
     } catch (e) {
       debugPrint('Error saving reversible time setting: $e');
     }
@@ -276,6 +277,7 @@ class SendScreenState extends State<SendScreen> {
       if (maxSendableAmount > BigInt.zero) {
         final formattedMax = _formattingService.formatBalance(
           maxSendableAmount,
+          addThousandsSeparators: false,
         );
         _amountController.text = formattedMax;
         _setSendAmount(maxSendableAmount);
@@ -363,8 +365,6 @@ class SendScreenState extends State<SendScreen> {
 
     if (scannedAddress != null && mounted) {
       _recipientController.text = scannedAddress;
-      // Add a small delay to ensure the text controller has updated
-      // await Future.delayed(const Duration(milliseconds: 100));
       if (mounted) {
         _lookupIdentity();
       }

--- a/mobile-app/lib/features/main/screens/send/send_screen.dart
+++ b/mobile-app/lib/features/main/screens/send/send_screen.dart
@@ -161,6 +161,10 @@ class SendScreenState extends State<SendScreen> {
 
     final parsedAmount = _formattingService.parseAmount(value);
 
+    _setSendAmount(parsedAmount);
+  }
+
+  void _setSendAmount(BigInt? parsedAmount) {
     if (parsedAmount == null) {
       setState(() {
         _amount = BigInt.zero;
@@ -264,6 +268,8 @@ class SendScreenState extends State<SendScreen> {
         recipient,
         _maxBalance,
       );
+      print("max balance: $_maxBalance");
+      print("estimated fee: $estimatedFee");
 
       final maxSendableAmount = _maxBalance - estimatedFee;
 
@@ -272,10 +278,10 @@ class SendScreenState extends State<SendScreen> {
           maxSendableAmount,
         );
         _amountController.text = formattedMax;
-        _validateAmount(formattedMax);
+        _setSendAmount(maxSendableAmount);
       } else {
         _amountController.text = '0';
-        _validateAmount('0');
+        _setSendAmount(BigInt.zero);
       }
     } catch (e, s) {
       print('Error setting max amount: $e');

--- a/mobile-app/lib/features/main/screens/send/send_screen.dart
+++ b/mobile-app/lib/features/main/screens/send/send_screen.dart
@@ -93,6 +93,12 @@ class SendScreenState extends State<SendScreen> {
     }
   }
 
+  // return recipient or null if recipient is invalid
+  String? _getValidRecipient() {
+    final recipient = _recipientController.text.trim();
+    return _isValidSS58Address(recipient) ? recipient : null;
+  }
+
   Future<void> _lookupIdentity() async {
     if (!mounted) return; // Add early return if not mounted
     final recipient = _recipientController.text.trim();
@@ -198,23 +204,7 @@ class SendScreenState extends State<SendScreen> {
     });
 
     try {
-      final account = await _settingsService.getActiveAccount();
-      BigInt estimatedFee;
-      if (_reversibleTimeSeconds > 0) {
-        estimatedFee = await ReversibleTransfersService()
-            .getReversibleTransferWithDelayFeeEstimate(
-              account: account,
-              recipientAddress: recipient,
-              amount: _amount,
-              delaySeconds: _reversibleTimeSeconds,
-            );
-      } else {
-        estimatedFee = await BalancesService().getBalanceTransferFee(
-          account,
-          recipient,
-          _amount,
-        );
-      }
+      BigInt estimatedFee = await getNetworkFeeForAmount(recipient, _amount);
 
       setState(() {
         _networkFee = estimatedFee;
@@ -237,15 +227,62 @@ class SendScreenState extends State<SendScreen> {
     }
   }
 
-  void _setMaxAmount() {
-    final maxSendableAmount = _maxBalance - _networkFee;
-    if (maxSendableAmount > BigInt.zero) {
-      final formattedMax = _formattingService.formatBalance(maxSendableAmount);
-      _amountController.text = formattedMax;
-      _validateAmount(formattedMax);
+  Future<BigInt> getNetworkFeeForAmount(String recipient, BigInt amount) async {
+    final account = await _settingsService.getActiveAccount();
+    BigInt estimatedFee;
+    if (_reversibleTimeSeconds > 0) {
+      estimatedFee = await ReversibleTransfersService()
+          .getReversibleTransferWithDelayFeeEstimate(
+            account: account,
+            recipientAddress: recipient,
+            amount: amount,
+            delaySeconds: _reversibleTimeSeconds,
+          );
     } else {
-      _amountController.text = '0';
-      _validateAmount('0');
+      estimatedFee = await BalancesService().getBalanceTransferFee(
+        account,
+        recipient,
+        amount,
+      );
+    }
+    return estimatedFee;
+  }
+
+  Future<void> _setMaxAmount() async {
+    String? recipient = _getValidRecipient();
+    if (recipient == null) {
+      showTopSnackBar(
+        context,
+        title: 'Error',
+        message: 'Invalid recipient address',
+      );
+      return;
+    }
+
+    try {
+      BigInt estimatedFee = await getNetworkFeeForAmount(recipient, _amount);
+
+      final maxSendableAmount = _maxBalance - estimatedFee;
+
+      if (maxSendableAmount > BigInt.zero) {
+        final formattedMax = _formattingService.formatBalance(
+          maxSendableAmount,
+        );
+        _amountController.text = formattedMax;
+        _validateAmount(formattedMax);
+      } else {
+        _amountController.text = '0';
+        _validateAmount('0');
+      }
+    } catch (e, s) {
+      print('Error setting max amount: $e');
+      print('Error setting max amount stack trace: $s');
+      showTopSnackBar(
+        // ignore: use_build_context_synchronously
+        context,
+        title: 'Error',
+        message: 'Error setting max amount: $e',
+      );
     }
   }
 

--- a/quantus_sdk/lib/src/services/number_formatting_service.dart
+++ b/quantus_sdk/lib/src/services/number_formatting_service.dart
@@ -14,7 +14,11 @@ class NumberFormattingService {
   /// user-readable string with a specified number of decimal places.
   ///
   /// Example: 1234500000000 -> "1.2345" (with maxDecimals = 4)
-  String formatBalance(BigInt balance, {int maxDecimals = 4}) {
+  String formatBalance(
+    BigInt balance, {
+    int maxDecimals = 4,
+    bool addThousandsSeparators = true,
+  }) {
     if (balance == BigInt.zero) {
       return '0';
     }
@@ -48,17 +52,20 @@ class NumberFormattingService {
       }
     }
 
-    // 5. Manually add thousand separators to the integer part.
-    final parts = asString.split('.');
-    final integerPart = parts[0];
-    final decimalPart = parts.length > 1 ? '.${parts[1]}' : '';
+    if (addThousandsSeparators) {
+      // 5. Manually add thousand separators to the integer part.
+      final parts = asString.split('.');
+      final integerPart = parts[0];
+      final decimalPart = parts.length > 1 ? '.${parts[1]}' : '';
 
-    final formattedInteger = integerPart.replaceAllMapped(
-      RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
-      (Match m) => '${m[1]},',
-    );
-
-    return formattedInteger + decimalPart;
+      final formattedInteger = integerPart.replaceAllMapped(
+        RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+        (Match m) => '${m[1]},',
+      );
+      return formattedInteger + decimalPart;
+    } else {
+      return asString;
+    }
   }
 
   /// Parses a user-entered formatted string amount (e.g., "1.23" or "1,23"


### PR DESCRIPTION
- Added get fee to max button function, like #137 
- No thousands separators in our send field
- Fetch network fee when switching from / to reversible / non-reversible - since they have different fees
- Show error when no valid recipient
- Show error when fee fetch fails
- Factor out getNetworkFeeForAmount
- Send max sets the amount directly - factored out _setSendAmount for this purpose 