### PR TITLE
Remove stale failed tx

### DIFF
--- a/mobile-app/lib/services/transaction_submission_service.dart
+++ b/mobile-app/lib/services/transaction_submission_service.dart
@@ -177,6 +177,7 @@ class TransactionSubmissionService {
               TransactionState.failed,
               error: 'Failed to submit after $maxRetries attempts: $e',
             );
+        _ref.read(pendingTransactionsProvider.notifier).remove(pendingTx.id);
       }
     }
   }


### PR DESCRIPTION
## Related Issue
#345 

## Summary
Previously the failed tx is not removed in pending tx but now we immediately remove it but we will still get failed tx notification so user can check the details