### PR TITLE
check for missing mnemonic

### DIFF
--- a/mobile-app/flutter_launcher_icons.yaml
+++ b/mobile-app/flutter_launcher_icons.yaml
@@ -3,7 +3,7 @@ flutter_launcher_icons:
   image_path: "assets/icon/icon.png"
 
   android: "launcher_icon"
-  image_path_android: "assets/quantus_icon_1024.png"
+  image_path_android: "assets/./"
   min_sdk_android: 21 # android min sdk min:16, default 21
   adaptive_icon_background: "#000000"
   adaptive_icon_foreground: "assets/quantus_icon_512.png"

--- a/mobile-app/flutter_launcher_icons.yaml
+++ b/mobile-app/flutter_launcher_icons.yaml
@@ -3,7 +3,7 @@ flutter_launcher_icons:
   image_path: "assets/icon/icon.png"
 
   android: "launcher_icon"
-  image_path_android: "assets/./"
+  image_path_android: "assets/quantus_icon_1024.png"
   min_sdk_android: 21 # android min sdk min:16, default 21
   adaptive_icon_background: "#000000"
   adaptive_icon_foreground: "assets/quantus_icon_512.png"

--- a/mobile-app/lib/services/logout_service.dart
+++ b/mobile-app/lib/services/logout_service.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/providers/account_associations_providers.dart';
+import 'package:resonance_network_wallet/providers/account_providers.dart';
+import 'package:resonance_network_wallet/providers/pending_transactions_provider.dart';
+import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
+import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
+import 'package:resonance_network_wallet/v2/screens/welcome/welcome_screen.dart';
+
+final logoutServiceProvider = Provider<LogoutService>((ref) => LogoutService(ref));
+
+class LogoutService {
+  final Ref _ref;
+  LogoutService(this._ref);
+
+  Future<void> logout(BuildContext context) async {
+    if (_ref.read(remoteConfigProvider).enableRemoteNotifications) {
+      _ref.read(firebaseMessagingServiceProvider).unregisterDevice();
+    }
+
+    SettingsService().clearAll();
+    SubstrateService().logout();
+    _ref.read(pendingTransactionsProvider.notifier).clear();
+    _ref.read(accountsProvider.notifier).reset();
+    _ref.read(activeAccountProvider.notifier).reset();
+    _ref.read(accountAssociationsProvider.notifier).reset();
+
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const WelcomeScreenV2()),
+      (r) => false,
+    );
+  }
+}

--- a/mobile-app/lib/services/logout_service.dart
+++ b/mobile-app/lib/services/logout_service.dart
@@ -26,10 +26,6 @@ class LogoutService {
     _ref.read(activeAccountProvider.notifier).reset();
     _ref.read(accountAssociationsProvider.notifier).reset();
 
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (_) => const WelcomeScreenV2()),
-      (r) => false,
-    );
+    Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (_) => const WelcomeScreenV2()), (r) => false);
   }
 }

--- a/mobile-app/lib/v2/screens/settings/settings_screen.dart
+++ b/mobile-app/lib/v2/screens/settings/settings_screen.dart
@@ -2,17 +2,13 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
-import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
-import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
+import 'package:resonance_network_wallet/services/logout_service.dart';
 import 'package:resonance_network_wallet/v2/components/glass_button.dart';
 import 'package:resonance_network_wallet/v2/screens/settings/recovery_phrase_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/settings/reset_confirmation_sheet.dart';
 import 'package:resonance_network_wallet/v2/screens/settings/select_wallet_screen.dart';
-import 'package:resonance_network_wallet/v2/screens/welcome/welcome_screen.dart';
-import 'package:resonance_network_wallet/providers/account_associations_providers.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/notification_config_provider.dart';
-import 'package:resonance_network_wallet/providers/pending_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/shared/utils/account_utils.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
@@ -66,20 +62,7 @@ class _SettingsScreenV2State extends ConsumerState<SettingsScreenV2> {
   }
 
   Future<void> _resetAndClearData() async {
-    if (ref.read(remoteConfigProvider).enableRemoteNotifications) {
-      ref.read(firebaseMessagingServiceProvider).unregisterDevice();
-    }
-
-    _settingsService.clearAll();
-    SubstrateService().logout();
-    ref.read(pendingTransactionsProvider.notifier).clear();
-    ref.read(accountsProvider.notifier).reset();
-    ref.read(activeAccountProvider.notifier).reset();
-    ref.read(accountAssociationsProvider.notifier).reset();
-
-    if (mounted) {
-      Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (_) => const WelcomeScreenV2()), (r) => false);
-    }
+    if (mounted) ref.read(logoutServiceProvider).logout(context);
   }
 
   void _showResetConfirmation() {

--- a/mobile-app/lib/wallet_initializer.dart
+++ b/mobile-app/lib/wallet_initializer.dart
@@ -9,6 +9,7 @@ import 'package:resonance_network_wallet/v2/screens/home/home_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/welcome/welcome_screen.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
+import 'package:resonance_network_wallet/services/logout_service.dart';
 import 'package:resonance_network_wallet/services/telemetry_service.dart';
 import 'package:resonance_network_wallet/utils/env_utils.dart';
 
@@ -109,14 +110,7 @@ class WalletInitializerState extends ConsumerState<WalletInitializer> {
         ),
       ),
     );
