### PR TITLE
Make remote notification work again

### DIFF
--- a/mobile-app/lib/app.dart
+++ b/mobile-app/lib/app.dart
@@ -45,12 +45,7 @@ class _ResonanceWalletAppState extends ConsumerState<ResonanceWalletApp> {
       title: 'Quantus Wallet',
       navigatorObservers: [TelemetryNavigatorObserver()],
       initialRoute: '/',
-      routes: {
-        '/': (context) => const WalletInitializer(),
-        // These routes are for deep linking, each will carry an intent
-        '/account': (context) => const WalletInitializer(),
-        '/transactions': (context) => const WalletInitializer(),
-      },
+      routes: {'/': (context) => const WalletInitializer()},
       theme: AppTheme.darkTheme(context),
       darkTheme: AppTheme.darkTheme(context),
       themeMode: ThemeMode.dark,

--- a/mobile-app/lib/app.dart
+++ b/mobile-app/lib/app.dart
@@ -24,14 +24,13 @@ class _ResonanceWalletAppState extends ConsumerState<ResonanceWalletApp> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(notificationIntegrationServiceProvider);
-      ref.read(deepLinkServiceProvider).init();
-      ref.read(localNotificationsServiceProvider).setupNotificationsClickListener();
-      ref.read(localNotificationsServiceProvider).handleLaunchByNotification();
+    ref.read(notificationIntegrationServiceProvider);
+    ref.read(deepLinkServiceProvider).init();
+    final localNotifications = ref.read(localNotificationsServiceProvider);
+    localNotifications.setupNotificationsClickListener();
+    localNotifications.handleLaunchByNotification();
 
-      if (Platform.isAndroid) _referralService.checkPlayStoreReferralCode();
-    });
+    if (Platform.isAndroid) _referralService.checkPlayStoreReferralCode();
   }
 
   @override

--- a/mobile-app/lib/app.dart
+++ b/mobile-app/lib/app.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:resonance_network_wallet/shared/global_navigator_key.dart';
 import 'package:resonance_network_wallet/wallet_initializer.dart';
 import 'package:resonance_network_wallet/v2/screens/auth/auth_wrapper.dart';
 import 'package:resonance_network_wallet/v2/theme/app_theme.dart';
@@ -27,9 +26,9 @@ class _ResonanceWalletAppState extends ConsumerState<ResonanceWalletApp> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(notificationIntegrationServiceProvider);
-      ref.read(deepLinkServiceProvider).init(navigatorKey);
-      ref.read(localNotificationsServiceProvider).setupNotificationsClickListener(navigatorKey);
-      ref.read(localNotificationsServiceProvider).handleLaunchByNotification(navigatorKey);
+      ref.read(deepLinkServiceProvider).init();
+      ref.read(localNotificationsServiceProvider).setupNotificationsClickListener();
+      ref.read(localNotificationsServiceProvider).handleLaunchByNotification();
 
       if (Platform.isAndroid) _referralService.checkPlayStoreReferralCode();
     });
@@ -45,7 +44,6 @@ class _ResonanceWalletAppState extends ConsumerState<ResonanceWalletApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Quantus Wallet',
-      navigatorKey: navigatorKey,
       navigatorObservers: [TelemetryNavigatorObserver()],
       initialRoute: '/',
       routes: {

--- a/mobile-app/lib/providers/remote_config_provider.dart
+++ b/mobile-app/lib/providers/remote_config_provider.dart
@@ -6,7 +6,6 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/firebase_options.dart';
 import 'package:resonance_network_wallet/services/remote_config_service.dart';
 import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
-import 'package:resonance_network_wallet/shared/global_navigator_key.dart';
 
 final remoteConfigServiceProvider = Provider<RemoteConfigService>((ref) {
   return RemoteConfigService();
@@ -71,7 +70,7 @@ class RemoteConfigNotifier extends StateNotifier<RemoteConfigModel> {
 
     // Ensure navigatorKey.currentState is attached before handling any initial message.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      fcmService.setupNotificationTapHandlers(navigatorKey);
+      fcmService.setupNotificationTapHandlers();
     });
 
     _isEnablingRemoteNotifications = false;

--- a/mobile-app/lib/providers/remote_config_provider.dart
+++ b/mobile-app/lib/providers/remote_config_provider.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'dart:async';
 import 'package:quantus_sdk/quantus_sdk.dart';
@@ -67,11 +66,7 @@ class RemoteConfigNotifier extends StateNotifier<RemoteConfigModel> {
 
     final fcmService = ref.read(firebaseMessagingServiceProvider);
     await fcmService.init(); // This requests notification permission.
-
-    // Ensure navigatorKey.currentState is attached before handling any initial message.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      fcmService.setupNotificationTapHandlers();
-    });
+    fcmService.setupNotificationTapHandlers();
 
     _isEnablingRemoteNotifications = false;
   }

