### PR TITLE
Version number

### DIFF
--- a/mobile-app/android/app/build.gradle
+++ b/mobile-app/android/app/build.gradle
@@ -68,6 +68,16 @@ android {
     }
 }
 
+tasks.register('generateVersion', Exec) {
+    commandLine '/bin/sh', "${rootProject.projectDir}/../tool/generate_version.sh"
+}
+
+afterEvaluate {
+    tasks.matching { it.name.startsWith("compileFlutterBuild") }.each {
+        it.dependsOn generateVersion
+    }
+}
+
 flutter {
     source = "../.."
 }

--- a/mobile-app/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile-app/ios/Runner.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+			shellScript = "/bin/sh \"$PROJECT_DIR/../tool/generate_version.sh\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
 		B6052CF4FD0946429CD348DC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/mobile-app/lib/generated/version.g.dart
+++ b/mobile-app/lib/generated/version.g.dart
@@ -1,0 +1,2 @@
+const appVersion = '1.3.0';
+const appBuildNumber = '85';

--- a/mobile-app/lib/v2/screens/settings/settings_screen.dart
+++ b/mobile-app/lib/v2/screens/settings/settings_screen.dart
@@ -15,6 +15,7 @@ import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
 import 'package:resonance_network_wallet/v2/components/v2_app_bar.dart';
 import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
+import 'package:resonance_network_wallet/generated/version.g.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SettingsScreenV2 extends ConsumerStatefulWidget {
@@ -157,6 +158,8 @@ class _SettingsScreenV2State extends ConsumerState<SettingsScreenV2> {
           ]),
           const SizedBox(height: 40),
           _resetButton(colors, text),
+          const SizedBox(height: 24),
+          Center(child: Text('v$appVersion ($appBuildNumber)', style: text.detail?.copyWith(color: colors.textTertiary))),
           const SizedBox(height: 48),
         ],
       ),

--- a/mobile-app/lib/v2/screens/settings/settings_screen.dart
+++ b/mobile-app/lib/v2/screens/settings/settings_screen.dart
@@ -159,7 +159,12 @@ class _SettingsScreenV2State extends ConsumerState<SettingsScreenV2> {
           const SizedBox(height: 40),
           _resetButton(colors, text),
           const SizedBox(height: 24),
-          Center(child: Text('v$appVersion ($appBuildNumber)', style: text.detail?.copyWith(color: colors.textTertiary))),
+          Center(
+            child: Text(
+              'Version: $appVersion ($appBuildNumber)',
+              style: text.detail?.copyWith(color: colors.textTertiary),
+            ),
+          ),
           const SizedBox(height: 48),
         ],
       ),

--- a/mobile-app/tool/generate_version.sh
+++ b/mobile-app/tool/generate_version.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cd "$(dirname "$0")/.."
+LINE=$(grep '^version:' pubspec.yaml)
+RAW=$(echo "$LINE" | sed 's/version: *//')
+VER=$(echo "$RAW" | cut -d'+' -f1)
+BUILD=$(echo "$RAW" | cut -d'+' -f2)
+mkdir -p lib/generated
+printf "const appVersion = '%s';\nconst appBuildNumber = '%s';\n" "$VER" "$BUILD" > lib/generated/version.g.dart


### PR DESCRIPTION
- Add version number script
- invoke script in both ios and android builds

This is better... I think.. than pulling in a 3rd party package like package_info_plus

We will see!  

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-04-06 at 15 00 21" src="https://github.com/user-attachments/assets/a544cf5a-f0bb-4bfc-80b4-0fcd853a18a0" />
