### PR TITLE
Fix app validation iOS

### DIFF
--- a/mobile-app/ios/Runner/Info.plist
+++ b/mobile-app/ios/Runner/Info.plist
@@ -52,6 +52,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
App submission failed like so:

```
Validation failed (409)
Invalid bundle. The “UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown” orientations were provided for the UISupportedInterfaceOrientations Info.plist key in the com.quantus.mobile-wallet bundle, but you need to include all of the “UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight” orientations to support iPad multitasking. For details, visit: https://developer.apple.com/documentation/bundleresources/information_property_list/uisupportedinterfaceorientations. (ID: ef7d238d-02ce-4d82-b3bb-68d8a7bb1a7e)
```