### PR TITLE
Add periodic timer

### DIFF
--- a/quantus_sdk/lib/src/services/network/redundant_endpoint.dart
+++ b/quantus_sdk/lib/src/services/network/redundant_endpoint.dart
@@ -33,10 +33,8 @@ class GraphQlEndpointService extends RedundantEndpointService {
         .post(Uri.parse(endpoint.url), headers: {'Content-Type': 'application/json'}, body: queryBody)
         .timeout(const Duration(seconds: 5));
 
-    print('GraphQL healthCheckImpl: ${response.statusCode}');
     if (response.statusCode == 200) {
       final jsonResponse = jsonDecode(response.body);
-      print('GraphQL healthCheckImpl: $jsonResponse');
       if (jsonResponse.containsKey('data')) {
         return true;
       }
@@ -62,7 +60,7 @@ class RpcEndpointService extends RedundantEndpointService {
   Future<bool> healthCheckImpl(Endpoint endpoint) async {
     final provider = Provider.fromUri(Uri.parse(endpoint.url));
     final result = await provider.send('system_health', []).timeout(const Duration(seconds: 7));
-    print('RPC healthCheckImpl: $result');
+    // print('RPC healthCheckImpl: $result');
     return result.error == null;
   }
 }
@@ -157,7 +155,6 @@ abstract class RedundantEndpointService {
   }
 
   Future<void> healthCheck() async {
-    print('healthCheck!');
     // note this has different semantics from executeTask - it's more lenient and does not penalize 
     // endpoints that are failing.
     for (final endpoint in endpoints) {


### PR DESCRIPTION
I am actually not sure we need this - the system works fine without it! 

The algorithm without this is: Hit any endpoint. If it doesn't work, mark the endpoint latency as 1 year. If it does work, set latency. If there's an error use the next endpoint. Sort endpoints by latency. 

This happens on every request, so even if all endpoints are marked bad, it will recover as long as any of them is reachable on the next request. 
