### PR TITLE
Some fixes

### DIFF
--- a/mobile-app/lib/v2/screens/accounts/create_account_screen.dart
+++ b/mobile-app/lib/v2/screens/accounts/create_account_screen.dart
@@ -29,9 +29,8 @@ class _CreateAccountScreenState extends ConsumerState<CreateAccountScreen> {
   List<Account> _accounts = [];
   int _walletIndex = 0;
   bool _isLoading = false;
-  String? _error;
 
-  bool get _isDisabled => _accountName.text.isEmpty || _isLoading || _error != null;
+  bool get _isDisabled => _accountName.text.trim().isEmpty || _isLoading;
 
   int _walletIndexForActiveAccount(List<Account> accounts, DisplayAccount? activeDisplayAccount) {
     if (activeDisplayAccount is RegularAccount) {
@@ -126,7 +125,7 @@ class _CreateAccountScreenState extends ConsumerState<CreateAccountScreen> {
 
     return ScaffoldBase(
       appBar: V2AppBar(title: l10n.createAccountAppBarTitle),
-      mainContent: NameField(controller: _accountName, subtitle: l10n.createAccountSubtitle, error: _error),
+      mainContent: NameField(controller: _accountName, subtitle: l10n.createAccountSubtitle),
       bottomContent: ScaffoldBaseBottomContent(
         child: QuantusButton.simple(
           label: l10n.createAccountButton,

--- a/mobile-app/lib/v2/screens/accounts/edit_account_screen.dart
+++ b/mobile-app/lib/v2/screens/accounts/edit_account_screen.dart
@@ -24,6 +24,8 @@ class EditAccountScreenState extends ConsumerState<EditAccountScreen> {
   final _accountsService = AccountsService();
   bool _saving = false;
 
+  bool get _isDisabled => _controller.text.trim().isEmpty;
+
   @override
   void initState() {
     super.initState();
@@ -82,6 +84,7 @@ class EditAccountScreenState extends ConsumerState<EditAccountScreen> {
           label: l10n.editAccountDone,
           onTap: _save,
           isLoading: _saving,
+          isDisabled: _isDisabled,
         ),
       ),
     );

--- a/mobile-app/lib/v2/screens/settings/mining_rewards_screen.dart
+++ b/mobile-app/lib/v2/screens/settings/mining_rewards_screen.dart
@@ -8,9 +8,7 @@ import 'package:resonance_network_wallet/providers/mining_rewards_provider.dart'
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/services/mining_rewards_service.dart';
 import 'package:resonance_network_wallet/shared/utils/open_external_url.dart';
-import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
-import 'package:resonance_network_wallet/v2/components/scaffold_base_bottom_content.dart';
 import 'package:resonance_network_wallet/v2/components/split_card.dart';
 import 'package:resonance_network_wallet/v2/components/v2_app_bar.dart';
 import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
@@ -37,13 +35,14 @@ class MiningRewardsScreen extends ConsumerWidget {
               _ErrorState(colors: colors, text: text, l10n: l10n, onRetry: () => ref.invalidate(miningRewardsProvider)),
         ),
       ],
-      bottomContent: miningAsync.when(
-        data: (data) => data.totalBlocks > 0
-            ? ScaffoldBaseBottomContent(child: QuantusButton.simple(label: l10n.settingsMiningRedeem, onTap: null))
-            : null,
-        loading: () => null,
-        error: (err, _) => null,
-      ),
+      // TODO: Enable redeem button when it is implemented
+      // bottomContent: miningAsync.when(
+      //   data: (data) => data.totalBlocks > 0
+      //       ? ScaffoldBaseBottomContent(child: QuantusButton.simple(label: l10n.settingsMiningRedeem, onTap: null))
+      //       : null,
+      //   loading: () => null,
+      //   error: (err, _) => null,
+      // ),
     );
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI/validation tweaks on account screens and removal of a non-functional mining button; no auth, payments, or persistence logic changes.
> 
> **Overview**
> Tightens account name flows and hides unfinished mining redeem UI.
> 
> **Create account** drops inline `_error` on `NameField` and no longer disables the primary action because of that state. The create button stays disabled only when the trimmed name is empty or a create is in progress.
> 
> **Edit account** now disables **Done** when the trimmed name is empty, matching create behavior and avoiding a no-op save tap (empty names still show a toaster in `_save` if reached).
> 
> **Mining rewards** removes the bottom **Redeem** bar (it had `onTap: null`) and comments it with a TODO until redeem is implemented; related button/scaffold imports are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d243b2f525e31027bca19d2e5cfb6018ad54f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->