### PR TITLE
Add support for Windows

### DIFF
--- a/miner-app/lib/src/services/binary_manager.dart
+++ b/miner-app/lib/src/services/binary_manager.dart
@@ -32,12 +32,12 @@ class BinaryManager {
 
   static Future<String> getNodeBinaryFilePath() async {
     final cacheDir = await _getCacheDir();
-    return p.join(cacheDir.path, _binary);
+    return p.join(cacheDir.path, _normalizeFilename(_binary));
   }
 
   static Future<String> getExternalMinerBinaryFilePath() async {
     final cacheDir = await _getCacheDir();
-    return p.join(cacheDir.path, _minerBinary);
+    return p.join(cacheDir.path, _normalizeFilename(_minerBinary));
   }
 
   static Future<bool> hasBinary() async {
@@ -76,7 +76,8 @@ class BinaryManager {
 
     // 3. pick asset name like the shell script
     final target = _targetTriple();
-    final asset = '$_binary-$tag-$target.tar.gz';
+    final extension = Platform.isWindows ? "zip" : "tar.gz";
+    final asset = '$_binary-$tag-$target.$extension';
     final url =
         'https://github.com/$_repoOwner/$_repoName/releases/download/$tag/$asset';
 
@@ -364,6 +365,8 @@ class BinaryManager {
     }
   }
 
+  static String _normalizeFilename(String file) => Platform.isWindows ? "$file.exe" : file;
+
   /* helpers */
   static Future<Directory> _getCacheDir() async => Directory(
     p.join(await getQuantusHomeDirectoryPath(), 'bin'),
@@ -373,7 +376,9 @@ class BinaryManager {
       Platform.environment['HOME'] ?? Platform.environment['USERPROFILE']!;
 
   static String _targetTriple() {
-    final os = Platform.isMacOS ? 'apple-darwin' : 'unknown-linux-gnu';
+    final os = Platform.isMacOS ? 'apple-darwin' : (
+      Platform.isWindows ? 'pc-windows-msvc' : 'unknown-linux-gnu'
+    );
     final arch =
         Platform.version.contains('arm64') ||
             Platform.version.contains('aarch64')

--- a/quantus_sdk/rust_builder/windows/CMakeLists.txt
+++ b/quantus_sdk/rust_builder/windows/CMakeLists.txt
@@ -9,7 +9,7 @@ set(PROJECT_NAME "rust_lib_resonance_network_wallet")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 include("../cargokit/cmake/cargokit.cmake")
-apply_cargokit(${PROJECT_NAME} ../../../../../../rust rust_lib_resonance_network_wallet "")
+apply_cargokit(${PROJECT_NAME} ../../../../../../../quantus_sdk/rust rust_lib_resonance_network_wallet "")
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an


### PR DESCRIPTION
I am addressing two issues here.

- The 1st one: for some reason, I was unable to build the `miner-app` repo because of some path error that I have addressed in the `CMakeLists.txt` file. I am not satisfied with my patch, so if you have a better solution, I am all ears.
- The 2nd one is that the app downloaded the node binary for Linux, as Windows wasn’t supported yet.

Of course, I haven’t tested whether my modifications made some regressions for Linux/Mac users.

Consider providing me with pointers on how to contribute efficiently to this repo.

Thank you for the time you will put into reviewing my work.