### PR TITLE
tapping active accounts also works now

### DIFF
--- a/mobile-app/lib/features/main/screens/accounts_screen.dart
+++ b/mobile-app/lib/features/main/screens/accounts_screen.dart
@@ -175,12 +175,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   Widget _buildAccountListItem(Account account, bool isActive, int index) {
     return InkWell(
       onTap: () async {
-        if (!isActive) {
-          await ref
-              .read(activeAccountProvider.notifier)
-              .setActiveAccount(account);
-          if (mounted) Navigator.pop(context);
-        }
+        await ref
+            .read(activeAccountProvider.notifier)
+            .setActiveAccount(account);
+        if (mounted) Navigator.pop(context);
       },
       child: Row(
         children: [


### PR DESCRIPTION
The problem was tapping active account didn't do anything - turns out there was a special case to not do anything on tapping active - that's not in the spec, also doesn't make sense. Fixed. 