### PR TITLE
new endpoints

### DIFF
--- a/quantus_sdk/lib/src/constants/app_constants.dart
+++ b/quantus_sdk/lib/src/constants/app_constants.dart
@@ -8,8 +8,13 @@ class AppConstants {
   // static const List<String> rpcEndpoints = ['ws://127.0.0.1:9944']; // local testing
   // static const List<String> graphQlEndpoints = ['http://127.0.0.1:4350']; // local testing
 
-  static const List<String> rpcEndpoints = ['https://matcha-latte.quantus.com', 'https://quantu.se'];
+  // old schrodinger testnet
+  // static const List<String> rpcEndpoints = ['https://matcha-latte.quantus.com', 'https://quantu.se'];
   static const List<String> graphQlEndpoints = ['https://subsquid.quantus.com/graphql', 'https://quantu.se/graphql'];
+
+  // new dirac testnet
+  static const List<String> rpcEndpoints = ['https://a1-heisenberg.quantus.cat', 'https://a2-heisenberg.quantus.cat'];
+  // TODO: Update gql node
 
   // local test android use special ip
   // static const String taskMasterEndpoint = 'http://10.0.2.2:3000/api';


### PR DESCRIPTION
new dirac endpoints - this version will run on the Dirac Testnet

TODO: Still needs graphQL endpoints