### PR TITLE
fix max button

### DIFF
--- a/mobile-app/lib/v2/screens/send/send_sheet.dart
+++ b/mobile-app/lib/v2/screens/send/send_sheet.dart
@@ -153,7 +153,7 @@ class _SendSheetState extends ConsumerState<SendSheet> {
   void _setMax() {
     final balance = ref.read(effectiveMaxBalanceProvider).value ?? BigInt.zero;
     final max = SendScreenLogic.calculateMaxSendableAmount(balance: balance, networkFee: _networkFee);
-    _amountController.text = _fmt.formatBalance(max, addThousandsSeparators: false);
+    _amountController.text = _fmt.formatBalance(max, maxDecimals: AppConstants.decimals, addThousandsSeparators: false);
   }
 
   Future<void> _scanQr() async {


### PR DESCRIPTION
Issue: "Max" button value was cut off at 2 digits of precision
Fix: Use full 12 digits


flutter: user balance qzmNaLjPU7hcvkjHpGmrVDPD9y12vdAFimCSrP1GkhVFJMaUq: 484937254373561

flutter: getFee: Instance of 'RpcResponse<dynamic, dynamic>'

flutter: partialFee: 667250304

484937254373561 - 667250304 ‎ = 484,936,587,123,257

<img width="487" height="1064" alt="image" src="https://github.com/user-attachments/assets/a371ee4b-36ca-4d9f-8622-1f8e75017612" />
