### PR TITLE
fix: deep linking

### DIFF
--- a/mobile-app/lib/services/deep_link_service.dart
+++ b/mobile-app/lib/services/deep_link_service.dart
@@ -47,7 +47,6 @@ class DeepLinkService {
 
       if (accountId != null && accountId.isNotEmpty) {
         _ref.read(sharedAccountIntentProvider.notifier).state = accountId;
-        navigatorKey.currentState?.pushNamed('/account');
       } else {
         print('Missing or empty account id');
       }
@@ -57,7 +56,6 @@ class DeepLinkService {
       final payment = PaymentIntent.tryParseUrl(uri.toString());
       if (payment != null) {
         _ref.read(paymentIntentProvider.notifier).state = payment;
-        navigatorKey.currentState?.pushNamed('/account');
       } else {
         print('Missing payment parameters');
       }


### PR DESCRIPTION
Main issues is that we push new screen over it so it's not properly shown, now we don't need to push navigation to consume intent. Much cleaner.



Tested on my iphone 14 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes forced navigation on deep-link reception and relies on existing Riverpod listeners to present UI; main risk is deep links no longer working if no screen consumes the intent state.
> 
> **Overview**
> Deep-link handling no longer pushes `'/account'` onto the navigator when receiving `/account` or `/pay` links; it now only sets `sharedAccountIntentProvider` / `paymentIntentProvider`.
> 
> This prevents deep links from stacking an extra screen and leaves the existing intent consumers (e.g., listeners on the home screen) to present the appropriate UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2099358284ec475cea6a2ac36b843563812ac02e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->