### PR TITLE
fix: pending cancel not persisted and processed on each tx fetch

### DIFF
--- a/mobile-app/lib/features/components/transaction_action_sheet.dart
+++ b/mobile-app/lib/features/components/transaction_action_sheet.dart
@@ -13,6 +13,7 @@ import 'package:resonance_network_wallet/features/styles/app_text_theme.dart';
 import 'package:resonance_network_wallet/providers/account_id_list_cache.dart';
 import 'package:resonance_network_wallet/providers/all_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/filtered_all_transactions_provider.dart';
+import 'package:resonance_network_wallet/providers/pending_cancellations_provider.dart';
 import 'package:resonance_network_wallet/services/reversible_transfer_monitoring_service.dart';
 import 'package:resonance_network_wallet/shared/extensions/media_query_data_extension.dart';
 
@@ -506,6 +507,9 @@ class _TransactionActionSheetState
               extrinsicHash,
               ReversibleTransferStatus.CANCELLED,
             );
+        ref
+            .read(pendingCancellationsProvider.notifier)
+            .addPendingCancellation(widget.transaction.id);
 
         // Filtered controllers for involved accounts
         final affectedAccounts = <String>{

--- a/mobile-app/lib/features/components/transaction_list_item.dart
+++ b/mobile-app/lib/features/components/transaction_list_item.dart
@@ -131,7 +131,7 @@ class TransactionListItemState extends State<TransactionListItem> {
     String senderAddress = _formatAddress(widget.transaction.from);
     String receiverAddress = _formatAddress(widget.transaction.to);
     if (widget.showFromAndTo) {
-      return 'from $senderAddress to $receiverAddress';
+      return 'from $senderAddress \nto $receiverAddress';
     } else {
       return role == TransactionRole.sender
           ? 'to $receiverAddress'

--- a/mobile-app/lib/features/main/screens/transactions_screen.dart
+++ b/mobile-app/lib/features/main/screens/transactions_screen.dart
@@ -251,6 +251,7 @@ class _TransactionsScreenState extends ConsumerState<TransactionsScreen> {
       data: (combinedData) {
         final allTransactions =
             TransactionUtils.combineAndDeduplicateTransactions(
+              pendingCancellationIds: combinedData.pendingCancellationIds,
               pendingTransactions: combinedData.pendingTransactions,
               reversibleTransfers: combinedData.reversibleTransfers,
               otherTransfers: combinedData.otherTransfers,

--- a/mobile-app/lib/features/main/screens/wallet_main/history_section.dart
+++ b/mobile-app/lib/features/main/screens/wallet_main/history_section.dart
@@ -31,6 +31,7 @@ class _HistorySectionState extends ConsumerState<HistorySection> {
         // Combine and deduplicate all transaction types
         final allTransactions =
             TransactionUtils.combineAndDeduplicateTransactions(
+              pendingCancellationIds: combinedData.pendingCancellationIds,
               pendingTransactions: combinedData.pendingTransactions,
               reversibleTransfers: combinedData.reversibleTransfers,
               otherTransfers: combinedData.otherTransfers,

--- a/mobile-app/lib/models/combined_transactions_list.dart
+++ b/mobile-app/lib/models/combined_transactions_list.dart
@@ -1,22 +1,26 @@
 import 'package:quantus_sdk/quantus_sdk.dart';
 
 class CombinedTransactionsList {
+  final Set<String> pendingCancellationIds;
   final List<PendingTransactionEvent> pendingTransactions;
   final List<ReversibleTransferEvent> reversibleTransfers;
   final List<TransactionEvent> otherTransfers;
 
   CombinedTransactionsList({
+    required this.pendingCancellationIds,
     required this.pendingTransactions,
     required this.reversibleTransfers,
     required this.otherTransfers,
   });
 
   CombinedTransactionsList copyWith({
+    Set<String>? pendingCancellationIds,
     List<PendingTransactionEvent>? pendingTransactions,
     List<ReversibleTransferEvent>? reversibleTransfers,
     List<TransactionEvent>? otherTransfers,
   }) {
     return CombinedTransactionsList(
+      pendingCancellationIds: pendingCancellationIds ?? this.pendingCancellationIds,
       pendingTransactions: pendingTransactions ?? this.pendingTransactions,
       reversibleTransfers: reversibleTransfers ?? this.reversibleTransfers,
       otherTransfers: otherTransfers ?? this.otherTransfers,
@@ -24,6 +28,7 @@ class CombinedTransactionsList {
   }
 
   static CombinedTransactionsList get empty => CombinedTransactionsList(
+    pendingCancellationIds: <String>{},
     pendingTransactions: [],
     reversibleTransfers: [],
     otherTransfers: [],

--- a/mobile-app/lib/models/pending_cancellation.dart
+++ b/mobile-app/lib/models/pending_cancellation.dart
@@ -1,0 +1,27 @@
+class PendingCancellation {
+  final String transactionId;
+  final DateTime timestamp;
+
+  const PendingCancellation({
+    required this.transactionId,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'transactionId': transactionId,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+    };
+  }
+
+  factory PendingCancellation.fromJson(Map<String, dynamic> json) {
+    return PendingCancellation(
+      transactionId: json['transactionId'] as String,
+      timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] as int),
+    );
+  }
+
+  bool isExpired({required Duration expiration}) {
+    return DateTime.now().difference(timestamp) > expiration;
+  }
+}

--- a/mobile-app/lib/providers/active_account_transactions_provider.dart
+++ b/mobile-app/lib/providers/active_account_transactions_provider.dart
@@ -18,6 +18,7 @@ final activeAccountTransactionsProvider =
           if (activeAccount == null) {
             return AsyncValue.data(
               CombinedTransactionsList(
+                pendingCancellationIds: <String>{},
                 pendingTransactions: [],
                 reversibleTransfers: [],
                 otherTransfers: [],

--- a/mobile-app/lib/providers/all_transactions_provider.dart
+++ b/mobile-app/lib/providers/all_transactions_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/models/combined_transactions_list.dart';
 import 'package:resonance_network_wallet/models/pagination_state.dart';
 import 'package:resonance_network_wallet/providers/controllers/unified_pagination_controller.dart';
+import 'package:resonance_network_wallet/providers/pending_cancellations_provider.dart';
 import 'package:resonance_network_wallet/providers/pending_transactions_provider.dart';
 
 final paginationControllerProvider =
@@ -13,6 +14,7 @@ final paginationControllerProvider =
 final allTransactionsProvider = Provider<AsyncValue<CombinedTransactionsList>>((
   ref,
 ) {
+  final pendingCancellationIds = ref.watch(pendingCancellationsProvider);
   final pending = ref.watch(pendingTransactionsProvider);
   final pagination = ref.watch(paginationControllerProvider);
 
@@ -25,6 +27,7 @@ final allTransactionsProvider = Provider<AsyncValue<CombinedTransactionsList>>((
 
   return AsyncValue.data(
     CombinedTransactionsList(
+      pendingCancellationIds: pendingCancellationIds,
       pendingTransactions: pending,
       reversibleTransfers: pagination.reversibleTransfers,
       otherTransfers: pagination.items,

--- a/mobile-app/lib/providers/filtered_all_transactions_provider.dart
+++ b/mobile-app/lib/providers/filtered_all_transactions_provider.dart
@@ -3,6 +3,7 @@ import 'package:resonance_network_wallet/models/combined_transactions_list.dart'
 import 'package:resonance_network_wallet/models/pagination_state.dart';
 import 'package:resonance_network_wallet/providers/account_id_list_cache.dart';
 import 'package:resonance_network_wallet/providers/controllers/unified_pagination_controller.dart';
+import 'package:resonance_network_wallet/providers/pending_cancellations_provider.dart';
 import 'package:resonance_network_wallet/providers/pending_transactions_provider.dart';
 
 /// Family provider for filtered pagination controllers
@@ -23,6 +24,7 @@ final filteredTransactionsProviderFamily =
       ref,
       accountIds,
     ) {
+      final pendingCancellationIds = ref.watch(pendingCancellationsProvider);
       final pending = ref.watch(pendingTransactionsProvider);
       final pagination = ref.watch(
         filteredPaginationControllerProviderFamily(
@@ -47,6 +49,7 @@ final filteredTransactionsProviderFamily =
 
       return AsyncValue.data(
         CombinedTransactionsList(
+          pendingCancellationIds: pendingCancellationIds,
           pendingTransactions: filteredPending,
           reversibleTransfers: pagination.reversibleTransfers,
           otherTransfers: pagination.items,

--- a/mobile-app/lib/providers/pending_cancellations_provider.dart
+++ b/mobile-app/lib/providers/pending_cancellations_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final pendingCancellationsProvider = StateNotifierProvider<PendingCancellationsNotifier, Set<String>>((ref) {
+  return PendingCancellationsNotifier();
+});
+
+class PendingCancellationsNotifier extends StateNotifier<Set<String>> {
+  static const String _key = 'pending_cancellations';
+
+  PendingCancellationsNotifier() : super(<String>{}) {
+    _loadPendingCancellations();
+  }
+
+  Future<void> _loadPendingCancellations() async {
+    final prefs = await SharedPreferences.getInstance();
+    final pending = prefs.getStringList(_key) ?? [];
+    state = pending.toSet();
+  }
+
+  Future<void> addPendingCancellation(String transactionId) async {
+    state = {...state, transactionId};
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, state.toList());
+  }
+
+  Future<void> removePendingCancellation(String transactionId) async {
+    state = state.where((id) => id != transactionId).toSet();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, state.toList());
+  }
+
+  Set<String> getPendingCancellations() => state;
+}

--- a/mobile-app/lib/providers/pending_cancellations_provider.dart
+++ b/mobile-app/lib/providers/pending_cancellations_provider.dart
@@ -1,33 +1,129 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:resonance_network_wallet/models/pending_cancellation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final pendingCancellationsProvider = StateNotifierProvider<PendingCancellationsNotifier, Set<String>>((ref) {
-  return PendingCancellationsNotifier();
-});
+final pendingCancellationsProvider =
+    StateNotifierProvider<PendingCancellationsNotifier, Set<String>>((ref) {
+      return PendingCancellationsNotifier();
+    });
 
 class PendingCancellationsNotifier extends StateNotifier<Set<String>> {
   static const String _key = 'pending_cancellations';
+  static const Duration _expireDuration = Duration(minutes: 5);
+
 
   PendingCancellationsNotifier() : super(<String>{}) {
-    _loadPendingCancellations();
+    _loadAndCleanupPendingCancellations();
   }
 
-  Future<void> _loadPendingCancellations() async {
+  bool _isNotExpired(PendingCancellation cancellation) {
+    return !cancellation.isExpired(expiration: _expireDuration);
+  }
+
+  Future<void> _loadAndCleanupPendingCancellations() async {
     final prefs = await SharedPreferences.getInstance();
-    final pending = prefs.getStringList(_key) ?? [];
-    state = pending.toSet();
+    final jsonList = prefs.getStringList(_key) ?? [];
+
+    final validCancellations = <PendingCancellation>[];
+
+    // Parse and filter expired entries
+    for (final jsonString in jsonList) {
+      try {
+        final json = jsonDecode(jsonString) as Map<String, dynamic>;
+        final cancellation = PendingCancellation.fromJson(json);
+        final isNotExpired = _isNotExpired(cancellation);
+
+        if (isNotExpired) {
+          validCancellations.add(cancellation);
+        } else {
+          print(
+            'Removing expired pending cancellation: ${cancellation.transactionId}',
+          );
+        }
+      } catch (e) {
+        throw FormatException('Error parsing pending cancellation: $e');
+      }
+    }
+
+    await _savePendingCancellations(validCancellations);
+    state = validCancellations.map((c) => c.transactionId).toSet();
+  }
+
+  Future<void> _savePendingCancellations(
+    List<PendingCancellation> cancellations,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonList = cancellations.map((c) => jsonEncode(c.toJson())).toList();
+    await prefs.setStringList(_key, jsonList);
   }
 
   Future<void> addPendingCancellation(String transactionId) async {
-    state = {...state, transactionId};
+    // Don't add if already exists
+    if (state.contains(transactionId)) return;
+
+    final newCancellation = PendingCancellation(
+      transactionId: transactionId,
+      timestamp: DateTime.now(),
+    );
+
+    // Load existing cancellations
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_key, state.toList());
+    final jsonList = prefs.getStringList(_key) ?? [];
+
+    final existingCancellations = <PendingCancellation>[];
+    for (final jsonString in jsonList) {
+      try {
+        final json = jsonDecode(jsonString) as Map<String, dynamic>;
+        final cancellation = PendingCancellation.fromJson(json);
+        final isNotExpired = _isNotExpired(cancellation);
+
+        // Only keep non-expired and different transaction IDs
+        if (isNotExpired && cancellation.transactionId != transactionId) {
+          existingCancellations.add(cancellation);
+        }
+      } catch (e) {
+        print('Error parsing existing cancellation: $e');
+      }
+    }
+
+    // Add new cancellation
+    final allCancellations = [...existingCancellations, newCancellation];
+    await _savePendingCancellations(allCancellations);
+
+    // Update state
+    state = {...state, transactionId};
   }
 
   Future<void> removePendingCancellation(String transactionId) async {
-    state = state.where((id) => id != transactionId).toSet();
+    if (!state.contains(transactionId)) return;
+
+    // Load and filter existing cancellations
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_key, state.toList());
+    final jsonList = prefs.getStringList(_key) ?? [];
+
+    final remainingCancellations = <PendingCancellation>[];
+    for (final jsonString in jsonList) {
+      try {
+        final json = jsonDecode(jsonString) as Map<String, dynamic>;
+        final cancellation = PendingCancellation.fromJson(json);
+        final isNotExpired = _isNotExpired(cancellation);
+
+        // Keep only non-expired and different transaction IDs
+        if (isNotExpired && cancellation.transactionId != transactionId) {
+          remainingCancellations.add(cancellation);
+        }
+      } catch (e) {
+        print('Error parsing cancellation during removal: $e');
+      }
+    }
+
+    await _savePendingCancellations(remainingCancellations);
+
+    // Update state
+    state = state.where((id) => id != transactionId).toSet();
   }
 
   Set<String> getPendingCancellations() => state;

--- a/mobile-app/lib/services/pending_transaction_reconciliation_service.dart
+++ b/mobile-app/lib/services/pending_transaction_reconciliation_service.dart
@@ -50,6 +50,7 @@ class PendingTransactionReconciliationService {
 
       final confirmedTransactions = allTransactionsAsync.when(
         data: (transactions) => TransactionUtils.combineAndDeduplicateTransactions(
+          pendingCancellationIds: transactions.pendingCancellationIds,
           pendingTransactions:
               [], // Don't include pending here as we're comparing against them
           reversibleTransfers: transactions.reversibleTransfers,

--- a/mobile-app/lib/services/reversible_transfer_monitoring_service.dart
+++ b/mobile-app/lib/services/reversible_transfer_monitoring_service.dart
@@ -8,6 +8,7 @@ import 'package:resonance_network_wallet/providers/account_id_list_cache.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/all_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/filtered_all_transactions_provider.dart';
+import 'package:resonance_network_wallet/providers/pending_cancellations_provider.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 
 /// Service that monitors reversible transfers approaching execution time
@@ -162,6 +163,9 @@ class ReversibleTransferMonitoringService {
               transfer.extrinsicHash!,
               status,
             );
+        _ref
+            .read(pendingCancellationsProvider.notifier)
+            .removePendingCancellation(transfer.id);
 
         // Also update filtered controllers for affected accounts so
         // active-account views reflect the change immediately

--- a/mobile-app/lib/utils/transaction_utils.dart
+++ b/mobile-app/lib/utils/transaction_utils.dart
@@ -6,6 +6,7 @@ class TransactionUtils {
   /// Priority order: pending -> reversible -> other
   /// Duplicates are removed based on transaction ID
   static List<TransactionEvent> combineAndDeduplicateTransactions({
+    required Set<String> pendingCancellationIds,
     required List<PendingTransactionEvent> pendingTransactions,
     required List<ReversibleTransferEvent> reversibleTransfers,
     required List<TransactionEvent> otherTransfers,
@@ -16,7 +17,14 @@ class TransactionUtils {
     // Add pending transactions first (highest priority)
     for (final transaction in pendingTransactions) {
       if (seenIds.add(transaction.id)) {
-        result.add(transaction);
+        if (transaction.isReversible &&
+            pendingCancellationIds.contains(transaction.id)) {
+          result.add(
+            transaction.copyWith(status: ReversibleTransferStatus.CANCELLED),
+          );
+        } else {
+          result.add(transaction);
+        }
       }
     }
 
@@ -24,7 +32,13 @@ class TransactionUtils {
     for (final transaction in reversibleTransfers) {
       if (transaction.status == ReversibleTransferStatus.SCHEDULED) {
         if (seenIds.add(transaction.id)) {
-          result.add(transaction);
+          if (pendingCancellationIds.contains(transaction.id)) {
+            result.add(
+              transaction.copyWith(status: ReversibleTransferStatus.CANCELLED),
+            );
+          } else {
+            result.add(transaction);
+          }
         }
       }
     }

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -109,6 +109,34 @@ class ReversibleTransferEvent extends TransactionEvent {
     );
   }
 
+   ReversibleTransferEvent copyWith({
+    String? id,
+    String? from,
+    String? to,
+    BigInt? amount,
+    DateTime? timestamp,
+    String? txId,
+    ReversibleTransferStatus? status,
+    DateTime? scheduledAt,
+    String? extrinsicHash,
+    int? blockNumber,
+    String? blockHash,
+  }) {
+    return ReversibleTransferEvent(
+      id: id ?? this.id,
+      from: from ?? this.from,
+      to: to ?? this.to,
+      amount: amount ?? this.amount,
+      timestamp: timestamp ?? this.timestamp,
+      txId: txId ?? this.txId,
+      status: status ?? this.status,
+      scheduledAt: scheduledAt ?? this.scheduledAt,
+      extrinsicHash: extrinsicHash ?? this.extrinsicHash,
+      blockNumber: blockNumber ?? this.blockNumber,
+      blockHash: blockHash ?? this.blockHash,
+    );
+  }
+
   // guaranteed to be positive or zero
   Duration get remainingTime => scheduledAt.difference(DateTime.now()).positive;
 


### PR DESCRIPTION
[fixed issue](https://github.com/Quantus-Network/quantus-apps/issues/196)

Notable change on this fix is that I added new provider for processing pending cancellation. We will persist it on user preference so we can get the list of pending cancellation even if user close the app.