### PR TITLE
simplified version with transport always in quan

### DIFF
--- a/mobile-app/lib/providers/route_intent_providers.dart
+++ b/mobile-app/lib/providers/route_intent_providers.dart
@@ -11,8 +11,6 @@ class PaymentIntent {
 
   const PaymentIntent({required this.to, required this.amount, this.ref});
 
-  BigInt? amountPlanck(NumberFormattingService formatting) => formatting.parseWireAmount(amount);
-
   static PaymentIntent? tryParseUrl(String input) {
     final uri = Uri.tryParse(input);
     if (uri == null || uri.pathSegments.isEmpty || uri.pathSegments.first != 'pay') return null;

--- a/mobile-app/lib/shared/utils/amount_input_logic.dart
+++ b/mobile-app/lib/shared/utils/amount_input_logic.dart
@@ -17,13 +17,6 @@ class ToggledInputResult {
   int get hashCode => text.hashCode ^ amount.hashCode;
 }
 
-class PaymentUrlAmountResult {
-  final BigInt planck;
-  final String displayText;
-
-  const PaymentUrlAmountResult({required this.planck, required this.displayText});
-}
-
 class AmountInputLogic {
   final ExchangeRateService exchangeRateService;
   final FiatCurrency selectedFiat;
@@ -54,17 +47,6 @@ class AmountInputLogic {
     if (fiatText.isEmpty) return BigInt.zero;
     final fiatDecimal = localeConfig.parseDecimal(fiatText);
     return exchangeRateService.fiatToQuanRaw(fiatDecimal, selectedFiat, AppConstants.decimals);
-  }
-
-  /// Parses a payment URL amount and formats it for the user's locale.
-  PaymentUrlAmountResult parsePaymentUrlAmount(String wireAmount, {required bool isFlipped}) {
-    final planck = formattingService.parseWireAmount(wireAmount) ?? BigInt.zero;
-    final displayText = planck == BigInt.zero
-        ? ''
-        : isFlipped
-        ? quanToFiatString(planck)
-        : formatQuanAmount(planck);
-    return PaymentUrlAmountResult(planck: planck, displayText: displayText);
   }
 
   /// Parses a QUAN amount string.

--- a/mobile-app/lib/v2/screens/pos/pos_amount_screen.dart
+++ b/mobile-app/lib/v2/screens/pos/pos_amount_screen.dart
@@ -54,8 +54,7 @@ class _PosAmountScreenState extends ConsumerState<PosAmountScreen> {
 
   void _onCharge() {
     if (_amount <= BigInt.zero) return;
-    final quanString = _amountInputLogic.formatQuanAmount(_amount);
-    Navigator.push(context, MaterialPageRoute(builder: (_) => PosQrScreen(amount: quanString)));
+    Navigator.push(context, MaterialPageRoute(builder: (_) => PosQrScreen(amountPlanck: _amount)));
   }
 
   Future<void> _toggleFlip() async {

--- a/mobile-app/lib/v2/screens/pos/pos_qr_screen.dart
+++ b/mobile-app/lib/v2/screens/pos/pos_qr_screen.dart
@@ -23,8 +23,8 @@ import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
 
 class PosQrScreen extends ConsumerStatefulWidget {
-  final String amount;
-  const PosQrScreen({super.key, required this.amount});
+  final BigInt amountPlanck;
+  const PosQrScreen({super.key, required this.amountPlanck});
 
   @override
   ConsumerState<PosQrScreen> createState() => _PosQrScreenState();
@@ -50,13 +50,11 @@ class _PosQrScreenState extends ConsumerState<PosQrScreen> {
   }
 
   void _startWatching() {
-    final formattingService = ref.watch(numberFormattingServiceProvider);
     final active = ref.read(activeAccountProvider).value;
     if (active == null) return;
 
-    final expectedPlanck = formattingService.parseAmount(widget.amount);
-    if (expectedPlanck == null) {
-      print('[PosQr] ERROR: failed to parse amount "${widget.amount}"');
+    if (widget.amountPlanck <= BigInt.zero) {
+      print('[PosQr] ERROR: invalid amount planck ${widget.amountPlanck}');
       if (mounted) setState(() => _watchError = 'Invalid amount. Tap to retry.');
       return;
     }
@@ -66,15 +64,15 @@ class _PosQrScreenState extends ConsumerState<PosQrScreen> {
       _watchError = null;
     });
 
-    print('[PosQr] watching address=${active.account.accountId} expected=$expectedPlanck planck');
+    print('[PosQr] watching address=${active.account.accountId} expected=${widget.amountPlanck} planck');
     _txWatch.watch(
       address: active.account.accountId,
       onTransfer: (tx) {
         print('[PosQr] onTransfer from=${tx.from} amount=${tx.amount} hash=${tx.txHash}');
         if (_isPaid) return;
         final received = BigInt.tryParse(tx.amount);
-        if (received != expectedPlanck) {
-          print('[PosQr] amount mismatch (received=$received expected=$expectedPlanck), ignoring');
+        if (received != widget.amountPlanck) {
+          print('[PosQr] amount mismatch (received=$received expected=${widget.amountPlanck}), ignoring');
           return;
         }
 
@@ -83,7 +81,7 @@ class _PosQrScreenState extends ConsumerState<PosQrScreen> {
           tempId: 'pending_recv_${DateTime.now().millisecondsSinceEpoch}',
           from: tx.from,
           to: active.account.accountId,
-          amount: expectedPlanck,
+          amount: widget.amountPlanck,
           timestamp: DateTime.now(),
           transactionState: TransactionState.pending,
           isReversible: false,
@@ -162,8 +160,12 @@ class _PosQrScreenState extends ConsumerState<PosQrScreen> {
     final text = context.themeText;
     final accountAsync = ref.watch(activeAccountProvider);
     final formattingService = ref.watch(numberFormattingServiceProvider);
-    final planck = formattingService.parseAmount(widget.amount) ?? BigInt.zero;
-    final display = ref.watch(txAmountDisplayProvider)(planck, withSignPrefix: false, isSend: false, quanDecimals: 4);
+    final display = ref.watch(txAmountDisplayProvider)(
+      widget.amountPlanck,
+      withSignPrefix: false,
+      isSend: false,
+      quanDecimals: 4,
+    );
 
     return ScaffoldBase(
       appBar: V2AppBar(title: _isPaid ? 'Payment Received' : 'Scan to Pay'),
@@ -176,7 +178,7 @@ class _PosQrScreenState extends ConsumerState<PosQrScreen> {
           if (active == null) return const Center(child: Text('No active account'));
           _request ??= PosService(
             formattingService: formattingService,
-          ).createPaymentRequest(accountId: active.account.accountId, amountPlanck: planck);
+          ).createPaymentRequest(accountId: active.account.accountId, amountPlanck: widget.amountPlanck);
           if (_isPaid) return _buildPaidContent(colors, text, display.primaryAmount);
           return _buildQrContent(_request!, colors, text, display);
         },

--- a/mobile-app/lib/v2/screens/send/input_amount_screen.dart
+++ b/mobile-app/lib/v2/screens/send/input_amount_screen.dart
@@ -65,12 +65,14 @@ class _InputAmountScreenState extends ConsumerState<InputAmountScreen> {
     super.initState();
     assert(widget.recipientAddress.trim().isNotEmpty, 'InputAmountScreen requires a recipient');
     _amountFocus.addListener(_onAmountFocusChanged);
-    if (widget.initialAmount != null) {
-      final isFlipped = ref.read(isCurrencyFlippedProvider);
-      final parsed = _amountInputLogic.parsePaymentUrlAmount(widget.initialAmount!, isFlipped: isFlipped);
-      if (parsed.planck > BigInt.zero) {
-        _amount = parsed.planck;
-        _amountController.text = parsed.displayText;
+    if (widget.initialAmount != null && widget.initialAmount!.isNotEmpty) {
+      final formattingService = ref.read(numberFormattingServiceProvider);
+      final planck = widget.isPayMode
+          ? formattingService.parseWireAmount(widget.initialAmount!) ?? BigInt.zero
+          : _amountInputLogic.parseQuanAmount(widget.initialAmount!);
+      if (planck > BigInt.zero) {
+        _amount = planck;
+        _amountController.text = _amountInputLogic.formatQuanAmount(planck);
       }
     }
     if (widget.recipientChecksum != null) {
@@ -116,7 +118,7 @@ class _InputAmountScreenState extends ConsumerState<InputAmountScreen> {
   }
 
   void _onAmountChanged(String _) {
-    final isFlipped = ref.read(isCurrencyFlippedProvider);
+    final isFlipped = widget.isPayMode ? false : ref.read(isCurrencyFlippedProvider);
     try {
       setState(() => _amount = _amountInputLogic.onAmountChanged(value: _amountController.text, isFlipped: isFlipped));
     } on InvalidNumberInputException catch (e, stack) {
@@ -337,7 +339,8 @@ class _InputAmountScreenState extends ConsumerState<InputAmountScreen> {
   }
 
   Widget _amountCenter(AppColorsV2 colors, AppTextTheme text) {
-    final isFlipped = ref.watch(isCurrencyFlippedProvider);
+    final isPayMode = widget.isPayMode;
+    final isFlipped = isPayMode ? false : ref.watch(isCurrencyFlippedProvider);
     final selectedFiat = ref.watch(selectedFiatCurrencyProvider);
     final localeConfig = ref.watch(localeNumberConfigProvider);
     final display = ref.watch(txAmountDisplayProvider)(
@@ -393,26 +396,28 @@ class _InputAmountScreenState extends ConsumerState<InputAmountScreen> {
               children: primaryRowChildren,
             ),
           ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                '≈ ${display.secondaryAmount}',
-                style: text.paragraph?.copyWith(
-                  color: colors.textTertiary,
-                  fontFamily: AppTextTheme.fontFamilySecondary,
+          if (!isPayMode) ...[
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  '≈ ${display.secondaryAmount}',
+                  style: text.paragraph?.copyWith(
+                    color: colors.textTertiary,
+                    fontFamily: AppTextTheme.fontFamilySecondary,
+                  ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              QuantusIconButton.circular(
-                icon: Icons.swap_vert,
-                onTap: _toggleFlip,
-                isActive: display.isFlipped,
-                size: IconButtonSize.small,
-              ),
-            ],
-          ),
+                const SizedBox(width: 8),
+                QuantusIconButton.circular(
+                  icon: Icons.swap_vert,
+                  onTap: _toggleFlip,
+                  isActive: display.isFlipped,
+                  size: IconButtonSize.small,
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );

--- a/mobile-app/lib/v2/screens/send/select_recipient_screen.dart
+++ b/mobile-app/lib/v2/screens/send/select_recipient_screen.dart
@@ -4,11 +4,9 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/features/components/dotted_border.dart';
 import 'package:resonance_network_wallet/features/components/skeleton.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
-import 'package:resonance_network_wallet/providers/currency_display_provider.dart';
 import 'package:resonance_network_wallet/providers/route_intent_providers.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/routes.dart';
-import 'package:resonance_network_wallet/shared/utils/amount_input_logic.dart';
 import 'package:resonance_network_wallet/v2/components/address_checkphrase_with_initial.dart';
 import 'package:resonance_network_wallet/v2/components/loader.dart';
 import 'package:resonance_network_wallet/v2/components/qr_scanner_page.dart';
@@ -133,17 +131,9 @@ class _SelectRecipientScreenState extends ConsumerState<SelectRecipientScreen> {
     if (scanResult == null || !mounted) return;
     final payment = PaymentIntent.tryParseUrl(scanResult);
     if (payment != null) {
-      final amountInputLogic = AmountInputLogic(
-        exchangeRateService: ref.read(exchangeRateServiceProvider),
-        selectedFiat: ref.read(selectedFiatCurrencyProvider),
-        localeConfig: ref.read(localeNumberConfigProvider),
-        formattingService: ref.read(numberFormattingServiceProvider),
-      );
-      final isFlipped = ref.read(isCurrencyFlippedProvider);
-      final parsed = amountInputLogic.parsePaymentUrlAmount(payment.amount, isFlipped: isFlipped);
       setState(() {
         _recipientController.text = payment.to;
-        _amountController.text = parsed.displayText;
+        _amountController.text = payment.amount;
         _isPayMode = true;
       });
     } else {

--- a/mobile-app/test/unit/amount_input_logic_test.dart
+++ b/mobile-app/test/unit/amount_input_logic_test.dart
@@ -78,38 +78,5 @@ void main() {
       expect(logic.formatQuanAmount(BigInt.zero), '');
     });
 
-    test('parsePaymentUrlAmount localizes canonical wire amount for payer locale', () {
-      final logic = createLogic();
-      final result = logic.parsePaymentUrlAmount('1.5', isFlipped: false);
-
-      expect(result.planck, BigInt.from(1500000000000));
-      expect(result.displayText, '1.5');
-    });
-
-    test('parsePaymentUrlAmount localizes legacy comma-decimal wire amount', () {
-      final logic = createLogic();
-      final result = logic.parsePaymentUrlAmount('1,5', isFlipped: false);
-
-      expect(result.planck, BigInt.from(1500000000000));
-      expect(result.displayText, '1.5');
-    });
-
-    test('parsePaymentUrlAmount displays comma decimal for comma-locale payers', () {
-      localeConfig = LocaleNumberConfig.commaDecimal;
-      formattingService = NumberFormattingService(localeConfig: localeConfig);
-      final logic = createLogic();
-      final result = logic.parsePaymentUrlAmount('1.5', isFlipped: false);
-
-      expect(result.planck, BigInt.from(1500000000000));
-      expect(result.displayText, '1,5');
-    });
-
-    test('parsePaymentUrlAmount returns empty display text for zero amount', () {
-      final logic = createLogic();
-      final result = logic.parsePaymentUrlAmount('', isFlipped: false);
-
-      expect(result.planck, BigInt.zero);
-      expect(result.displayText, '');
-    });
   });
 }

--- a/mobile-app/test/unit/amount_input_logic_test.dart
+++ b/mobile-app/test/unit/amount_input_logic_test.dart
@@ -77,6 +77,5 @@ void main() {
       final logic = createLogic();
       expect(logic.formatQuanAmount(BigInt.zero), '');
     });
-
   });
 }


### PR DESCRIPTION
Prompt: I want this to work as follows

- users can enter their fiat currency that's fine in POS Mode - normal switch between quan/fiat
- data transport layer alwyas sends QUAN, we also check for Quan paid on the other end
- URL encoded value is Quan
- Quick check on POS checks quan amount (has always done that)
- On the receiving end, the user sees the value in Quan, we ignore fiat / quan settings for this, we show them exactly how many quan they're sending