### PR TITLE
Update Android toolchain to AGP 9.2.0 / Gradle 9.5.1 / Kotlin 2.3.21

### DIFF
--- a/mobile-app/android/build.gradle
+++ b/mobile-app/android/build.gradle
@@ -1,13 +1,13 @@
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.3.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/mobile-app/android/gradle.properties
+++ b/mobile-app/android/gradle.properties
@@ -9,7 +9,13 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 # Disabled due to incompatibility with Flutter task and Cargokit plugin
 org.gradle.configuration-cache=false
-# This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false

--- a/mobile-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip

--- a/mobile-app/android/settings.gradle
+++ b/mobile-app/android/settings.gradle
@@ -18,11 +18,11 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.13.2' apply false
+    id "com.android.application" version '9.2.0' apply false
     // START: FlutterFire Configuration
-    id "com.google.gms.google-services" version "4.3.15" apply false
+    id "com.google.gms.google-services" version "4.4.4" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.21" apply false
 }
 
 include ":app"

--- a/quantus_sdk/rust_builder/cargokit/gradle/plugin.gradle
+++ b/quantus_sdk/rust_builder/cargokit/gradle/plugin.gradle
@@ -2,7 +2,9 @@
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
 import java.nio.file.Paths
+import javax.inject.Inject
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
 
 CargoKitPlugin.file = buildscript.sourceFile
 
@@ -42,6 +44,9 @@ abstract class CargoKitBuildTask extends DefaultTask {
     @Input
     List<String> targetPlatforms
 
+    @Inject
+    abstract ExecOperations getExecOperations()
+
     @TaskAction
     def build() {
         if (project.cargokit.manifestDir == null) {
@@ -58,14 +63,14 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def manifestDir = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.manifestDir)
 
         def rootProjectDir = project.rootProject.projectDir
-        
+
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            project.exec {
+            execOperations.exec {
                 commandLine 'chmod', '+x', path
             }
         }
-        
-        project.exec {
+
+        execOperations.exec {
             executable path
             args "build-gradle"
             environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir


### PR DESCRIPTION
## Summary

Upgrades the Android build to the latest stable toolchain versions and fixes the Gradle 9 incompatibility in the Cargokit Rust integration.

### Upgraded versions

| Tool | Before | After |
|------|--------|-------|
| Gradle | 8.13 | **9.5.1** |
| Android Gradle Plugin | 8.13.2 | **9.2.0** |
| Kotlin Gradle Plugin | 2.2.0 | **2.3.21** |
| Google Services plugin | 4.3.15 | **4.4.4** |

### Fixes

- **Cargokit Gradle 9 compatibility** (`quantus_sdk/rust_builder/cargokit/gradle/plugin.gradle`): Gradle 9 removed `Project.exec`, which the Cargokit plugin relied on, causing builds to fail with `Could not find method exec() for arguments [...] on project ':rust_lib_quantus_wallet'`. Migrated `CargoKitBuildTask` to use the injected `ExecOperations` service (the official replacement per [Gradle 9 upgrade guide](https://docs.gradle.org/9.5.0/userguide/upgrading_major_version_9.html#deprecated_project_exec)).
- **Google Services plugin bump to 4.4.4**: required for AGP 9.x compatibility (older versions referenced the now-removed `applicationVariants` API).
- **gradle.properties tweaks**: added several `android.*` flags surfaced by the AGP migrator.

### Known follow-ups (not in this PR)

- **Built-in Kotlin migration** is deferred: Flutter 3.44's own Gradle plugin doesn't yet support `android.newDsl=true`, and many third-party Flutter plugins (`flutter_timezone`, `local_auth_android`, `mobile_scanner`, `play_install_referrer`, `share_plus`, `shared_preferences_android`, `telemetrydecksdk`, `app_links`, ...) still apply the legacy `kotlin-android` plugin. The Flutter team explicitly recommends keeping `builtInKotlin=false` and `newDsl=false` until those migrate. The "future Flutter" warnings during build are informational and not fatal.

## Test plan

- [x] `flutter build apk` succeeds (verified: `Built build/app/outputs/flutter-apk/app-release.apk (94.3MB)` in ~93s)
- [x] Smoke-test the release APK on a physical Android device
- [x] Verify the Rust bridge (`rust_lib_quantus_wallet`) still works at runtime (key signing, wormhole, etc.)
- [x] Confirm Firebase / FCM still wires up correctly with `google-services` 4.4.4

## Notes
We get the following warnings on flutter builds - but "fixing" them causes actual build errors, so this is just flutter being a little bit retarded...

```
WARNING: Your Android app project: app located at: /Users/elohim/play/quantus-network/quantus-apps/mobile-app/android/app/build.gradle
applies the Kotlin Gradle Plugin, which will cause build failures in future versions of Flutter. 
Please migrate your app to Built-in Kotlin using this guide: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers

WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): flutter_timezone, local_auth_android, mobile_scanner, play_install_referrer, share_plus, shared_preferences_android, telemetrydecksdk
Future versions of Flutter will fail to build if your app uses plugins that apply KGP.

Please check the changelogs of these plugins and upgrade to a version that supports Built-in Kotlin.
If no such version exists, report the issue to the plugin. If necessary, here is a guide on filing 
an issue against a plugin: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers#report-incompatible-kotlin-gradle-plugin-usage-to-plugin-authors

```