--- a/mobile-app/lib/services/deep_link_service.dart
+++ b/mobile-app/lib/services/deep_link_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:app_links/app_links.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/providers/account_associations_providers.dart';
@@ -17,22 +16,22 @@ class DeepLinkService {
   final _appLinks = AppLinks();
   StreamSubscription<Uri>? _linkSubscription;
 
-  Future<void> init(GlobalKey<NavigatorState> navigatorKey) async {
+  Future<void> init() async {
     // Handle links when the app is already open (warm state)
     _linkSubscription = _appLinks.uriLinkStream.listen((uri) {
       print('Received link while app is open: $uri');
-      _handleLink(uri, navigatorKey);
+      _handleLink(uri);
     });
 
     // Handle the link that opened the app (cold state)
     final initialUri = await _appLinks.getInitialLink();
     if (initialUri != null) {
       print('Received initial link: $initialUri');
-      _handleLink(initialUri, navigatorKey);
+      _handleLink(initialUri);
     }
   }
 
-  void _handleLink(Uri uri, GlobalKey<NavigatorState> navigatorKey) {
+  void _handleLink(Uri uri) {
     if (uri.pathSegments.isNotEmpty && uri.pathSegments.first == 'account') {
       String? accountId;
 

--- a/mobile-app/lib/services/firebase_messaging_service.dart
+++ b/mobile-app/lib/services/firebase_messaging_service.dart
@@ -22,7 +22,7 @@ class FirebaseMessagingService {
   final SenotiService _senotiService = SenotiService();
 
   bool _isInitialized = false;
-  bool __hasRegisteredHandlers = false;
+  bool _hasRegisteredHandlers = false;
   String? _cachedToken;
 
   FirebaseMessagingService(this._ref);
@@ -149,8 +149,8 @@ class FirebaseMessagingService {
   /// Handle the user tapping on an FCM notification that launched/resumed the app.
   /// Call this after the navigator key is available.
   void setupNotificationTapHandlers() {
-    if (__hasRegisteredHandlers) return;
-    __hasRegisteredHandlers = true;
+    if (_hasRegisteredHandlers) return;
+    _hasRegisteredHandlers = true;
 
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
       debugPrint('FCM notification tapped (background): ${message.messageId}');

--- a/mobile-app/lib/services/firebase_messaging_service.dart
+++ b/mobile-app/lib/services/firebase_messaging_service.dart
@@ -105,8 +105,8 @@ class FirebaseMessagingService {
       return;
     }
     try {
-      _cachedToken = null;
       await _senotiService.unregisterDevice(token, _platform);
+      _cachedToken = null;
     } catch (e) {
       debugPrint('Failed to unregister device: $e');
     }
@@ -147,7 +147,6 @@ class FirebaseMessagingService {
   }
 
   /// Handle the user tapping on an FCM notification that launched/resumed the app.
-  /// Call this after the navigator key is available.
   void setupNotificationTapHandlers() {
     if (_hasRegisteredHandlers) return;
     _hasRegisteredHandlers = true;

--- a/mobile-app/lib/services/firebase_messaging_service.dart
+++ b/mobile-app/lib/services/firebase_messaging_service.dart
@@ -105,6 +105,7 @@ class FirebaseMessagingService {
       return;
     }
     try {
+      _cachedToken = null;
       await _senotiService.unregisterDevice(token, _platform);
     } catch (e) {
       debugPrint('Failed to unregister device: $e');
@@ -169,10 +170,12 @@ class FirebaseMessagingService {
 
   void _handleNotificationTap(RemoteMessage message, GlobalKey<NavigatorState> navigatorKey) {
     final data = message.data;
+
+    print('FCM notification data: $data');
     if (data.isEmpty) return;
 
     final txService = _ref.read(transactionServiceProvider);
-    txService.navigateToTransactionFromPayloadIfPossible(data, navigatorKey);
+    txService.navigateToTransactionFromPayloadIfPossible(data);
   }
 
   NotificationData? _remoteMessageToNotificationData(RemoteMessage message) {

--- a/mobile-app/lib/services/firebase_messaging_service.dart
+++ b/mobile-app/lib/services/firebase_messaging_service.dart
@@ -148,30 +148,29 @@ class FirebaseMessagingService {
 
   /// Handle the user tapping on an FCM notification that launched/resumed the app.
   /// Call this after the navigator key is available.
-  void setupNotificationTapHandlers(GlobalKey<NavigatorState> navigatorKey) {
+  void setupNotificationTapHandlers() {
     if (__hasRegisteredHandlers) return;
     __hasRegisteredHandlers = true;
 
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
       debugPrint('FCM notification tapped (background): ${message.messageId}');
-      _handleNotificationTap(message, navigatorKey);
+      _handleNotificationTap(message);
     });
 
-    _handleInitialMessage(navigatorKey);
+    _handleInitialMessage();
   }
 
-  Future<void> _handleInitialMessage(GlobalKey<NavigatorState> navigatorKey) async {
+  Future<void> _handleInitialMessage() async {
     final initialMessage = await _messaging.getInitialMessage();
     if (initialMessage != null) {
       debugPrint('FCM initial message (terminated): ${initialMessage.messageId}');
-      _handleNotificationTap(initialMessage, navigatorKey);
+      _handleNotificationTap(initialMessage);
     }
   }
 
-  void _handleNotificationTap(RemoteMessage message, GlobalKey<NavigatorState> navigatorKey) {
+  void _handleNotificationTap(RemoteMessage message) {
     final data = message.data;
 
-    print('FCM notification data: $data');
     if (data.isEmpty) return;
 
     final txService = _ref.read(transactionServiceProvider);

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -77,6 +77,7 @@ class LocalNotificationsService {
 
     final txService = _ref.read(transactionServiceProvider);
     final json = jsonDecode(payload);
+    if (json == null) return;
 
     txService.navigateToTransactionFromPayloadIfPossible(json);
   }
@@ -130,6 +131,7 @@ class LocalNotificationsService {
 
       final txService = _ref.read(transactionServiceProvider);
       final json = jsonDecode(payload);
+      if (json == null) return;
 
       txService.navigateToTransactionFromPayloadIfPossible(json);
     });

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -147,7 +147,8 @@ class LocalNotificationsService {
         debugPrint('Error decoding payload setup notifications click listener: $e');
         TelemetryService().sendError(
           'Error decoding payload',
-          error: 'When decoding json payload in setup notifications click listener, it failed. There might be malformed data.',
+          error:
+              'When decoding json payload in setup notifications click listener, it failed. There might be malformed data.',
           stackTrace: StackTrace.current,
         );
       }

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/models/notification_models.dart';
@@ -69,7 +68,7 @@ class LocalNotificationsService {
   }
 
   // This is for handling when app is in terminated state then launched by tapping notification.
-  Future<void> handleLaunchByNotification(GlobalKey<NavigatorState> navigatorKey) async {
+  Future<void> handleLaunchByNotification() async {
     final notificationAppLaunchDetails = await _notificationPlugin.getNotificationAppLaunchDetails();
     if (notificationAppLaunchDetails?.didNotificationLaunchApp != true) return;
 
@@ -125,7 +124,7 @@ class LocalNotificationsService {
     }
   }
 
-  void setupNotificationsClickListener(GlobalKey<NavigatorState> navigatorKey) {
+  void setupNotificationsClickListener() {
     _onNotificationClick.stream.listen((payload) {
       if (payload == null || payload.isEmpty) return;
 

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -79,7 +79,7 @@ class LocalNotificationsService {
     final txService = _ref.read(transactionServiceProvider);
     final json = jsonDecode(payload);
 
-    txService.navigateToTransactionFromPayloadIfPossible(json, navigatorKey);
+    txService.navigateToTransactionFromPayloadIfPossible(json);
   }
 
   Future<void> _showNotification(NotificationData notification) async {
@@ -132,7 +132,7 @@ class LocalNotificationsService {
       final txService = _ref.read(transactionServiceProvider);
       final json = jsonDecode(payload);
 
-      txService.navigateToTransactionFromPayloadIfPossible(json, navigatorKey);
+      txService.navigateToTransactionFromPayloadIfPossible(json);
     });
   }
 

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/models/notification_models.dart';
+import 'package:resonance_network_wallet/services/telemetry_service.dart';
 import 'package:resonance_network_wallet/services/transaction_service.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz;
@@ -76,10 +78,17 @@ class LocalNotificationsService {
     if (payload == null || payload.isEmpty) return;
 
     final txService = _ref.read(transactionServiceProvider);
-    final json = jsonDecode(payload);
-    if (json == null) return;
-
-    txService.navigateToTransactionFromPayloadIfPossible(json);
+    try {
+      final json = jsonDecode(payload);
+      txService.navigateToTransactionFromPayloadIfPossible(json);
+    } catch (e) {
+      debugPrint('Error decoding payload handle launch by notification: $e');
+      TelemetryService().sendError(
+        'Error decoding payload launch by notification',
+        error: e,
+        stackTrace: StackTrace.current,
+      );
+    }
   }
 
   Future<void> _showNotification(NotificationData notification) async {
@@ -130,10 +139,18 @@ class LocalNotificationsService {
       if (payload == null || payload.isEmpty) return;
 
       final txService = _ref.read(transactionServiceProvider);
-      final json = jsonDecode(payload);
-      if (json == null) return;
 
-      txService.navigateToTransactionFromPayloadIfPossible(json);
+      try {
+        final json = jsonDecode(payload);
+        txService.navigateToTransactionFromPayloadIfPossible(json);
+      } catch (e) {
+        debugPrint('Error decoding payload setup notifications click listener: $e');
+        TelemetryService().sendError(
+          'Error decoding payload setup notifications click listener',
+          error: e,
+          stackTrace: StackTrace.current,
+        );
+      }
     });
   }
 

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -84,8 +84,8 @@ class LocalNotificationsService {
     } catch (e) {
       debugPrint('Error decoding payload handle launch by notification: $e');
       TelemetryService().sendError(
-        'Error decoding payload',
-        error: 'When decoding json payload in handle launch by notification, it failed. There might be malformed data.',
+        'Error decoding notification launch payload',
+        error: e.runtimeType.toString(),
         stackTrace: StackTrace.current,
       );
     }
@@ -146,9 +146,8 @@ class LocalNotificationsService {
       } catch (e) {
         debugPrint('Error decoding payload setup notifications click listener: $e');
         TelemetryService().sendError(
-          'Error decoding payload',
-          error:
-              'When decoding json payload in setup notifications click listener, it failed. There might be malformed data.',
+          'Error decoding notification click payload',
+          error: e.runtimeType.toString(),
           stackTrace: StackTrace.current,
         );
       }

--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -84,8 +84,8 @@ class LocalNotificationsService {
     } catch (e) {
       debugPrint('Error decoding payload handle launch by notification: $e');
       TelemetryService().sendError(
-        'Error decoding payload launch by notification',
-        error: e,
+        'Error decoding payload',
+        error: 'When decoding json payload in handle launch by notification, it failed. There might be malformed data.',
         stackTrace: StackTrace.current,
       );
     }
@@ -146,8 +146,8 @@ class LocalNotificationsService {
       } catch (e) {
         debugPrint('Error decoding payload setup notifications click listener: $e');
         TelemetryService().sendError(
-          'Error decoding payload setup notifications click listener',
-          error: e,
+          'Error decoding payload',
+          error: 'When decoding json payload in setup notifications click listener, it failed. There might be malformed data.',
           stackTrace: StackTrace.current,
         );
       }

--- a/mobile-app/lib/services/transaction_service.dart
+++ b/mobile-app/lib/services/transaction_service.dart
@@ -112,7 +112,11 @@ class TransactionService {
       }
     } catch (e) {
       debugPrint('Failed deserializing $txType event: $e');
-      TelemetryService().sendError('Failed deserializing $txType event', error: e, stackTrace: StackTrace.current);
+      TelemetryService().sendError(
+        'Failed deserializing $txType event',
+        error: e.runtimeType.toString(),
+        stackTrace: StackTrace.current,
+      );
     }
 
     return event;

--- a/mobile-app/lib/services/transaction_service.dart
+++ b/mobile-app/lib/services/transaction_service.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/models/transaction_role.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/route_intent_providers.dart';
+import 'package:resonance_network_wallet/services/telemetry_service.dart';
 
 final transactionServiceProvider = Provider<TransactionService>((ref) {
   return TransactionService(ref);
@@ -109,7 +111,8 @@ class TransactionService {
         event = PendingTransactionEvent.fromJson(json);
       }
     } catch (e) {
-      print('Failed deserializing event: $e');
+      debugPrint('Failed deserializing $txType event: $e');
+      TelemetryService().sendError('Failed deserializing $txType event', error: e, stackTrace: StackTrace.current);
     }
 
     return event;

--- a/mobile-app/lib/services/transaction_service.dart
+++ b/mobile-app/lib/services/transaction_service.dart
@@ -90,7 +90,7 @@ class TransactionService {
     }
   }
 
-  void navigateToTransactionFromPayloadIfPossible(Map<String, dynamic>? json) {
+  void navigateToTransactionFromPayloadIfPossible(Map<String, dynamic> json) {
     final event = deserializeTxEventFromJsonIfPossible(json);
 
     if (event != null) {

--- a/mobile-app/lib/services/transaction_service.dart
+++ b/mobile-app/lib/services/transaction_service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/models/transaction_role.dart';
@@ -89,12 +88,11 @@ class TransactionService {
     }
   }
 
-  void navigateToTransactionFromPayloadIfPossible(Map<String, dynamic>? json, GlobalKey<NavigatorState> navigatorKey) {
+  void navigateToTransactionFromPayloadIfPossible(Map<String, dynamic>? json) {
     final event = deserializeTxEventFromJsonIfPossible(json);
 
     if (event != null) {
       _ref.read(transactionIntentProvider.notifier).state = event;
-      navigatorKey.currentState?.pushNamed('/transactions');
     }
   }
 

--- a/mobile-app/lib/shared/global_navigator_key.dart
+++ b/mobile-app/lib/shared/global_navigator_key.dart
@@ -1,3 +1,0 @@
-import 'package:flutter/material.dart';
-
-final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();

--- a/mobile-app/lib/v2/screens/activity/transaction_detail_sheet.dart
+++ b/mobile-app/lib/v2/screens/activity/transaction_detail_sheet.dart
@@ -11,7 +11,7 @@ import 'package:resonance_network_wallet/v2/components/bottom_sheet_container.da
 import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
 
-void showTransactionDetailSheet(BuildContext context, TransactionEvent tx, String? activeAccountId) {
+void showTransactionDetailSheet(BuildContext context, TransactionEvent tx, String activeAccountId) {
   BottomSheetContainer.show(
     context,
     builder: (_) => _TransactionDetailSheet(tx: tx, activeAccountId: activeAccountId),
@@ -20,7 +20,7 @@ void showTransactionDetailSheet(BuildContext context, TransactionEvent tx, Strin
 
 class _TransactionDetailSheet extends StatelessWidget {
   final TransactionEvent tx;
-  final String? activeAccountId;
+  final String activeAccountId;
 
   const _TransactionDetailSheet({required this.tx, required this.activeAccountId});
 
@@ -28,7 +28,6 @@ class _TransactionDetailSheet extends StatelessWidget {
   bool get _isPending => tx is PendingTransactionEvent;
 
   String get _title {
-    if (activeAccountId == null) return 'Transaction Details';
     if (_isPending) return 'Sending';
     if (tx.isReversibleScheduled) return _isSend ? 'Scheduled' : 'Receiving';
     return _isSend ? 'Sent' : 'Received';

--- a/mobile-app/lib/v2/screens/activity/transaction_detail_sheet.dart
+++ b/mobile-app/lib/v2/screens/activity/transaction_detail_sheet.dart
@@ -11,7 +11,7 @@ import 'package:resonance_network_wallet/v2/components/bottom_sheet_container.da
 import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
 
-void showTransactionDetailSheet(BuildContext context, TransactionEvent tx, String activeAccountId) {
+void showTransactionDetailSheet(BuildContext context, TransactionEvent tx, String? activeAccountId) {
   BottomSheetContainer.show(
     context,
     builder: (_) => _TransactionDetailSheet(tx: tx, activeAccountId: activeAccountId),
@@ -20,7 +20,7 @@ void showTransactionDetailSheet(BuildContext context, TransactionEvent tx, Strin
 
 class _TransactionDetailSheet extends StatelessWidget {
   final TransactionEvent tx;
-  final String activeAccountId;
+  final String? activeAccountId;
 
   const _TransactionDetailSheet({required this.tx, required this.activeAccountId});
 
@@ -28,6 +28,7 @@ class _TransactionDetailSheet extends StatelessWidget {
   bool get _isPending => tx is PendingTransactionEvent;
 
   String get _title {
+    if (activeAccountId == null) return 'Transaction Details';
     if (_isPending) return 'Sending';
     if (tx.isReversibleScheduled) return _isSend ? 'Scheduled' : 'Receiving';
     return _isSend ? 'Sent' : 'Received';

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -13,6 +13,7 @@ import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_icon_button.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base_bottom_content.dart';
 import 'package:resonance_network_wallet/v2/screens/accounts/open_accounts_management_button.dart';
+import 'package:resonance_network_wallet/v2/screens/activity/transaction_detail_sheet.dart';
 import 'package:resonance_network_wallet/v2/screens/receive/receive_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/send/input_amount_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/send/select_recipient_screen.dart';
@@ -86,6 +87,17 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       if (shared == null) return;
       ref.read(sharedAccountIntentProvider.notifier).state = null;
       showSharedAddressActionSheet(context, shared);
+    });
+
+    ref.listen(transactionIntentProvider, (_, transaction) {
+      if (transaction == null) return;
+
+      ref.read(transactionIntentProvider.notifier).state = null;
+      final active = ref.read(activeAccountProvider).value;
+
+      if (active != null) {
+        showTransactionDetailSheet(context, transaction, active.account.accountId);
+      }
     });
 
     final accountAsync = ref.watch(activeAccountProvider);

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -77,8 +77,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) =>
-            InputAmountScreen(recipientAddress: payment.to, initialAmount: payment.amount, isPayMode: true),
+        builder: (_) => InputAmountScreen(recipientAddress: payment.to, initialAmount: payment.amount, isPayMode: true),
       ),
     );
   }

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -95,9 +95,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ref.read(transactionIntentProvider.notifier).state = null;
       final active = ref.read(activeAccountProvider).value;
 
-      if (active != null) {
-        showTransactionDetailSheet(context, transaction, active.account.accountId);
-      }
+      showTransactionDetailSheet(context, transaction, active?.account.accountId);
     });
 
     final accountAsync = ref.watch(activeAccountProvider);

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -45,30 +45,48 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   void initState() {
     super.initState();
 
-    ref.listenManual<TransactionEvent?>(transactionIntentProvider, (_, transaction) {
-      if (transaction == null || !mounted) return;
-      ref.read(transactionIntentProvider.notifier).state = null;
-      final active = ref.read(activeAccountProvider).value;
-      showTransactionDetailSheet(context, transaction, active?.account.accountId);
-    }, fireImmediately: true);
+    ref.listenManual<TransactionEvent?>(transactionIntentProvider, _onTransactionIntent);
+    ref.listenManual<PaymentIntent?>(paymentIntentProvider, _onPaymentIntent);
+    ref.listenManual<String?>(sharedAccountIntentProvider, _onSharedIntent);
+    ref.listenManual<AsyncValue<DisplayAccount?>>(activeAccountProvider, (_, async) {
+      if (async.value == null) return;
+      _onTransactionIntent(null, ref.read(transactionIntentProvider));
+    });
 
-    ref.listenManual<PaymentIntent?>(paymentIntentProvider, (_, payment) {
-      if (payment == null || !mounted) return;
-      ref.read(paymentIntentProvider.notifier).state = null;
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) =>
-              InputAmountScreen(recipientAddress: payment.to, initialAmount: payment.amount, isPayMode: true),
-        ),
-      );
-    }, fireImmediately: true);
+    Future.microtask(_drainPendingIntents);
+  }
 
-    ref.listenManual<String?>(sharedAccountIntentProvider, (_, shared) {
-      if (shared == null || !mounted) return;
-      ref.read(sharedAccountIntentProvider.notifier).state = null;
-      showSharedAddressActionSheet(context, shared);
-    }, fireImmediately: true);
+  void _drainPendingIntents() {
+    if (!mounted) return;
+    _onTransactionIntent(null, ref.read(transactionIntentProvider));
+    _onPaymentIntent(null, ref.read(paymentIntentProvider));
+    _onSharedIntent(null, ref.read(sharedAccountIntentProvider));
+  }
+
+  void _onTransactionIntent(TransactionEvent? _, TransactionEvent? transaction) {
+    if (transaction == null || !mounted) return;
+    final active = ref.read(activeAccountProvider).value;
+    if (active == null) return;
+    ref.read(transactionIntentProvider.notifier).state = null;
+    showTransactionDetailSheet(context, transaction, active.account.accountId);
+  }
+
+  void _onPaymentIntent(PaymentIntent? _, PaymentIntent? payment) {
+    if (payment == null || !mounted) return;
+    ref.read(paymentIntentProvider.notifier).state = null;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) =>
+            InputAmountScreen(recipientAddress: payment.to, initialAmount: payment.amount, isPayMode: true),
+      ),
+    );
+  }
+
+  void _onSharedIntent(String? _, String? shared) {
+    if (shared == null || !mounted) return;
+    ref.read(sharedAccountIntentProvider.notifier).state = null;
+    showSharedAddressActionSheet(context, shared);
   }
 
   Future<void> _refresh() async {

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -41,6 +41,36 @@ class HomeScreen extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    ref.listenManual<TransactionEvent?>(transactionIntentProvider, (_, transaction) {
+      if (transaction == null || !mounted) return;
+      ref.read(transactionIntentProvider.notifier).state = null;
+      final active = ref.read(activeAccountProvider).value;
+      showTransactionDetailSheet(context, transaction, active?.account.accountId);
+    }, fireImmediately: true);
+
+    ref.listenManual<PaymentIntent?>(paymentIntentProvider, (_, payment) {
+      if (payment == null || !mounted) return;
+      ref.read(paymentIntentProvider.notifier).state = null;
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) =>
+              InputAmountScreen(recipientAddress: payment.to, initialAmount: payment.amount, isPayMode: true),
+        ),
+      );
+    }, fireImmediately: true);
+
+    ref.listenManual<String?>(sharedAccountIntentProvider, (_, shared) {
+      if (shared == null || !mounted) return;
+      ref.read(sharedAccountIntentProvider.notifier).state = null;
+      showSharedAddressActionSheet(context, shared);
+    }, fireImmediately: true);
+  }
+
   Future<void> _refresh() async {
     final active = ref.read(activeAccountProvider).value;
     ref.invalidate(balanceProviderFamily);
@@ -71,33 +101,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen(paymentIntentProvider, (_, payment) {
-      if (payment == null) return;
-      ref.read(paymentIntentProvider.notifier).state = null;
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) =>
-              InputAmountScreen(recipientAddress: payment.to, initialAmount: payment.amount, isPayMode: true),
-        ),
-      );
-    });
-
-    ref.listen(sharedAccountIntentProvider, (_, shared) {
-      if (shared == null) return;
-      ref.read(sharedAccountIntentProvider.notifier).state = null;
-      showSharedAddressActionSheet(context, shared);
-    });
-
-    ref.listen(transactionIntentProvider, (_, transaction) {
-      if (transaction == null) return;
-
-      ref.read(transactionIntentProvider.notifier).state = null;
-      final active = ref.read(activeAccountProvider).value;
-
-      showTransactionDetailSheet(context, transaction, active?.account.accountId);
-    });
-
     final accountAsync = ref.watch(activeAccountProvider);
     final txAsync = ref.watch(activeAccountTransactionsProvider(TransactionFilter.all));
     final colors = context.colors;

--- a/mobile-app/test/unit/transaction_service_test.dart
+++ b/mobile-app/test/unit/transaction_service_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/services/transaction_service.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('TransactionService.deserializeTxEventFromJsonIfPossible', () {
+    /// Typical REST shape (nested maps, amount/fee as decimal strings).
+    Map<String, dynamic> transferPayloadFromSample() => {
+      'amount': '1000000000',
+      'sender': {'id': 'qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC'},
+      'id': '0000197242-9c90c-000002',
+      'receiver': {'id': 'qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda'},
+      'block': {'hash': '0x9c90cf5b0d7348e49c7ed427b42f5cc7cfe37e11bd7f4e3254c7fc4c7acbbf62', 'height': 197242},
+      'extrinsic': {'id': '0x60db7af926aa917d0e15c02fa4ddf54ed759ae564b380b8e73b63570000924e7'},
+      'fee': '8189972000',
+      'type': 'TRANSFER',
+      'timestamp': '2026-05-12T12:39:51.706Z',
+    };
+
+    test('returns TransferEvent for TRANSFER type with sample payload', () {
+      final service = container.read(transactionServiceProvider);
+      final json = transferPayloadFromSample();
+
+      final event = service.deserializeTxEventFromJsonIfPossible(json);
+
+      expect(event, isA<TransferEvent>());
+      final transfer = event! as TransferEvent;
+      expect(transfer.id, '0000197242-9c90c-000002');
+      expect(transfer.from, 'qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC');
+      expect(transfer.to, 'qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda');
+      expect(transfer.amount, BigInt.parse('1000000000'));
+      expect(transfer.fee, BigInt.parse('8189972000'));
+      expect(transfer.blockNumber, 197242);
+      expect(transfer.blockHash, '0x9c90cf5b0d7348e49c7ed427b42f5cc7cfe37e11bd7f4e3254c7fc4c7acbbf62');
+      expect(transfer.extrinsicHash, '0x60db7af926aa917d0e15c02fa4ddf54ed759ae564b380b8e73b63570000924e7');
+      expect(transfer.timestamp.toUtc(), DateTime.parse('2026-05-12T12:39:51.706Z').toUtc());
+    });
+
+    test('returns null when type is not supported', () {
+      final service = container.read(transactionServiceProvider);
+      final json = <String, dynamic>{...transferPayloadFromSample(), 'type': 'UNKNOWN'};
+
+      expect(service.deserializeTxEventFromJsonIfPossible(json), isNull);
+    });
+
+    test('parses FCM-style TRANSFER (JSON string block/senders, int amounts, '
+        'top-level extrinsicHash)', () {
+      final service = container.read(transactionServiceProvider);
+      final json = <String, dynamic>{
+        'amount': 1000000000,
+        'fee': 8189972000,
+        'sender': '{"id":"qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC"}',
+        'id': '0000197378-4f5d2-000002',
+        'receiver': '{"id":"qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda"}',
+        'block': '{"hash":"0x4f5d27e7b1c679e64292606c9560432f610f7a6fccab992f5ab6326f5171f90c","height":197378}',
+        'extrinsicHash': '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7',
+        'type': 'TRANSFER',
+        'timestamp': '2026-05-12T13:08:21.846Z',
+      };
+
+      final event = service.deserializeTxEventFromJsonIfPossible(json);
+
+      expect(event, isA<TransferEvent>());
+      final transfer = event! as TransferEvent;
+      expect(transfer.blockNumber, 197378);
+      expect(transfer.extrinsicHash, '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7');
+    });
+  });
+}

--- a/quantus_sdk/lib/src/models/json_dynamic_parse.dart
+++ b/quantus_sdk/lib/src/models/json_dynamic_parse.dart
@@ -12,13 +12,9 @@ Map<String, dynamic>? jsonMapOrNull(dynamic value) {
     final decoded = jsonDecode(trimmed);
     if (decoded is Map<String, dynamic>) return decoded;
     if (decoded is Map) return Map<String, dynamic>.from(decoded);
-    throw FormatException(
-      'JSON string must decode to an object, got ${decoded.runtimeType}',
-    );
+    throw FormatException('JSON string must decode to an object, got ${decoded.runtimeType}');
   }
-  throw FormatException(
-    'Expected Map or JSON object string, got ${value.runtimeType}',
-  );
+  throw FormatException('Expected Map or JSON object string, got ${value.runtimeType}');
 }
 
 Map<String, dynamic> jsonMapRequired(dynamic value, String fieldName) {
@@ -33,17 +29,13 @@ BigInt bigIntFromJson(dynamic value) {
   if (value is BigInt) return value;
   if (value is int) return BigInt.from(value);
   if (value is String) return BigInt.parse(value);
-  throw FormatException(
-    'Cannot parse BigInt from ${value.runtimeType}: $value',
-  );
+  throw FormatException('Cannot parse BigInt from ${value.runtimeType}: $value');
 }
 
 DateTime dateTimeFromJson(dynamic value) {
   if (value is DateTime) return value;
   if (value is String) return DateTime.parse(value);
-  throw FormatException(
-    'Cannot parse DateTime from ${value.runtimeType}: $value',
-  );
+  throw FormatException('Cannot parse DateTime from ${value.runtimeType}: $value');
 }
 
 String stringFromJson(dynamic value) {

--- a/quantus_sdk/lib/src/models/json_dynamic_parse.dart
+++ b/quantus_sdk/lib/src/models/json_dynamic_parse.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+/// Parses values produced by APIs that sometimes nest objects and sometimes
+/// JSON-encode them as strings (e.g. FCM [RemoteMessage.data]).
+Map<String, dynamic>? jsonMapOrNull(dynamic value) {
+  if (value == null) return null;
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) return Map<String, dynamic>.from(value);
+  if (value is String) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    final decoded = jsonDecode(trimmed);
+    if (decoded is Map<String, dynamic>) return decoded;
+    if (decoded is Map) return Map<String, dynamic>.from(decoded);
+    throw FormatException(
+      'JSON string must decode to an object, got ${decoded.runtimeType}',
+    );
+  }
+  throw FormatException(
+    'Expected Map or JSON object string, got ${value.runtimeType}',
+  );
+}
+
+Map<String, dynamic> jsonMapRequired(dynamic value, String fieldName) {
+  final m = jsonMapOrNull(value);
+  if (m == null) {
+    throw FormatException('Missing or empty map for $fieldName');
+  }
+  return m;
+}
+
+BigInt bigIntFromJson(dynamic value) {
+  if (value is BigInt) return value;
+  if (value is int) return BigInt.from(value);
+  if (value is String) return BigInt.parse(value);
+  throw FormatException(
+    'Cannot parse BigInt from ${value.runtimeType}: $value',
+  );
+}
+
+DateTime dateTimeFromJson(dynamic value) {
+  if (value is DateTime) return value;
+  if (value is String) return DateTime.parse(value);
+  throw FormatException(
+    'Cannot parse DateTime from ${value.runtimeType}: $value',
+  );
+}
+
+String stringFromJson(dynamic value) {
+  if (value is String) return value;
+  throw FormatException('Expected String, got ${value.runtimeType}: $value');
+}
+
+/// Resolves `{"id":"..."}`, a JSON string of that object, or a bare address
+/// string.
+String nestedAccountId(dynamic holder) {
+  if (holder == null) return '';
+  if (holder is String) {
+    final s = holder.trim();
+    if (s.startsWith('{')) {
+      final m = jsonMapOrNull(s);
+      final id = m?['id'];
+      if (id is String) return id;
+      if (id != null) return id.toString();
+      return '';
+    }
+    return s;
+  }
+  final m = jsonMapOrNull(holder);
+  if (m != null) {
+    final id = m['id'];
+    if (id is String) return id;
+    if (id != null) return id.toString();
+  }
+  return '';
+}
+
+String? optionalExtrinsicHash(Map<String, dynamic> json) {
+  final nested = jsonMapOrNull(json['extrinsic'])?['id'];
+  if (nested is String) return nested;
+  final direct = json['extrinsicHash'];
+  if (direct is String) return direct;
+  return null;
+}
+
+int blockHeightFromJsonMap(Map<String, dynamic>? block) {
+  if (block == null) return 0;
+  final h = block['height'];
+  if (h == null) return 0;
+  if (h is int) return h;
+  if (h is num) return h.toInt();
+  if (h is String) return int.parse(h);
+  throw FormatException('Invalid block height: $h (${h.runtimeType})');
+}
+
+String blockHashFromJsonMap(Map<String, dynamic>? block) {
+  if (block == null) return '';
+  final hash = block['hash'];
+  if (hash == null) return '';
+  if (hash is String) return hash;
+  return hash.toString();
+}

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -1,5 +1,7 @@
 import 'package:quantus_sdk/quantus_sdk.dart';
 
+import 'json_dynamic_parse.dart';
+
 // Base class for different transaction types
 abstract class TransactionEvent {
   final String id;
@@ -45,17 +47,17 @@ class TransferEvent extends TransactionEvent {
   });
 
   factory TransferEvent.fromJson(Map<String, dynamic> json) {
-    final block = json['block'] as Map<String, dynamic>?;
-    final blockHeight = block?['height'] as int? ?? 0;
-    final blockHash = block?['hash'] as String? ?? '';
+    final block = jsonMapOrNull(json['block']);
+    final blockHeight = blockHeightFromJsonMap(block);
+    final blockHash = blockHashFromJsonMap(block);
     return TransferEvent(
-      id: json['id'] as String,
-      from: json['from']?['id'] as String? ?? '',
-      to: json['to']?['id'] as String? ?? '',
-      amount: BigInt.parse(json['amount'] as String),
-      timestamp: DateTime.parse(json['timestamp'] as String),
-      fee: json['fee'] != null ? BigInt.parse(json['fee'] as String) : BigInt.zero,
-      extrinsicHash: json['extrinsic']?['id'] as String?,
+      id: stringFromJson(json['id']),
+      from: nestedAccountId(json['sender'] ?? json['from']),
+      to: nestedAccountId(json['receiver'] ?? json['to']),
+      amount: bigIntFromJson(json['amount']),
+      timestamp: dateTimeFromJson(json['timestamp']),
+      fee: json['fee'] != null ? bigIntFromJson(json['fee']) : BigInt.zero,
+      extrinsicHash: optionalExtrinsicHash(json),
       blockNumber: blockHeight,
       blockHash: blockHash,
     );
@@ -103,26 +105,31 @@ class ReversibleTransferEvent extends TransactionEvent {
   });
 
   // Create a ReversibleTransferEvent with a known status
-  factory ReversibleTransferEvent.fromJson(Map<String, dynamic> json, {required ReversibleTransferStatus status}) {
-    final block = json['block'] as Map<String, dynamic>;
-    final transfer = json['scheduledTransfer'] as Map<String, dynamic>? ?? json;
+  factory ReversibleTransferEvent.fromJson(
+    Map<String, dynamic> json, {
+    required ReversibleTransferStatus status,
+  }) {
+    final block = jsonMapRequired(json['block'], 'block');
+    final transfer = jsonMapOrNull(json['scheduledTransfer']) ?? json;
     return ReversibleTransferEvent(
-      id: json['id'] as String,
-      from: transfer['from']?['id'] as String? ?? '',
-      to: transfer['to']?['id'] as String? ?? '',
-      amount: BigInt.parse(transfer['amount'] as String),
-      timestamp: DateTime.parse(json['timestamp'] as String),
-      txId: json['txId'] as String,
+      id: stringFromJson(json['id']),
+      from: nestedAccountId(transfer['sender'] ?? transfer['from']),
+      to: nestedAccountId(transfer['receiver'] ?? transfer['to']),
+      amount: bigIntFromJson(transfer['amount']),
+      timestamp: dateTimeFromJson(json['timestamp']),
+      txId: stringFromJson(json['txId']),
       status: status,
-      scheduledAt: DateTime.parse(transfer['scheduledAt'] as String),
-      extrinsicHash: json['extrinsic']?['id'] as String?,
-      blockNumber: block['height'] as int,
-      blockHash: block['hash'] as String? ?? '',
+      scheduledAt: dateTimeFromJson(transfer['scheduledAt']),
+      extrinsicHash: optionalExtrinsicHash(json),
+      blockNumber: blockHeightFromJsonMap(block),
+      blockHash: blockHashFromJsonMap(block),
     );
   }
 
   // Create a ReversibleTransferEvent we previously stored as JSON using toJson()
-  factory ReversibleTransferEvent.deserializeFromJson(Map<String, dynamic> json) {
+  factory ReversibleTransferEvent.deserializeFromJson(
+    Map<String, dynamic> json,
+  ) {
     return ReversibleTransferEvent.fromJson(
       json,
       status: ReversibleTransferStatus.values.byName(json['status'] as String),

--- a/quantus_sdk/lib/src/models/transaction_event.dart
+++ b/quantus_sdk/lib/src/models/transaction_event.dart
@@ -105,10 +105,7 @@ class ReversibleTransferEvent extends TransactionEvent {
   });
 
   // Create a ReversibleTransferEvent with a known status
-  factory ReversibleTransferEvent.fromJson(
-    Map<String, dynamic> json, {
-    required ReversibleTransferStatus status,
-  }) {
+  factory ReversibleTransferEvent.fromJson(Map<String, dynamic> json, {required ReversibleTransferStatus status}) {
     final block = jsonMapRequired(json['block'], 'block');
     final transfer = jsonMapOrNull(json['scheduledTransfer']) ?? json;
     return ReversibleTransferEvent(
@@ -127,9 +124,7 @@ class ReversibleTransferEvent extends TransactionEvent {
   }
 
   // Create a ReversibleTransferEvent we previously stored as JSON using toJson()
-  factory ReversibleTransferEvent.deserializeFromJson(
-    Map<String, dynamic> json,
-  ) {
+  factory ReversibleTransferEvent.deserializeFromJson(Map<String, dynamic> json) {
     return ReversibleTransferEvent.fromJson(
       json,
       status: ReversibleTransferStatus.values.byName(json['status'] as String),

--- a/quantus_sdk/test/models/transfer_event_from_json_test.dart
+++ b/quantus_sdk/test/models/transfer_event_from_json_test.dart
@@ -6,22 +6,14 @@ void main() {
     test('parses nested maps from typical REST JSON', () {
       final json = <String, dynamic>{
         'amount': '1000000000',
-        'sender': <String, dynamic>{
-          'id': 'qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC',
-        },
+        'sender': <String, dynamic>{'id': 'qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC'},
         'id': '0000197242-9c90c-000002',
-        'receiver': <String, dynamic>{
-          'id': 'qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda',
-        },
+        'receiver': <String, dynamic>{'id': 'qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda'},
         'block': <String, dynamic>{
-          'hash':
-              '0x9c90cf5b0d7348e49c7ed427b42f5cc7cfe37e11bd7f4e3254c7fc4c7acbbf62',
+          'hash': '0x9c90cf5b0d7348e49c7ed427b42f5cc7cfe37e11bd7f4e3254c7fc4c7acbbf62',
           'height': 197242,
         },
-        'extrinsic': <String, dynamic>{
-          'id':
-              '0x60db7af926aa917d0e15c02fa4ddf54ed759ae564b380b8e73b63570000924e7',
-        },
+        'extrinsic': <String, dynamic>{'id': '0x60db7af926aa917d0e15c02fa4ddf54ed759ae564b380b8e73b63570000924e7'},
         'fee': '8189972000',
         'timestamp': '2026-05-12T12:39:51.706Z',
       };
@@ -38,22 +30,16 @@ void main() {
         'fee': 8189972000,
         'sender': '{"id":"qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC"}',
         'id': '0000197378-4f5d2-000002',
-        'receiver':
-            '{"id":"qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda"}',
-        'block':
-            '{"hash":"0x4f5d27e7b1c679e64292606c9560432f610f7a6fccab992f5ab6326f5171f90c","height":197378}',
-        'extrinsicHash':
-            '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7',
+        'receiver': '{"id":"qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda"}',
+        'block': '{"hash":"0x4f5d27e7b1c679e64292606c9560432f610f7a6fccab992f5ab6326f5171f90c","height":197378}',
+        'extrinsicHash': '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7',
         'timestamp': '2026-05-12T13:08:21.846Z',
       };
 
       final event = TransferEvent.fromJson(json);
 
       expect(event.blockNumber, 197378);
-      expect(
-        event.extrinsicHash,
-        '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7',
-      );
+      expect(event.extrinsicHash, '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7');
       expect(event.amount, BigInt.from(1000000000));
       expect(event.fee, BigInt.from(8189972000));
     });

--- a/quantus_sdk/test/models/transfer_event_from_json_test.dart
+++ b/quantus_sdk/test/models/transfer_event_from_json_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quantus_sdk/src/models/transaction_event.dart';
+
+void main() {
+  group('TransferEvent.fromJson', () {
+    test('parses nested maps from typical REST JSON', () {
+      final json = <String, dynamic>{
+        'amount': '1000000000',
+        'sender': <String, dynamic>{
+          'id': 'qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC',
+        },
+        'id': '0000197242-9c90c-000002',
+        'receiver': <String, dynamic>{
+          'id': 'qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda',
+        },
+        'block': <String, dynamic>{
+          'hash':
+              '0x9c90cf5b0d7348e49c7ed427b42f5cc7cfe37e11bd7f4e3254c7fc4c7acbbf62',
+          'height': 197242,
+        },
+        'extrinsic': <String, dynamic>{
+          'id':
+              '0x60db7af926aa917d0e15c02fa4ddf54ed759ae564b380b8e73b63570000924e7',
+        },
+        'fee': '8189972000',
+        'timestamp': '2026-05-12T12:39:51.706Z',
+      };
+
+      final event = TransferEvent.fromJson(json);
+
+      expect(event.blockNumber, 197242);
+      expect(event.amount, BigInt.parse('1000000000'));
+    });
+
+    test('parses FCM-style string-encoded nested objects and int amounts', () {
+      final json = <String, dynamic>{
+        'amount': 1000000000,
+        'fee': 8189972000,
+        'sender': '{"id":"qzjij4Tiow9jtse9d7L1T3NEZuxgFW8JdUbaTLsfgubF7ZQAC"}',
+        'id': '0000197378-4f5d2-000002',
+        'receiver':
+            '{"id":"qzpyxSr48YN9EQe2ito734iCReTXjnungmNCSY4Yph1YznEda"}',
+        'block':
+            '{"hash":"0x4f5d27e7b1c679e64292606c9560432f610f7a6fccab992f5ab6326f5171f90c","height":197378}',
+        'extrinsicHash':
+            '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7',
+        'timestamp': '2026-05-12T13:08:21.846Z',
+      };
+
+      final event = TransferEvent.fromJson(json);
+
+      expect(event.blockNumber, 197378);
+      expect(
+        event.extrinsicHash,
+        '0xc399a24c2cd9b3a85f2b10cdb6a0bb98ff8f02eb8185c23959f9b7e7d943a9b7',
+      );
+      expect(event.amount, BigInt.from(1000000000));
+      expect(event.fee, BigInt.from(8189972000));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Updated how we parse json for tx event, since FCM seems to stringify each nested object
- Show tx detail on processing tx event
- Add unit tests

Already tested on my iPhone 14 it works!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes push-notification/deep-link handling and transaction JSON deserialization (including SDK model parsing), which can affect navigation and transaction display across multiple entry points.
> 
> **Overview**
> Restores notification-driven navigation by removing the global `navigatorKey` pattern and routing everything through Riverpod *intent* providers.
> 
> Push/local notification taps and app launches now set `transactionIntentProvider`, and `HomeScreen` consumes intents in `initState` to open `showTransactionDetailSheet` (also making the sheet tolerate a missing active account id). Local-notification payload decoding is wrapped with error handling and telemetry.
> 
> Improves transaction event parsing to support FCM-style payloads (string-encoded nested objects, int amounts, top-level `extrinsicHash`) via new SDK helpers in `json_dynamic_parse.dart`, updates `TransferEvent`/`ReversibleTransferEvent` deserialization accordingly, and adds unit tests in both the app and `quantus_sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8979cde35f677e4fc43a4ee2b8865dd77958975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->