### PR TITLE
Oauth: change to in app browser

### DIFF
--- a/mobile-app/lib/features/main/screens/account_associations_screen.dart
+++ b/mobile-app/lib/features/main/screens/account_associations_screen.dart
@@ -26,7 +26,7 @@ class AccountAssociationsScreen extends ConsumerStatefulWidget {
   ConsumerState<AccountAssociationsScreen> createState() => _AccountAssociationsScreenState();
 }
 
-class _AccountAssociationsScreenState extends ConsumerState<AccountAssociationsScreen> {
+class _AccountAssociationsScreenState extends ConsumerState<AccountAssociationsScreen> with WidgetsBindingObserver {
   final TaskmasterService _taskmasterService = TaskmasterService();
 
   final _ethAddress = TextEditingController();
@@ -92,7 +92,7 @@ class _AccountAssociationsScreenState extends ConsumerState<AccountAssociationsS
       final oauthRequest = await _taskmasterService.generateAssociateXLink();
       final Uri url = Uri.parse(oauthRequest.url);
 
-      launchUrl(url, mode: LaunchMode.externalApplication);
+      launchUrl(url, mode: LaunchMode.inAppBrowserView);
     } catch (e) {
       print('Failed associating X account: $e');
 
@@ -109,6 +109,33 @@ class _AccountAssociationsScreenState extends ConsumerState<AccountAssociationsS
   Future<void> _removeXAccount() async {
     await _taskmasterService.dissociateXAccount();
     ref.invalidate(accountAssociationsProvider);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.detached:
+        break;
+
+      case AppLifecycleState.resumed:
+        ref.invalidate(accountAssociationsProvider);
+        break;
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
Closed previous PR #335 because of wanting to make it more secure by using domain association. After trying many ways and fighting with other package. I come up with a nice fallback instead by using existing package that we use `url_launcher`. The good news, it works for android even the deep linking wohooo!! The bad news it still fail for the ios but I have a nice website page fallback which I think good enough still. So, to make sure we get the data change I also listen to state change in the associations screen.

## Screenshots
- Oauth in app browser view
<img width="1170" height="2532" alt="IMG_1318" src="https://github.com/user-attachments/assets/23e22980-f487-49fa-9017-d62311ab130f" />

- Oauth deep link fallback
<img width="1170" height="2532" alt="IMG_1319" src="https://github.com/user-attachments/assets/d4905700-31e4-42e8-9328-f48819b15287" />

- X associated
<img width="1170" height="2532" alt="IMG_1320" src="https://github.com/user-attachments/assets/1c604eb7-4a94-44e9-a1c1-60e39261a850" />


