### PR TITLE
refresh miner balance periodically and on mining new block

### DIFF
--- a/miner-app/lib/features/miner/miner_balance_card.dart
+++ b/miner-app/lib/features/miner/miner_balance_card.dart
@@ -1,5 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:quantus_miner/src/config/miner_config.dart';
+import 'package:quantus_miner/src/services/log_stream_processor.dart';
 import 'package:quantus_miner/src/services/miner_wallet_service.dart';
+import 'package:quantus_miner/src/services/mining_orchestrator.dart';
 import 'package:quantus_miner/src/shared/extensions/snackbar_extensions.dart';
 import 'package:quantus_miner/src/utils/app_logger.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
@@ -9,7 +14,9 @@ import '../withdrawal/claim_rewards_dialog.dart';
 final _log = log.withTag('BalanceCard');
 
 class MinerBalanceCard extends StatefulWidget {
-  const MinerBalanceCard({super.key});
+  final MiningOrchestrator? orchestrator;
+
+  const MinerBalanceCard({super.key, this.orchestrator});
 
   @override
   State<MinerBalanceCard> createState() => _MinerBalanceCardState();
@@ -24,10 +31,54 @@ class _MinerBalanceCardState extends State<MinerBalanceCard> {
   bool _balanceLoading = false;
   bool _canWithdraw = false;
 
+  StreamSubscription<LogEntry>? _logsSubscription;
+  Timer? _periodicRefreshTimer;
+  Timer? _pendingPostBlockRefreshTimer;
+
   @override
   void initState() {
     super.initState();
     _loadData();
+    _subscribeToOrchestrator(widget.orchestrator);
+    _periodicRefreshTimer = Timer.periodic(MinerConfig.balancePollingInterval, (_) => _refresh());
+  }
+
+  @override
+  void didUpdateWidget(covariant MinerBalanceCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.orchestrator != widget.orchestrator) {
+      _subscribeToOrchestrator(widget.orchestrator);
+    }
+  }
+
+  @override
+  void dispose() {
+    _logsSubscription?.cancel();
+    _periodicRefreshTimer?.cancel();
+    _pendingPostBlockRefreshTimer?.cancel();
+    super.dispose();
+  }
+
+  void _subscribeToOrchestrator(MiningOrchestrator? orchestrator) {
+    _logsSubscription?.cancel();
+    _logsSubscription = orchestrator?.logsStream.listen((entry) {
+      if (entry.message.contains(MinerConfig.blockSubmittedLogMarker)) {
+        _scheduleRefreshAfterBlock();
+      }
+    });
+  }
+
+  void _scheduleRefreshAfterBlock() {
+    if (_pendingPostBlockRefreshTimer?.isActive == true) {
+      _log.d('Block submitted but a post-block refresh is already pending');
+      return;
+    }
+    final delay = MinerConfig.balanceRefreshDelayAfterBlock;
+    _log.i('Block submission detected — refreshing balance in ${delay.inSeconds}s');
+    _pendingPostBlockRefreshTimer = Timer(delay, () {
+      _pendingPostBlockRefreshTimer = null;
+      _refresh();
+    });
   }
 
   String? _secretHex;
@@ -77,10 +128,10 @@ class _MinerBalanceCardState extends State<MinerBalanceCard> {
   }
 
   void _refresh() {
+    if (_balanceLoading) return;
     final address = _address;
     final secret = _secretHex;
     if (address != null && secret != null && secret.isNotEmpty) {
-      _log.i('Manual refresh triggered');
       _loadBalance(address, secret);
     }
   }

--- a/miner-app/lib/features/miner/miner_dashboard_screen.dart
+++ b/miner-app/lib/features/miner/miner_dashboard_screen.dart
@@ -387,7 +387,7 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
         if (constraints.maxWidth > 800) {
           return Row(
             children: [
-              const Expanded(child: MinerBalanceCard()),
+              Expanded(child: MinerBalanceCard(orchestrator: _orchestrator)),
               const SizedBox(width: 16),
               Expanded(child: MinerStatsCard(miningStats: _miningStats)),
             ],
@@ -395,7 +395,7 @@ class _MinerDashboardScreenState extends State<MinerDashboardScreen> {
         } else {
           return Column(
             children: [
-              const MinerBalanceCard(),
+              MinerBalanceCard(orchestrator: _orchestrator),
               MinerStatsCard(miningStats: _miningStats),
             ],
           );

--- a/miner-app/lib/main.dart
+++ b/miner-app/lib/main.dart
@@ -9,6 +9,7 @@ import 'features/setup/rewards_address_setup_screen.dart';
 import 'features/miner/miner_dashboard_screen.dart';
 import 'features/withdrawal/withdrawal_screen.dart';
 import 'src/services/binary_manager.dart';
+import 'src/services/log_file_sink.dart';
 import 'src/services/miner_wallet_service.dart';
 import 'src/services/mining_orchestrator.dart';
 import 'src/services/process_cleanup_service.dart';
@@ -156,6 +157,13 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized(); // Ensure Flutter bindings are initialized
 
   // Note: Startup cleanup removed for simplicity
+
+  try {
+    final logsDir = await LogFileSink.getLogsDirectory();
+    _log.i('Process logs directory: ${logsDir.path}');
+  } catch (e, st) {
+    _log.e('Failed to prepare logs directory', error: e, stackTrace: st);
+  }
 
   try {
     await QuantusSdk.init();

--- a/miner-app/lib/src/config/miner_config.dart
+++ b/miner-app/lib/src/config/miner_config.dart
@@ -72,7 +72,18 @@ class MinerConfig {
   static const Duration chainRpcPollingInterval = Duration(seconds: 1);
 
   /// How often to poll wallet balance (backup timer)
-  static const Duration balancePollingInterval = Duration(seconds: 30);
+  static const Duration balancePollingInterval = Duration(minutes: 5);
+
+  /// Delay between detecting a successful block submission and refreshing the
+  /// balance. Wormhole balances are read from a remote Subsquid indexer which
+  /// lags the chain head; refreshing immediately would just re-fetch the stale
+  /// pre-block snapshot.
+  static const Duration balanceRefreshDelayAfterBlock = Duration(seconds: 15);
+
+  /// Substring in node logs that signals a successful block submission.
+  /// Emitted by the node from `service.rs` on both local and external mining paths
+  /// (e.g. "🥇 Successfully mined and submitted a new block ...").
+  static const String blockSubmittedLogMarker = 'Successfully mined and submitted a new block';
 
   // ============================================================
   // Hardware Detection

--- a/miner-app/lib/src/config/miner_config.dart
+++ b/miner-app/lib/src/config/miner_config.dart
@@ -174,6 +174,17 @@ class MinerConfig {
   /// Initial lines to print before filtering kicks in
   static const int initialLinesToPrint = 50;
 
+  /// Subdirectory (under quantus home) where rotated log files live
+  static const String logsDirName = 'logs';
+
+  /// Maximum size of a single log file before it rotates (bytes)
+  static const int logMaxFileBytes = 2 * 1024 * 1024; // 2 MB
+
+  /// Number of rotated backup files kept per source (in addition to the active file).
+  /// Total per-source budget = logMaxFileBytes * (logMaxBackupFiles + 1).
+  /// Default: 2MB * 5 = 10MB per source.
+  static const int logMaxBackupFiles = 4;
+
   // ============================================================
   // Port Range for Finding Alternatives
   // ============================================================

--- a/miner-app/lib/src/services/log_file_sink.dart
+++ b/miner-app/lib/src/services/log_file_sink.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:quantus_miner/src/config/miner_config.dart';
+import 'package:quantus_miner/src/services/binary_manager.dart';
+import 'package:quantus_miner/src/utils/app_logger.dart';
+
+final _log = log.withTag('LogFileSink');
+
+/// Append-only, size-rotating log sink for a single source (e.g. 'node', 'miner').
+///
+/// Writes raw lines to `<QuantusHome>/logs/<source>.log`. When the active file
+/// exceeds [MinerConfig.logMaxFileBytes], it is rotated to `<source>.log.1`,
+/// existing `<source>.log.N` files are shifted up, and `.N+1` beyond
+/// [MinerConfig.logMaxBackupFiles] is deleted.
+///
+/// Total on-disk budget per source =
+///   logMaxFileBytes * (logMaxBackupFiles + 1)  (≈ 10MB by default).
+///
+/// Fail-early: any I/O error disables the sink for the rest of the session
+/// (no silent fallback, no retry storm).
+class LogFileSink {
+  final String source;
+
+  IOSink? _sink;
+  File? _activeFile;
+  int _bytesWritten = 0;
+  bool _disabled = false;
+  bool _initializing = false;
+  Future<void>? _pendingInit;
+
+  LogFileSink({required this.source});
+
+  /// Returns the directory holding rotated log files (creates it if needed).
+  static Future<Directory> getLogsDirectory() async {
+    final home = await BinaryManager.getQuantusHomeDirectoryPath();
+    final dir = Directory(p.join(home, MinerConfig.logsDirName));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  /// Append a single line to the log file. A trailing newline is added.
+  /// No-op if the sink has been disabled by a prior failure.
+  Future<void> writeLine(String line) async {
+    if (_disabled) return;
+
+    if (_sink == null) {
+      _pendingInit ??= _open();
+      await _pendingInit;
+      if (_disabled) return;
+    }
+
+    try {
+      final encoded = utf8.encode('$line\n');
+      _sink!.add(encoded);
+      _bytesWritten += encoded.length;
+      if (_bytesWritten >= MinerConfig.logMaxFileBytes) {
+        await _rotate();
+      }
+    } catch (e, st) {
+      _log.e('Write failed for "$source", disabling file logging', error: e, stackTrace: st);
+      _disabled = true;
+      await _safeClose();
+    }
+  }
+
+  /// Flush buffered bytes to disk. Best-effort.
+  Future<void> flush() async {
+    try {
+      await _sink?.flush();
+    } catch (e, st) {
+      _log.w('Flush failed for "$source"', error: e, stackTrace: st);
+    }
+  }
+
+  /// Close the sink and release the file handle.
+  Future<void> close() async {
+    await _safeClose();
+  }
+
+  Future<void> _open() async {
+    if (_initializing) return;
+    _initializing = true;
+    try {
+      final dir = await getLogsDirectory();
+      final file = File(p.join(dir.path, '$source.log'));
+      if (!await file.exists()) {
+        await file.create(recursive: true);
+      }
+      final stat = await file.stat();
+      _activeFile = file;
+      _bytesWritten = stat.size;
+      _sink = file.openWrite(mode: FileMode.append);
+      _log.i('Logging "$source" to ${file.path}');
+
+      if (_bytesWritten >= MinerConfig.logMaxFileBytes) {
+        await _rotate();
+      }
+    } catch (e, st) {
+      _log.e('Failed to open log file for "$source", disabling file logging', error: e, stackTrace: st);
+      _disabled = true;
+      _sink = null;
+      _activeFile = null;
+    } finally {
+      _initializing = false;
+      _pendingInit = null;
+    }
+  }
+
+  /// Rotate active file: shift `.N` -> `.N+1`, drop the oldest, move active -> `.1`,
+  /// then reopen a fresh active file.
+  Future<void> _rotate() async {
+    final active = _activeFile;
+    if (active == null) return;
+
+    try {
+      await _sink?.flush();
+      await _sink?.close();
+      _sink = null;
+
+      final dir = active.parent;
+      final base = p.basename(active.path);
+
+      // Drop the oldest backup (if exists).
+      final oldest = File(p.join(dir.path, '$base.${MinerConfig.logMaxBackupFiles}'));
+      if (await oldest.exists()) {
+        await oldest.delete();
+      }
+
+      // Shift .N -> .N+1, working from oldest to newest.
+      for (var i = MinerConfig.logMaxBackupFiles - 1; i >= 1; i--) {
+        final src = File(p.join(dir.path, '$base.$i'));
+        if (await src.exists()) {
+          await src.rename(p.join(dir.path, '$base.${i + 1}'));
+        }
+      }
+
+      // Move active -> .1, then reopen fresh active file.
+      if (MinerConfig.logMaxBackupFiles >= 1) {
+        await active.rename(p.join(dir.path, '$base.1'));
+      } else {
+        await active.delete();
+      }
+
+      final fresh = File(p.join(dir.path, base));
+      await fresh.create(recursive: true);
+      _activeFile = fresh;
+      _bytesWritten = 0;
+      _sink = fresh.openWrite(mode: FileMode.append);
+    } catch (e, st) {
+      _log.e('Rotation failed for "$source", disabling file logging', error: e, stackTrace: st);
+      _disabled = true;
+      await _safeClose();
+    }
+  }
+
+  Future<void> _safeClose() async {
+    try {
+      await _sink?.flush();
+      await _sink?.close();
+    } catch (_) {
+      // ignore: handle already closed / broken sinks silently here, since we're tearing down
+    }
+    _sink = null;
+    _activeFile = null;
+  }
+}

--- a/miner-app/lib/src/services/log_filter_service.dart
+++ b/miner-app/lib/src/services/log_filter_service.dart
@@ -1,3 +1,5 @@
+import 'package:quantus_miner/src/config/miner_config.dart';
+
 class LogFilterService {
   final int initialLinesToPrint;
   int _linesProcessed = 0;
@@ -33,7 +35,7 @@ class LogFilterService {
       'finalized',
       'sealed',
       'proposed',
-      'Miner rewarded:',
+      MinerConfig.blockSubmittedLogMarker,
       // Keep existing keywords
       '[peers]',
     ],

--- a/miner-app/lib/src/services/log_stream_processor.dart
+++ b/miner-app/lib/src/services/log_stream_processor.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:quantus_miner/src/services/log_file_sink.dart';
 import 'package:quantus_miner/src/services/log_filter_service.dart';
 import 'package:quantus_miner/src/shared/extensions/log_string_extension.dart';
 import 'package:quantus_miner/src/utils/app_logger.dart';
@@ -45,6 +46,7 @@ class LogStreamProcessor {
   final String sourceName;
   final LogFilterService _filter;
   final SyncStateProvider? _getSyncState;
+  final LogFileSink _fileSink;
 
   StreamSubscription<String>? _stdoutSubscription;
   StreamSubscription<String>? _stderrSubscription;
@@ -59,7 +61,8 @@ class LogStreamProcessor {
 
   LogStreamProcessor({required this.sourceName, SyncStateProvider? getSyncState})
     : _filter = LogFilterService(),
-      _getSyncState = getSyncState;
+      _getSyncState = getSyncState,
+      _fileSink = LogFileSink(source: sourceName);
 
   /// Start processing logs from a process.
   ///
@@ -86,18 +89,21 @@ class LogStreamProcessor {
     _stderrSubscription?.cancel();
     _stdoutSubscription = null;
     _stderrSubscription = null;
+    _fileSink.flush();
     _log.d('Detached from process');
   }
 
   /// Close the log stream permanently.
   void dispose() {
     detach();
+    _fileSink.close();
     if (!_logController.isClosed) {
       _logController.close();
     }
   }
 
   void _processStdoutLine(String line) {
+    _fileSink.writeLine(line);
     final shouldPrint = _filter.shouldPrintLine(line, isNodeSyncing: _getSyncState?.call() ?? false);
 
     if (shouldPrint) {
@@ -119,6 +125,7 @@ class LogStreamProcessor {
   }
 
   void _processStderrLine(String line) {
+    _fileSink.writeLine(line);
     // stderr is always potentially important
     final isError = _isErrorLine(line);
     final entry = LogEntry(

--- a/miner-app/run_miner.sh
+++ b/miner-app/run_miner.sh
@@ -1,0 +1,4 @@
+## If we run in debug mode - fluter default - ZK operations are extremely slow to the point where it seems they don't work
+
+echo "Running miner on macOS in release mode"
+flutter run --release -d macos

--- a/scripts/tail_miner_node__logs.sh
+++ b/scripts/tail_miner_node__logs.sh
@@ -1,0 +1,1 @@
+tail -f ~/.quantus/logs/node.log


### PR DESCRIPTION
automatic balance refresh

- Balance refresh is expensive - we query the chain for all nullifiers etc
- Balance refreshes when we submit a block
- Slight delay to allow network to update
- Balance refreshes every 5 minutes in addition to that
- Add logging for sanity

<img width="785" height="702" alt="image" src="https://github.com/user-attachments/assets/24679b41-7b7d-4198-9bd2-61618cb8f656" />
