### PR TITLE
Share button fix

### DIFF
--- a/mobile-app/lib/features/main/screens/quests_screen.dart
+++ b/mobile-app/lib/features/main/screens/quests_screen.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/features/components/basic_card.dart';
 import 'package:resonance_network_wallet/features/components/button.dart';
-import 'package:resonance_network_wallet/features/components/loading_text_animation.dart';
 import 'package:resonance_network_wallet/features/components/quests_promo_video.dart';
 import 'package:resonance_network_wallet/features/components/scaffold_base.dart';
+import 'package:resonance_network_wallet/features/components/loading_text_animation.dart';
 import 'package:resonance_network_wallet/features/components/skeleton.dart';
 import 'package:resonance_network_wallet/features/components/sphere.dart';
 import 'package:resonance_network_wallet/features/main/screens/navbar.dart';
@@ -29,7 +29,6 @@ class QuestsScreen extends ConsumerStatefulWidget {
 class _QuestsScreenState extends ConsumerState<QuestsScreen> with WidgetsBindingObserver {
   final ReferralService _referralService = ReferralService();
   final ScrollController _scrollController = ScrollController();
-  final GlobalKey _shareButtonKey = GlobalKey();
 
   String? _referralCode;
   bool _isRewardProgramParticipant = false;
@@ -69,27 +68,7 @@ class _QuestsScreenState extends ConsumerState<QuestsScreen> with WidgetsBinding
 
   Future<void> _shareReferralLink() async {
     final params = await _referralService.getShareLinkParameters();
-
-    return Future<void>.microtask(() async {
-      await Future.delayed(const Duration(milliseconds: 100));
-      
-      final RenderBox? renderBox = _shareButtonKey.currentContext?.findRenderObject() as RenderBox?;
-      if (renderBox != null && renderBox.hasSize) {
-        final position = renderBox.localToGlobal(Offset.zero);
-        final size = renderBox.size;
-        if (size.width > 0 && size.height > 0 && position.dx >= 0 && position.dy >= 0) {
-          final shareParams = ShareParams(
-            text: params.text,
-            subject: params.subject,
-            title: params.title,
-            sharePositionOrigin: Rect.fromLTWH(position.dx, position.dy, size.width, size.height),
-          );
-          await SharePlus.instance.share(shareParams);
-          return;
-        }
-      }
-      await SharePlus.instance.share(params);
-    });
+    SharePlus.instance.share(params);
   }
 
   void _copyReferralCode() {
@@ -305,7 +284,6 @@ class _QuestsScreenState extends ConsumerState<QuestsScreen> with WidgetsBinding
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 24),
                       child: Button(
-                        key: _shareButtonKey,
                         variant: ButtonVariant.glassOutline,
                         label: 'Share Referral Link',
                         onPressed: _shareReferralLink,


### PR DESCRIPTION
Fix this error ios 26

Quests page Share referral link:

```
flutter: UnifiedPaginationController: Fetching page for accounts: [qzmNaLjPU7hcvkjHpGmrVDPD9y12vdAFimCSrP1GkhVFJMaUq, qzn5St24cMsjE4JKYdXLBctusWj5zom67dnrW22SweAahLGeG], offset: 0
flutter:   fetchTransfers for account: [qzmNaLjPU7hcvkjHpGmrVDPD9y12vdAFimCSrP1GkhVFJMaUq, qzn5St24cMsjE4JKYdXLBctusWj5zom67dnrW22SweAahLGeG] (limit: 20, offset: 0)
flutter: UnifiedPaginationController: Fetched 4 transactions, 0 reversible
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: PlatformException(error, sharePositionOrigin: argument must be set, {{0, 0}, {0, 0}} must be non-zero and within coordinate space of source view: {{0, 0}, {402, 874}}, null, null)
#0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:653:7)
message_codecs.dart:653
#1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:367:18)
platform_channel.dart:367
<asynchronous suspension>
#2      MethodChannelShare.share (package:share_plus_platform_interface/method_channel/method_channel_share.dart:25:20)
method_channel_share.dart:25
<asynchronous suspension>
```

And the same in settings, invite and share.

Turns out just updating share plus fixes it.