### PR TITLE
Pass --no-mdns to quantus-node to suppress macOS local network prompt

### DIFF
--- a/miner-app/lib/src/services/node_process_manager.dart
+++ b/miner-app/lib/src/services/node_process_manager.dart
@@ -144,6 +144,7 @@ class NodeProcessManager extends BaseProcessManager {
       // Chain selection
       if (config.chainId == 'dev') '--dev' else ...['--chain', config.chainId],
       '--port', config.p2pPort.toString(),
+      '--no-mdns',
       '--prometheus-port', config.prometheusPort.toString(),
       '--experimental-rpc-endpoint',
       'listen-addr=${MinerConfig.localhost}:${config.rpcPort},methods=unsafe,cors=all',


### PR DESCRIPTION

<img width="274" height="260" alt="Screenshot 2026-05-01 at 2 26 28 AM" src="https://github.com/user-attachments/assets/26396bf0-b809-4fbe-b4c6-5f593837332d" />
user reported unnecessary alert as 'sus'

## Summary

The miner spawns `quantus-node` without `--no-mdns`, so libp2p's mDNS local peer discovery stays on by default. On macOS this triggers the local network permission prompt at startup, which is bad UX for solo miners who only need WAN peer discovery via bootnodes + Kademlia DHT.

This adds `--no-mdns` to the args built in `node_process_manager.dart`. The node still finds peers normally over the internet — mining is unaffected.

## Tradeoffs

- The only thing lost is fast peer discovery between multiple Quantus nodes on the same LAN, which is irrelevant for the default solo-miner case.
- If LAN discovery is ever needed (e.g. devs running local testnets), it can be re-exposed as an opt-in setting later.

## Test plan

- [ ] Build and launch the miner on macOS — verify the local network permission prompt no longer appears
- [ ] Confirm the node still connects to bootnodes and syncs / mines normally
- [ ] Sanity check that `--no-mdns` is present in the spawned process args