### PR TITLE
loop last video

### DIFF
--- a/mobile-app/lib/features/components/quests_promo_video.dart
+++ b/mobile-app/lib/features/components/quests_promo_video.dart
@@ -83,8 +83,13 @@ class _QuestsPromoVideoState extends State<QuestsPromoVideo> {
     try {
       await _controller.initialize();
       setState(() {});
+      
+      // Set looping only for the final video
+      final isFinalVideo = index == _storyVideos.length - 1;
+      _controller.setLooping(isFinalVideo);
+      
       _controller.play();
-      widget.setIsFinalVideo(_currentStoryIndex == _storyVideos.length - 1);
+      widget.setIsFinalVideo(isFinalVideo);
 
       // Listen for video completion
       _controller.addListener(_videoListener);
@@ -96,8 +101,8 @@ class _QuestsPromoVideoState extends State<QuestsPromoVideo> {
   void _videoListener() {
     if (_controller.value.position >= _controller.value.duration) {
       if (_currentStoryIndex == _storyVideos.length - 1) {
-        _controller.seekTo(Duration.zero);
-        _controller.play();
+        // Use setLooping for infinite loop
+        _controller.setLooping(true);
       } else {
         _nextStory();
       }


### PR DESCRIPTION
loop reliably on last video

Fixes this issue:

I noticed when leaving the last video looping for a while, the loop would eventually stop after a few minutes and be a black screen and the progress bar on top would glitch. 
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 13 00 38" src="https://github.com/user-attachments/assets/8b2a863d-e186-4289-8fa0-c1b7c327104c" />