-    await _settingsService.clearAll();
-    if (mounted) {
-      Navigator.pushAndRemoveUntil(
-        context,
-        MaterialPageRoute(builder: (_) => const WelcomeScreenV2()),
-        (r) => false,
-      );
-    }
+    if (mounted) ref.read(logoutServiceProvider).logout(context);
   }
 
   void _reloadAccounts() {

--- a/mobile-app/lib/wallet_initializer.dart
+++ b/mobile-app/lib/wallet_initializer.dart
@@ -96,16 +96,9 @@ class WalletInitializerState extends ConsumerState<WalletInitializer> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              'Unable to find secret phrase. Please restore your wallet.',
-              style: ctx.themeText.smallParagraph,
-            ),
+            Text('Unable to find secret phrase. Please restore your wallet.', style: ctx.themeText.smallParagraph),
             const SizedBox(height: 32),
-            GlassButton.simple(
-              label: 'OK',
-              onTap: () => Navigator.pop(ctx),
-              variant: ButtonVariant.secondary,
-            ),
+            GlassButton.simple(label: 'OK', onTap: () => Navigator.pop(ctx), variant: ButtonVariant.secondary),
           ],
         ),
       ),

--- a/mobile-app/lib/wallet_initializer.dart
+++ b/mobile-app/lib/wallet_initializer.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/features/components/migration_dialog.dart';
+import 'package:resonance_network_wallet/v2/components/bottom_sheet_container.dart';
+import 'package:resonance_network_wallet/v2/components/glass_button.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
 import 'package:resonance_network_wallet/v2/screens/home/home_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/welcome/welcome_screen.dart';
+import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/services/telemetry_service.dart';
 import 'package:resonance_network_wallet/utils/env_utils.dart';
@@ -33,6 +36,16 @@ class WalletInitializerState extends ConsumerState<WalletInitializer> {
 
   Future<void> _checkWalletAndMigration() async {
     final hasWallet = await _settingsService.getHasWallet();
+
+    if (hasWallet) {
+      final mnemonic = await _settingsService.getMnemonic(0);
+      if (mnemonic == null) {
+        TelemetryService().sendEvent('user_lost_mnemonic');
+        if (mounted) await _showMnemonicLostDialog();
+        return;
+      }
+    }
+
     final needsMigration = _migrationService.needsMigration();
 
     if (needsMigration) {
@@ -71,6 +84,38 @@ class WalletInitializerState extends ConsumerState<WalletInitializer> {
         _walletExists = hasWallet;
         _loading = false;
       });
+    }
+  }
+
+  Future<void> _showMnemonicLostDialog() async {
+    await BottomSheetContainer.show(
+      context,
+      builder: (ctx) => BottomSheetContainer(
+        title: 'Wallet Error',
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Unable to find secret phrase. Please restore your wallet.',
+              style: ctx.themeText.smallParagraph,
+            ),
+            const SizedBox(height: 32),
+            GlassButton.simple(
+              label: 'OK',
+              onTap: () => Navigator.pop(ctx),
+              variant: ButtonVariant.secondary,
+            ),
+          ],
+        ),
+      ),
+    );
+    await _settingsService.clearAll();
+    if (mounted) {
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(builder: (_) => const WelcomeScreenV2()),
+        (r) => false,
+      );
     }
   }
 

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -11,7 +11,9 @@ class SettingsService {
   SettingsService._internal();
 
   late SharedPreferences _prefs;
-  final _secureStorage = const FlutterSecureStorage();
+  final _secureStorage = const FlutterSecureStorage(
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
 
   // New keys for multi-account support
   static const String _accountsKey = 'accounts_v4';


### PR DESCRIPTION
Fix for https://github.com/Quantus-Network/quantus-apps/issues/434

- On startup, check for mnemonic!
- If missing, log user out
- Setting to store mnemonic in encrypted backups (iOS) 

Mnemonic still won't get stored in unencrypted backups, that's an iOS safety feature.


#### Testing
Change the code to always pretend like the mnemonic is missing, ie 
instead of 
`      if (mnemonic == null) {
`
do 

      if (true) {
