### PR TITLE
Fix send max reversible

### DIFF
--- a/miner-app/lib/features/miner/miner_dashboard_screen.dart
+++ b/miner-app/lib/features/miner/miner_dashboard_screen.dart
@@ -68,8 +68,10 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
 
         setState(() {
           // Assuming NumberFormattingService and AppConstants are available via quantus_sdk export
-          _walletBalance =
-              '${NumberFormattingService().formatBalance(balance)} ${AppConstants.tokenSymbol}';
+          _walletBalance = NumberFormattingService().formatBalance(
+            balance,
+            addSymbol: true,
+          );
           _walletAddress = address;
         });
       } else {

--- a/mobile-app/lib/app_lifecycle_manager.dart
+++ b/mobile-app/lib/app_lifecycle_manager.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/services/history_polling_manager.dart';
 
+/// Provider that holds the current app lifecycle state
+final appLifecycleStateProvider = StateProvider<AppLifecycleState>(
+  (ref) => AppLifecycleState.resumed,
+);
+
 /// App lifecycle listener that manages polling based on app state
 class AppLifecycleManager extends ConsumerStatefulWidget {
   final Widget child;
@@ -19,6 +24,9 @@ class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // Set initial state
+    ref.read(appLifecycleStateProvider.notifier).state =
+        WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.resumed;
   }
 
   @override
@@ -29,11 +37,14 @@ class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    ref.read(appLifecycleStateProvider.notifier).state = state;
+
     final pollingManager = ref.read(historyPollingManagerProvider);
 
     switch (state) {
       case AppLifecycleState.paused:
       case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
         // Pause global polling when app goes to background
         // Transaction tracking continues for pending transactions
         pollingManager.pausePolling();
@@ -50,11 +61,6 @@ class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager>
         // App is being terminated
         pollingManager.stopPolling();
         break;
-
-      case AppLifecycleState.hidden:
-        // App is hidden but still running
-        pollingManager.pausePolling();
-        break;
     }
   }
 
@@ -63,22 +69,3 @@ class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager>
     return widget.child;
   }
 }
-
-/// Usage example for your main app:
-/// 
-/// ```dart
-/// class MyApp extends StatelessWidget {
-///   @override
-///   Widget build(BuildContext context) {
-///     return ProviderScope(
-///       child: AppInitializer(
-///         child: AppLifecycleManager(
-///           child: MaterialApp(
-///             // Your app content here
-///           ),
-///         ),
-///       ),
-///     );
-///   }
-/// }
-/// ```

--- a/mobile-app/lib/features/components/transaction_action_sheet.dart
+++ b/mobile-app/lib/features/components/transaction_action_sheet.dart
@@ -71,7 +71,7 @@ class _TransactionActionSheetState extends State<TransactionActionSheet> {
   }
 
   String _formatAmount(BigInt amount) {
-    return '${_formattingService.formatBalance(amount)} QUAN';
+    return _formattingService.formatBalance(amount, addSymbol: true);
   }
 
   @override

