### PR TITLE
Fix auth timer

### DIFF
--- a/mobile-app/lib/app_lifecycle_manager.dart
+++ b/mobile-app/lib/app_lifecycle_manager.dart
@@ -19,10 +19,18 @@ class AppLifecycleManager extends ConsumerStatefulWidget {
 }
 
 class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager> with WidgetsBindingObserver {
+  // Track if we have already performed background/pause actions to avoid duplicates
+  // as the OS can cycle through multiple states (inactive -> hidden -> paused)
+  bool _isBackgrounded = false;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+
+    // Initialize background state
+    final currentState = WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.resumed;
+    _isBackgrounded = currentState != AppLifecycleState.resumed;
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final localAuthNotifier = ref.read(localAuthProvider.notifier);
@@ -69,26 +77,16 @@ class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager> with 
   void didChangeAppLifecycleState(AppLifecycleState state) {
     ref.read(appLifecycleStateProvider.notifier).state = state;
     final localAuthNotifier = ref.read(localAuthProvider.notifier);
-    final isAuthenticated = ref.read(localAuthProvider).isAuthenticated;
-
     final pollingManager = ref.read(historyPollingManagerProvider);
     final isOnline = ref.read(isOnlineProvider);
 
-    switch (state) {
-      case AppLifecycleState.paused:
-      case AppLifecycleState.inactive:
-      case AppLifecycleState.hidden:
-        // Pause global polling when app goes to background
-        // Transaction tracking continues for pending transactions
-        pollingManager.pausePolling();
+    if (state == AppLifecycleState.resumed) {
+      // Only resume if we were previously backgrounded
+      if (_isBackgrounded) {
+        print('AppLifecycleState.resumed - resuming from background');
+        _isBackgrounded = false;
 
-        // When the app goes into the background, lock it.
-        localAuthNotifier.lockApp();
-        break;
-
-      case AppLifecycleState.resumed:
-        print('AppLifecycleState.resumed');
-        // Only resume if online
+        // Only resume polling if online
         if (isOnline) {
           pollingManager.resumePolling();
           pollingManager.triggerSilentRefresh();
@@ -96,20 +94,28 @@ class _AppLifecycleManagerState extends ConsumerState<AppLifecycleManager> with 
           print('App resumed but offline - polling paused');
         }
 
-        // If the app is resumed and we are not authenticated,
-        // trigger a new auth check.
-        if (!isAuthenticated) {
-          localAuthNotifier.checkAuthentication();
-        }
+        // Always check authentication on resume to enforce inactivity timeout
+        localAuthNotifier.checkAuthentication();
 
         // Initialize Taskmaster login if wallet exists
         _initializeTaskmasterLogin();
-        break;
+      }
+    } else {
+      // Handle background states (inactive, paused, hidden, detached)
+      // Only act if we haven't already processed a background transition
+      if (!_isBackgrounded) {
+        print('AppLifecycleState.$state - pausing and locking');
+        _isBackgrounded = true;
 
-      case AppLifecycleState.detached:
+        // Pause global polling when app goes to background
+        // Transaction tracking continues for pending transactions
+        pollingManager.pausePolling();
+
         // When the app goes into the background, lock it.
         localAuthNotifier.lockApp();
-        break;
+      } else {
+        print('AppLifecycleState.$state - already backgrounded, skipping actions');
+      }
     }
   }
 

--- a/mobile-app/lib/providers/local_auth_provider.dart
+++ b/mobile-app/lib/providers/local_auth_provider.dart
@@ -42,6 +42,7 @@ class LocalAuthController extends StateNotifier<LocalAuthState> {
   /// If auth is not required, it sets the state to authenticated.
   void checkAuthentication() {
     if (_localAuthService.shouldRequireAuthentication()) {
+      state = state.copyWith(isAuthenticated: false);
       authenticate();
     } else {
       // If user has biometrics disabled, just let them in.
@@ -50,8 +51,8 @@ class LocalAuthController extends StateNotifier<LocalAuthState> {
   }
 
   void lockApp() {
-    if (_localAuthService.shouldRequireAuthentication()) {
-      state = state.copyWith(isAuthenticated: false);
-    }
+    print('lockApp CALLED HERE');
+    _localAuthService.updateLastPausedTime();
+    state = state.copyWith(isAuthenticated: false);
   }
 }

--- a/mobile-app/lib/services/local_auth_service.dart
+++ b/mobile-app/lib/services/local_auth_service.dart
@@ -95,8 +95,7 @@ class LocalAuthService {
       );
 
       if (didAuthenticate) {
-        // Update last successful auth time
-        _settingsService.setLastSuccessfulAuthTime(DateTime.now());
+        _cleanLastPausedTime();
       }
 
       return didAuthenticate;
@@ -174,25 +173,32 @@ class LocalAuthService {
       final bool isEnabled = isLocalAuthEnabled();
       if (!isEnabled) return false;
 
-      final DateTime? lastAuthTime = _settingsService.getLastSuccessfulAuthTime();
+      final DateTime? lastPausedTime = _settingsService.getLastPausedTime();
 
-      if (lastAuthTime == null) return true;
+      if (lastPausedTime == null) return false;
 
       final int timeoutDurationInMinutes = getAuthTimeoutMinutes();
 
       final Duration authTimeout = Duration(minutes: timeoutDurationInMinutes);
 
-      print(
-        // ignore: lines_longer_than_80_chars
-        'auth time difference: ${DateTime.now().difference(lastAuthTime).inSeconds}',
-      );
+      print('lastPausedTime: $lastPausedTime');
+      print('now: ${DateTime.now()}');
+      print('auth time difference: ${DateTime.now().difference(lastPausedTime).inSeconds}');
 
-      final isTimeout = DateTime.now().difference(lastAuthTime) > authTimeout;
+      final isTimeout = DateTime.now().difference(lastPausedTime) > authTimeout;
       return isTimeout;
     } catch (e) {
       debugPrint('Error checking if authentication is required: $e');
       return true; // Err on the side of caution
     }
+  }
+
+  void updateLastPausedTime() {
+    _settingsService.setLastPausedTime(DateTime.now());
+  }
+
+  void _cleanLastPausedTime() {
+    _settingsService.cleanLastPausedTime();
   }
 
   /// Stop local authentication (useful for cleanup)

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -24,6 +24,7 @@ class SettingsService {
   // Local authentication keys
   static const String _isLocalAuthEnabledKey = 'is_local_auth_enabled';
   static const String _lastSuccessfulAuthKey = 'last_successful_auth';
+  static const String _lastPausedTimeKey = 'last_paused_time';
   static const String _authTimeoutKey = 'auth_timeout';
 
   // referral status
@@ -223,6 +224,22 @@ class SettingsService {
 
   void setLastSuccessfulAuthTime(DateTime time) {
     _prefs.setString(_lastSuccessfulAuthKey, time.toIso8601String());
+  }
+
+  DateTime? getLastPausedTime() {
+    final String? lastPausedString = _prefs.getString(_lastPausedTimeKey);
+    if (lastPausedString == null) return null;
+
+    final DateTime lastPaused = DateTime.parse(lastPausedString);
+    return lastPaused;
+  }
+
+  void setLastPausedTime(DateTime time) {
+    _prefs.setString(_lastPausedTimeKey, time.toIso8601String());
+  }
+
+  void cleanLastPausedTime() {
+    _prefs.remove(_lastPausedTimeKey);
   }
 
   /// Do not call this directly - call local auth service getAuthTimeoutMinutes() instead.


### PR DESCRIPTION
## Related Issue
#343 

## Key Changes

**1. Authentication Logic Shift (`LocalAuthService`)**
-   **Old Behavior:** Checked if the time since the *last successful authentication* exceeded the timeout.
-   **New Behavior:** Checks if the time since the *app was paused (backgrounded)* exceeds the timeout.
-   **Implementation:**
    -   Added `updateLastPausedTime()` (called when app locks) and `_cleanLastPausedTime()` (called after successful auth).
    -   `shouldRequireAuthentication()` now calculates the difference between `DateTime.now()` and `getLastPausedTime()`. If `lastPausedTime` is null, it assumes no auth is needed (e.g., fresh start or already authenticated session).

**2. Lifecycle State Management (`AppLifecycleManager`)**
-   Added `_isBackgrounded` boolean to debounce lifecycle state changes. This prevents duplicate actions when the OS transitions through multiple background states (e.g., `inactive` -> `hidden` -> `paused`).
-   **On Background:** Now explicitly calls `localAuthNotifier.lockApp()` which triggers the timestamp update.
-   **On Resume:** Calls `localAuthNotifier.checkAuthentication()` which evaluates the new time-difference logic.

**3. State Provider Updates (`LocalAuthProvider`)**
-   `lockApp()`: Now records the pause time via `_localAuthService.updateLastPausedTime()` and sets `isAuthenticated` to `false`.
-   `checkAuthentication()`: explicitly sets `isAuthenticated` to `false` before prompting for biometrics, likely to ensure the UI reflects the locked state immediately.

**4. Storage (`SettingsService`)**
-   Added persistence for `last_paused_time` in `SharedPreferences` to survive app restarts if the OS kills the app while in background.

## Summary
This change fixes the issue where users might have been prompted to re-authenticate prematurely based on when they *started* their session, rather than how long they were away. It implements a true "inactivity/background timeout."