### PR TITLE
fix 16KB alignment on Android

### DIFF
--- a/quantus_sdk/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
+++ b/quantus_sdk/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
@@ -190,6 +190,7 @@ class AndroidEnvironment {
       rustFlags = '$rustFlags\x1f';
     }
     rustFlags = '$rustFlags-L\x1f$workaroundDir';
+    rustFlags = '$rustFlags\x1f-C\x1flink-arg=-Wl,-z,max-page-size=16384';
     return rustFlags;
   }
 }


### PR DESCRIPTION
# Error addressed - Play store warning message

<img width="1422" height="704" alt="Untitled 2" src="https://github.com/user-attachments/assets/0e1ef1c4-79a0-479e-9a58-b0b40ded885e" />

# What it means

This only concerns native libraries. We use the flutter rust bridge which generates native libraries from Rust code. 

The fix is also in Rust, setting page size to 16KB

This is required by Android because it's more efficient, faster, uses less battery and CPU to have bigger page sizes, even though it increases memory use by a little bit. 

# Alignment check

https://developer.android.com/guide/practices/page-sizes

**Generated APK after fix: All native libs are 16KB**

<img width="1356" height="685" alt="image" src="https://github.com/user-attachments/assets/0581c65e-a826-403c-ada5-4e0052c64f06" />