--- a/mobile-app/lib/features/components/transaction_list_item.dart
+++ b/mobile-app/lib/features/components/transaction_list_item.dart
@@ -107,7 +107,7 @@ class TransactionListItemState extends State<TransactionListItem> {
   final NumberFormattingService _formattingService = NumberFormattingService();
 
   String _formatAmount(BigInt amount) {
-    return '${_formattingService.formatBalance(amount)} QUAN';
+    return _formattingService.formatBalance(amount, addSymbol: true);
   }
 
   String _formatAddress(String address) {

--- a/mobile-app/lib/features/main/screens/accounts_screen.dart
+++ b/mobile-app/lib/features/main/screens/accounts_screen.dart
@@ -369,9 +369,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                     MaterialPageRoute(
                       builder: (context) => AccountSettingsScreen(
                         account: account,
-                        balance:
-                            '${_formattingService.formatBalance(balance)}'
-                            ' ${AppConstants.tokenSymbol}',
+                        balance: _formattingService.formatBalance(
+                          balance,
+                          addSymbol: true,
+                        ),
                         checksumName: checksumName,
                       ),
                     ),

--- a/mobile-app/lib/features/main/screens/app.dart
+++ b/mobile-app/lib/features/main/screens/app.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:resonance_network_wallet/features/styles/app_theme.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/features/main/screens/authentication_wrapper.dart';
 import 'package:resonance_network_wallet/features/main/screens/send/send_screen.dart';
+import 'package:resonance_network_wallet/features/styles/app_theme.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/services/local_auth_service.dart';
 

--- a/mobile-app/lib/features/main/screens/send/send_screen.dart
+++ b/mobile-app/lib/features/main/screens/send/send_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:quantus_sdk/generated/resonance/pallets/balances.dart'
+    as balances;
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/features/components/app_modal_bottom_sheet.dart';
 import 'package:resonance_network_wallet/features/components/base_with_background.dart';
@@ -248,6 +250,9 @@ class SendScreenState extends State<SendScreen> {
             amount: amount,
             delaySeconds: _reversibleTimeSeconds,
           );
+
+      // Can't send more than existentia deposit with a reversible transfer
+      estimatedFee = estimatedFee + balances.Constants().existentialDeposit;
     } else {
       estimatedFee = await BalancesService().getBalanceTransferFee(
         account,
@@ -276,6 +281,8 @@ class SendScreenState extends State<SendScreen> {
       );
 
       final maxSendableAmount = _maxBalance - estimatedFee;
+
+      print('max sendable amount: $maxSendableAmount');
 
       if (maxSendableAmount > BigInt.zero) {
         final formattedMax = _formattingService.formatBalance(
@@ -1027,8 +1034,10 @@ class SendScreenState extends State<SendScreen> {
                           Row(
                             children: [
                               Text(
-                                // ignore: lines_longer_than_80_chars
-                                '${_formattingService.formatBalance(_networkFee)} ${AppConstants.tokenSymbol}',
+                                _formattingService.formatBalance(
+                                  _networkFee,
+                                  addSymbol: true,
+                                ),
                                 style: context.themeText.detail?.copyWith(
                                   color: context.themeColors.textMuted,
                                   fontWeight: FontWeight.w600,
@@ -1093,7 +1102,7 @@ class SendScreenState extends State<SendScreen> {
                               : _hasAmountError
                               ? 'Insufficient Balance'
                               // ignore: lines_longer_than_80_chars
-                              : 'Send ${_formattingService.formatBalance(_amount)} ${AppConstants.tokenSymbol}',
+                              : 'Send ${_formattingService.formatBalance(_amount, addSymbol: true)}',
                           textAlign: TextAlign.center,
                           style: context.themeText.smallTitle?.copyWith(
                             color: context.themeColors.textSecondary,

--- a/mobile-app/lib/providers/all_transactions_provider.dart
+++ b/mobile-app/lib/providers/all_transactions_provider.dart
@@ -76,6 +76,7 @@ class PaginationController extends StateNotifier<PaginationState> {
             accountIds: accountIds,
             limit: _limit,
             offset: state.offset,
+            printName: 'allTx - fetchPage',
           );
 
       final newItems = newTransactions.otherTransfers;
@@ -107,10 +108,10 @@ class PaginationController extends StateNotifier<PaginationState> {
   Future<void> silentRefresh() async {
     print('Pagination Controller: Silent refresh called');
     if (state.isFetching) return;
-    final accounts = ref.read(accountsProvider).value;
-    if (accounts == null || accounts.isEmpty) return;
+    final activeAccount = ref.read(activeAccountProvider).value;
+    if (activeAccount == null) return;
 
-    await _silentFetchFirstPage(accounts.map((e) => e.accountId).toList());
+    await _silentFetchFirstPage([activeAccount.accountId]);
   }
 
   /// Refresh data with loading indicators.
@@ -138,6 +139,7 @@ class PaginationController extends StateNotifier<PaginationState> {
             accountIds: accountIds,
             limit: _limit,
             offset: 0,
+            printName: 'silentFetchFirstPage',
           );
 
       final newItems = newTransactions.otherTransfers;

--- a/mobile-app/lib/providers/filtered_all_transactions_provider.dart
+++ b/mobile-app/lib/providers/filtered_all_transactions_provider.dart
@@ -29,6 +29,7 @@ class FilteredPaginationController extends StateNotifier<PaginationState> {
             accountIds: targetAccountIds,
             limit: _limit,
             offset: state.offset,
+            printName: 'filteredTx - fetchPage',
           );
 
       final newItems = newTransactions.otherTransfers;

--- a/mobile-app/lib/providers/history_transactions_provider.dart
+++ b/mobile-app/lib/providers/history_transactions_provider.dart
@@ -55,6 +55,7 @@ class PaginatedTransactionsNotifier
             accountIds: accountIds,
             limit: _limit,
             offset: _offset,
+            printName: 'historyTx - fetchPage',
           );
 
       final newItems = newTransactions.otherTransfers;

--- a/mobile-app/lib/providers/wallet_providers.dart
+++ b/mobile-app/lib/providers/wallet_providers.dart
@@ -102,6 +102,7 @@ final historyProviderFamily =
 
       return await chainHistoryService.fetchAllTransactionTypes(
         accountIds: accountIds,
+        printName: 'historyProviderFamily',
       );
     });
 

--- a/mobile-app/lib/services/reversible_transfer_monitoring_service.dart
+++ b/mobile-app/lib/services/reversible_transfer_monitoring_service.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/app_lifecycle_manager.dart';
 import 'package:resonance_network_wallet/providers/all_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 
@@ -16,12 +18,19 @@ class ReversibleTransferMonitoringService {
   static const Duration _pollInterval = Duration(
     seconds: 5,
   ); // Aggressive polling
-  static const Duration _timeBuffer = Duration(
-    seconds: 30,
-  ); // Start monitoring the timer x seconds before
 
   ReversibleTransferMonitoringService(this._ref) {
-    _listenToTransactions();
+    _ref.listen(appLifecycleStateProvider, (previous, next) {
+      if (next == AppLifecycleState.resumed) {
+        _listenToTransactions();
+      } else {
+        dispose();
+      }
+    });
+
+    if (_ref.read(appLifecycleStateProvider) == AppLifecycleState.resumed) {
+      _listenToTransactions();
+    }
   }
 
   void _listenToTransactions() {
@@ -44,14 +53,16 @@ class ReversibleTransferMonitoringService {
         .where((tx) => tx.status == ReversibleTransferStatus.SCHEDULED)
         .toList();
 
+    print(
+      // ignore: lines_longer_than_80_chars
+      'monitoring setvice: watching ${scheduledTransfers.length} reversible transfers!',
+    );
+
     // Start monitoring transfers approaching execution
     for (final transfer in scheduledTransfers) {
-      final remainingTime = transfer.remainingTime;
-
-      // If we're not already monitoring this transfer and it's close
-      // to execution
-      if (!_timers.containsKey(transfer.id) && remainingTime <= _timeBuffer) {
-        _startMonitoringTransfer(transfer);
+      // If we're not already monitoring this transfer
+      if (!_timers.containsKey(transfer.id)) {
+        _scheduleExecutionPolling(transfer);
       }
     }
 
@@ -66,38 +77,31 @@ class ReversibleTransferMonitoringService {
     }
   }
 
-  void _startMonitoringTransfer(ReversibleTransferEvent transfer) {
-    print('Starting to monitor reversible transfer timer: ${transfer.id}');
-
-    // Create a timer that checks remaining time every second
-    final timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      _checkTransferTimer(transfer);
-    });
-
-    _timers[transfer.id] = timer;
-
-    // Check immediately in case it's already at zero
-    _checkTransferTimer(transfer);
-  }
-
-  void _checkTransferTimer(ReversibleTransferEvent transfer) {
+  void _scheduleExecutionPolling(ReversibleTransferEvent transfer) {
     final remainingTime = transfer.remainingTime;
 
-    // If timer hit zero and we're not already polling for execution
-    if (remainingTime <= Duration.zero &&
-        !_executionPollers.containsKey(transfer.id)) {
-      print(
-        'Reversible transfer timer hit zero: ${transfer.id} - '
-        'starting execution polling',
-      );
-      _startExecutionPolling(transfer);
+    print(
+      'Scheduling execution poll for ${transfer.id} '
+      'in $remainingTime',
+    );
 
-      // Stop the timer monitoring since we're now polling for execution
-      _stopTimerMonitoring(transfer.id);
+    if (remainingTime <= Duration.zero) {
+      // If time is already up, start polling immediately
+      _startExecutionPolling(transfer);
+    } else {
+      // Set a timer for when the remaining time is up
+      final timer = Timer(remainingTime, () {
+        _startExecutionPolling(transfer);
+        _timers.remove(transfer.id); // Timer has fired, remove it
+      });
+      _timers[transfer.id] = timer;
     }
   }
 
   void _startExecutionPolling(ReversibleTransferEvent transfer) {
+    if (_executionPollers.containsKey(transfer.id)) {
+      return; // Already polling
+    }
     print('Starting execution polling for: ${transfer.id}');
 
     // Create aggressive polling timer
@@ -182,11 +186,6 @@ class ReversibleTransferMonitoringService {
     return null;
   }
 
-  void _stopTimerMonitoring(String transferId) {
-    final timer = _timers.remove(transferId);
-    timer?.cancel();
-  }
-
   void _stopExecutionPolling(String transferId) {
     final poller = _executionPollers.remove(transferId);
     poller?.cancel();
@@ -194,7 +193,8 @@ class ReversibleTransferMonitoringService {
   }
 
   void _stopMonitoringTransfer(String transferId) {
-    _stopTimerMonitoring(transferId);
+    final timer = _timers.remove(transferId);
+    timer?.cancel();
     _stopExecutionPolling(transferId);
     print('Stopped monitoring transfer: $transferId');
   }
@@ -226,7 +226,7 @@ final reversibleTransferMonitoringServiceProvider =
       final service = ReversibleTransferMonitoringService(ref);
 
       // Clean up when provider is disposed
-      ref.onDispose(() => service.dispose());
+      ref.onDispose(service.dispose);
 
       return service;
     });

--- a/mobile-app/lib/services/transaction_tracking_service.dart
+++ b/mobile-app/lib/services/transaction_tracking_service.dart
@@ -101,9 +101,11 @@ class TransactionTrackingService {
         return;
       }
 
-      // If the block *is* indexed, but our transaction is not in it, mark as failed.
+      // If the block is indexed, but our transaction is not in it,
+      // mark as failed.
       if (response.transactions.isEmpty) {
         print(
+          // ignore: lines_longer_than_80_chars
           'Transaction ${pendingTx.id} not found in block $blockHash. Marking as failed.',
         );
         _ref

--- a/mobile-app/lib/services/transaction_tracking_service.dart
+++ b/mobile-app/lib/services/transaction_tracking_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
-import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/all_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/pending_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
@@ -79,23 +78,52 @@ class TransactionTrackingService {
     PendingTransactionEvent pendingTx,
   ) async {
     try {
-      // Get the accounts to search in
-      final accountsState = _ref.read(accountsProvider);
-      final accounts = accountsState.value;
-      if (accounts == null || accounts.isEmpty) return;
-
-      final accountIds = accounts.map((a) => a.accountId).toList();
-
-      // Fetch recent history to see if our transaction appears
       final historyService = _ref.read(chainHistoryServiceProvider);
-      final recentHistory = await historyService.fetchAllTransactionTypes(
-        accountIds: accountIds,
-        limit: 50, // Check more recent transactions
-        offset: 0,
+      final blockHash = pendingTx.blockHash;
+      if (blockHash == null) {
+        print(
+          'Error: blockHash is null for pending transaction ${pendingTx.id}',
+        );
+        return;
+      }
+
+      // Query for the block and transaction in one go
+      final response = await historyService.getTransactionsInBlock(
+        blockHash: blockHash,
+        from: pendingTx.from,
+        to: pendingTx.to,
+        isReversible: pendingTx.isReversible,
       );
 
-      // Check if our pending transaction appears in the history
-      final foundInHistory = _findMatchingTransaction(pendingTx, recentHistory);
+      // If block is not yet indexed, just wait for the next poll cycle.
+      if (!response.blockExists) {
+        print('Block $blockHash not indexed yet, waiting for next poll.');
+        return;
+      }
+
+      // If the block *is* indexed, but our transaction is not in it, mark as failed.
+      if (response.transactions.isEmpty) {
+        print(
+          'Transaction ${pendingTx.id} not found in block $blockHash. Marking as failed.',
+        );
+        _ref
+            .read(pendingTransactionsProvider.notifier)
+            .updateState(
+              pendingTx.id,
+              TransactionState.failed,
+              blockHash: pendingTx.blockHash,
+            );
+        Timer(const Duration(seconds: 2), () {
+          _ref.read(pendingTransactionsProvider.notifier).remove(pendingTx.id);
+        });
+        _stopTrackingTransaction(pendingTx.id);
+        return;
+      }
+
+      final foundInHistory = _findMatchingTransaction(
+        pendingTx,
+        response.transactions,
+      );
 
       if (foundInHistory != null) {
         print('Transaction found in history: ${pendingTx.id}');
@@ -135,16 +163,10 @@ class TransactionTrackingService {
   /// This matches by amount, from/to addresses, and proximity in time.
   TransactionEvent? _findMatchingTransaction(
     PendingTransactionEvent pendingTx,
-    SortedTransactionsList history,
+    List<TransactionEvent> history,
   ) {
-    // Combine all history transactions
-    final allHistoryTxs = [
-      ...history.otherTransfers,
-      ...history.reversibleTransfers,
-    ];
-
     // Look for transactions that match our pending transaction
-    for (final historyTx in allHistoryTxs) {
+    for (final historyTx in history) {
       if (_isMatchingTransaction(pendingTx, historyTx)) {
         return historyTx;
       }
@@ -158,7 +180,7 @@ class TransactionTrackingService {
     PendingTransactionEvent pendingTx,
     TransactionEvent historyTx,
   ) {
-    print('matching history for ${pendingTx.id}');
+    print('matching history for ${pendingTx.id} ${pendingTx.blockHash}');
     // Match by amount
     if (pendingTx.amount != historyTx.amount) return false;
 
@@ -168,6 +190,7 @@ class TransactionTrackingService {
     // Match by to address
     if (pendingTx.to != historyTx.to) return false;
 
+    print('checking block hash ${pendingTx.blockHash}');
     // If we have a block hash, try to match it
     if (pendingTx.blockHash != null && historyTx.blockHash != null) {
       if (pendingTx.blockHash == historyTx.blockHash) {

--- a/quantus_sdk/lib/quantus_sdk.dart
+++ b/quantus_sdk/lib/quantus_sdk.dart
@@ -5,6 +5,7 @@ import 'package:quantus_sdk/src/services/settings_service.dart';
 
 import 'src/rust/frb_generated.dart';
 
+export 'generated/resonance/pallets/balances.dart';
 export 'generated/resonance/types/quantus_runtime/runtime_call.dart';
 export 'src/constants/app_constants.dart';
 export 'src/extensions/color_extensions.dart';

--- a/quantus_sdk/lib/src/services/chain_history_service.dart
+++ b/quantus_sdk/lib/src/services/chain_history_service.dart
@@ -30,6 +30,13 @@ class TransferResult {
   });
 }
 
+class BlockQueryResponse {
+  final bool blockExists;
+  final List<TransactionEvent> transactions;
+
+  BlockQueryResponse({required this.blockExists, required this.transactions});
+}
+
 class ChainHistoryService {
   final String _graphQlEndpoint = AppConstants.graphQlEndpoint;
 
@@ -212,16 +219,96 @@ query EventsByAccounts($accounts: [String!]!, $limit: Int!, $offset: Int!) {
 }
 ''';
 
+  final String _reversibleTransactionsInBlockQuery = r'''
+query TransactionsAndBlockInBlock(
+  $blockHash: String!,
+  $from: String!,
+  $to: String!
+) {
+  blocks(where: { hash_eq: $blockHash }, limit: 1) {
+    id
+  }
+  events(
+    limit: 500
+    offset: 0
+    where: {
+      block: { hash_eq: $blockHash },
+      reversibleTransfer: {
+        from: { id_eq: $from },
+        to: { id_eq: $to }
+      }
+    }
+    orderBy: timestamp_DESC
+  ) {
+    id
+    reversibleTransfer {
+      id
+      amount
+      timestamp
+      from { id }
+      to { id }
+      txId
+      scheduledAt
+      status
+      block { height hash }
+      extrinsicHash
+      timestamp
+    }
+    extrinsicHash
+  }
+}
+''';
+
+  final String _transferInBlockQuery = r'''
+query TransactionsAndBlockInBlock(
+  $blockHash: String!,
+  $from: String!,
+  $to: String!
+) {
+  blocks(where: { hash_eq: $blockHash }, limit: 1) {
+    id
+  }
+  events(
+    limit: 500
+    offset: 0
+    where: {
+      block: { hash_eq: $blockHash },
+      transfer: {
+        from: { id_eq: $from },
+        to: { id_eq: $to }
+      }
+    }
+    orderBy: timestamp_DESC
+  ) {
+    id
+    transfer {
+      id
+      amount
+      timestamp
+      from { id }
+      to { id }
+      block { height hash }
+      extrinsicHash
+      timestamp
+      fee
+    }
+    extrinsicHash
+  }
+}
+''';
+
   Future<SortedTransactionsList> fetchAllTransactionTypes({
     required List<String> accountIds,
     int limit = 20,
     int offset = 0,
+    String? printName,
   }) async {
     final scheduled = await fetchScheduledTransfers(accountIds: accountIds);
     final other = await _fetchOtherTransfers(
       accountIds: accountIds,
       limit: limit,
       offset: offset,
+      printName: printName,
     );
 
     return SortedTransactionsList(
@@ -375,10 +462,12 @@ query EventsByAccounts($accounts: [String!]!, $limit: Int!, $offset: Int!) {
     required List<String> accountIds,
     int limit = 10,
     int offset = 0,
+    String? printName,
   }) async {
     final Uri uri = Uri.parse('$_graphQlEndpoint/graphql');
     print(
-      'fetchTransfers for account: $accountIds from $uri (limit: $limit, offset: $offset)',
+      '${printName ?? ''} '
+      ' fetchTransfers for account: $accountIds from $uri (limit: $limit, offset: $offset)',
     );
 
     // Construct the GraphQL request body
@@ -456,4 +545,85 @@ query EventsByAccounts($accounts: [String!]!, $limit: Int!, $offset: Int!) {
   }
 
   // Add other methods for fetching historical data as needed
+
+  Future<BlockQueryResponse> getTransactionsInBlock({
+    required String blockHash,
+    required String from,
+    required String to,
+    required bool isReversible,
+  }) async {
+    final Uri uri = Uri.parse('$_graphQlEndpoint/graphql');
+
+    print('Fetching transactions in block: $blockHash');
+
+    final Map<String, dynamic> requestBody = {
+      'query': isReversible
+          ? _reversibleTransactionsInBlockQuery
+          : _transferInBlockQuery,
+      'variables': {'blockHash': blockHash, 'from': from, 'to': to},
+    };
+
+    try {
+      final http.Response response = await http.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(requestBody),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception(
+          'GraphQL request failed with status: ${response.statusCode}. Body: ${response.body}',
+        );
+      }
+
+      final Map<String, dynamic> responseBody = jsonDecode(response.body);
+
+      if (responseBody['errors'] != null) {
+        print('GraphQL errors in response: ${responseBody['errors']}');
+        throw Exception('GraphQL errors: ${responseBody['errors'].toString()}');
+      }
+
+      final Map<String, dynamic>? data = responseBody['data'];
+      if (data == null) {
+        throw Exception('GraphQL response data is null.');
+      }
+
+      final List<dynamic>? blocks = data['blocks'];
+      final bool blockExists = blocks != null && blocks.isNotEmpty;
+
+      final List<dynamic>? events = data['events'];
+
+      if (events == null || events.isEmpty) {
+        return BlockQueryResponse(blockExists: blockExists, transactions: []);
+      }
+
+      final List<TransactionEvent> transactions = [];
+      for (var eventJson in events) {
+        final event = eventJson as Map<String, dynamic>;
+
+        if (event['transfer'] != null) {
+          final transferData = event['transfer'] as Map<String, dynamic>;
+          transferData['extrinsicHash'] ??= event['extrinsicHash'];
+          transactions.add(TransferEvent.fromJson(transferData));
+        } else if (event['reversibleTransfer'] != null) {
+          final reversibleTransferData =
+              event['reversibleTransfer'] as Map<String, dynamic>;
+          reversibleTransferData['extrinsicHash'] ??= event['extrinsicHash'];
+          transactions.add(
+            ReversibleTransferEvent.fromJson(reversibleTransferData),
+          );
+        }
+      }
+
+      print('Found ${transactions.length} transactions in block $blockHash');
+      return BlockQueryResponse(
+        blockExists: blockExists,
+        transactions: transactions,
+      );
+    } catch (e, stackTrace) {
+      print('Error fetching transactions by block hash: $e');
+      print(stackTrace);
+      rethrow;
+    }
+  }
 }

--- a/quantus_sdk/lib/src/services/number_formatting_service.dart
+++ b/quantus_sdk/lib/src/services/number_formatting_service.dart
@@ -18,6 +18,7 @@ class NumberFormattingService {
     BigInt balance, {
     int maxDecimals = 4,
     bool addThousandsSeparators = true,
+    bool addSymbol = false,
   }) {
     if (balance == BigInt.zero) {
       return '0';
@@ -52,6 +53,8 @@ class NumberFormattingService {
       }
     }
 
+    String resultString = asString;
+
     if (addThousandsSeparators) {
       // 5. Manually add thousand separators to the integer part.
       final parts = asString.split('.');
@@ -62,10 +65,13 @@ class NumberFormattingService {
         RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
         (Match m) => '${m[1]},',
       );
-      return formattedInteger + decimalPart;
-    } else {
-      return asString;
+      resultString = formattedInteger + decimalPart;
     }
+
+    if (addSymbol) {
+      resultString = '$resultString ${AppConstants.tokenSymbol}';
+    }
+    return resultString;
   }
 
   /// Parses a user-entered formatted string amount (e.g., "1.23" or "1,23"

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -172,6 +172,7 @@ class SubstrateService {
   Future<BigInt> queryUserBalance() async {
     final keyPair = await _getUserWallet();
     final balance = await queryBalance(keyPair.ss58Address);
+    print('user balance: $balance');
     return balance;
   }
 
@@ -184,6 +185,8 @@ class SubstrateService {
 
       // Retrieve Account Balance
       final accountInfo = await resonanceApi.query.system.account(accountID);
+
+      print('user balance $address: ${accountInfo.data.free}');
 
       // Get the free balance
       return accountInfo.data.free;


### PR DESCRIPTION
Fixed 2 bugs:
- Failed transactions would not be removed correctly from pending
- Reversible max was not working #158 

First fix: Now polling block hash for pending transactions - this way we know for sure whether or not the transaction was successful. If we find the block, we check if it's in there, if yes, it worked, if no, it failed.

Second fix: Reversible needs to subtract existential deposit from max send. Else it won't work. 

User feedback could be better since it's not actually a fee for existential deposit. We should pop something saying you can't send the entire balance reversible, only balance - existential fee. 

Also there is then 0.001 left in the account, not 0. 

But unless we change the runtime, that's how it works.

Could be that we can't freeze more assets also. Not sure where the existential deposit check happens. 