### PR TITLE
Fix double spend bug

### DIFF
--- a/mobile-app/lib/services/transaction_submission_service.dart
+++ b/mobile-app/lib/services/transaction_submission_service.dart
@@ -41,8 +41,7 @@ class TransactionSubmissionService {
     // B. Immediately add it to the state so the UI can update
     _ref.read(pendingTransactionsProvider.notifier).add(pendingTx);
 
-    // C. Define the builder function that creates fresh submissions on each
-    // retry
+    // C. Submit once; SDK retries the same signed extrinsic on RPC failure.
 
     // ignore: prefer_function_declarations_over_variables
     final submissionBuilder = () => BalancesService().balanceTransfer(account, targetAddress, amount);
@@ -59,7 +58,6 @@ class TransactionSubmissionService {
     required BigInt amount,
     required int delaySeconds,
     required BigInt feeEstimate,
-    int maxRetries = 3,
     required int blockHeight,
   }) async {
     final pending = createPendingTransaction(
@@ -75,7 +73,7 @@ class TransactionSubmissionService {
     // Add to pending transactions so UI can show it immediately
     _ref.read(pendingTransactionsProvider.notifier).add(pending);
 
-    // Define the builder function that creates fresh submissions on each retry
+    // Submit once; SDK retries the same signed extrinsic on RPC failure.
 
     // ignore: prefer_function_declarations_over_variables
     final submissionBuilder = () => ReversibleTransfersService().scheduleReversibleTransferWithDelaySeconds(
@@ -87,7 +85,7 @@ class TransactionSubmissionService {
 
     TelemetryService().sendEvent('send_reversible');
 
-    await submitAndTrackTransaction(submissionBuilder, pending, maxRetries: maxRetries);
+    await submitAndTrackTransaction(submissionBuilder, pending);
   }
 
   Future<void> scheduleTransfer({
@@ -113,7 +111,7 @@ class TransactionSubmissionService {
     // B. Immediately add it to the state so the UI can update
     _ref.read(pendingTransactionsProvider.notifier).add(pendingTx);
 
-    // C. Define the builder function that creates fresh submissions on each retry
+    // C. Submit once; SDK retries the same signed extrinsic on RPC failure.
     Future<Uint8List> submissionBuilder() async {
       return ReversibleTransfersService().scheduleReversibleTransfer(
         account: account,
@@ -154,28 +152,23 @@ class TransactionSubmissionService {
 
   // This is the generic tracking logic, extracted from WalletStateManager
   /// Submits a transaction and tracks its status. Returns immediately without
-  /// waiting.
-  /// Handles retries in the background for 'invalid' status.
-  /// submissionBuilder: Function that creates fresh submission on each retry
+  /// waiting. RPC retries are handled inside [SubstrateService.submitExtrinsic].
   Future<void> submitAndTrackTransaction(
     Future<Uint8List> Function() submissionBuilder,
-    PendingTransactionEvent pendingTx, {
-    int maxRetries = 3,
-  }) async {
+    PendingTransactionEvent pendingTx,
+  ) async {
     // Start the submission process in the background
     // This allows the UI to continue immediately
-    unawaited(_submitAndTrackBackground(submissionBuilder, pendingTx, maxRetries: maxRetries));
+    unawaited(_submitAndTrackBackground(submissionBuilder, pendingTx));
   }
 
-  /// Background submission with retry logic - runs asynchronously
+  /// Background submission - runs asynchronously
   Future<void> _submitAndTrackBackground(
     Future<Uint8List> Function() submissionBuilder,
-    PendingTransactionEvent pendingTx, {
-    required int maxRetries,
-    int attempt = 1,
-  }) async {
+    PendingTransactionEvent pendingTx,
+  ) async {
     try {
-      quantusDebugPrint('Submitting transaction attempt $attempt/$maxRetries: ${pendingTx.id}');
+      quantusDebugPrint('Submitting transaction: ${pendingTx.id}');
 
       final extrinsicHashBytes = await submissionBuilder();
       final extrinsicHash = '0x${hex.encode(extrinsicHashBytes)}';
@@ -189,27 +182,17 @@ class TransactionSubmissionService {
 
       _startPollingForTransaction(pendingTx.copyWith(extrinsicHash: extrinsicHash));
     } catch (e, stackTrace) {
-      quantusDebugPrint('Failed submitting transaction attempt $attempt: $e');
+      quantusDebugPrint('Failed submitting transaction: $e');
+      quantusDebugPrint('Stack trace: $stackTrace');
 
-      if (attempt < maxRetries) {
-        quantusDebugPrint('Retrying due to submission error, attempt ${attempt + 1}/$maxRetries');
-        // Brief delay before retry
-        await Future.delayed(const Duration(seconds: 2));
-        await _submitAndTrackBackground(submissionBuilder, pendingTx, maxRetries: maxRetries, attempt: attempt + 1);
-      } else {
-        quantusDebugPrint('Failed to submit transaction after $maxRetries attempts: $e');
-        quantusDebugPrint('Stack trace: $stackTrace');
-
-        // Mark as permanently failed
-        _ref
-            .read(pendingTransactionsProvider.notifier)
-            .updateState(
-              pendingTx.id,
-              TransactionState.failed,
-              error: 'Failed to submit after $maxRetries attempts: $e',
-            );
-        _ref.read(pendingTransactionsProvider.notifier).remove(pendingTx.id);
-      }
+      _ref
+          .read(pendingTransactionsProvider.notifier)
+          .updateState(
+            pendingTx.id,
+            TransactionState.failed,
+            error: 'Failed to submit transaction: $e',
+          );
+      _ref.read(pendingTransactionsProvider.notifier).remove(pendingTx.id);
     }
   }
 

--- a/mobile-app/lib/services/transaction_submission_service.dart
+++ b/mobile-app/lib/services/transaction_submission_service.dart
@@ -187,11 +187,7 @@ class TransactionSubmissionService {
 
       _ref
           .read(pendingTransactionsProvider.notifier)
-          .updateState(
-            pendingTx.id,
-            TransactionState.failed,
-            error: 'Failed to submit transaction: $e',
-          );
+          .updateState(pendingTx.id, TransactionState.failed, error: 'Failed to submit transaction: $e');
       _ref.read(pendingTransactionsProvider.notifier).remove(pendingTx.id);
     }
   }

--- a/mobile-app/lib/v2/screens/send/review_send_screen.dart
+++ b/mobile-app/lib/v2/screens/send/review_send_screen.dart
@@ -52,6 +52,8 @@ class _ReviewSendScreenState extends ConsumerState<ReviewSendScreen> {
   }
 
   Future<void> _confirmSend() async {
+    if (_submitting) return;
+
     setState(() {
       _submitting = true;
       _errorMessage = null;

--- a/quantus_sdk/lib/src/extensions/keypair_extensions.dart
+++ b/quantus_sdk/lib/src/extensions/keypair_extensions.dart
@@ -8,9 +8,7 @@ extension KeypairExtensions on crypto.Keypair {
   Uint8List get addressBytes => Address.decode(ss58Address).pubkey;
 
   /// Hedged (randomized) ML-DSA signature. Fresh entropy is generated per call.
-  Uint8List sign(List<int> message) =>
-      crypto.signMessage(keypair: this, message: message, entropy: _hedgeEntropy());
-
+  Uint8List sign(List<int> message) => crypto.signMessage(keypair: this, message: message, entropy: _hedgeEntropy());
 }
 
 crypto.U8Array32 _hedgeEntropy() {

--- a/quantus_sdk/lib/src/services/extrinsic_submission_utils.dart
+++ b/quantus_sdk/lib/src/services/extrinsic_submission_utils.dart
@@ -13,7 +13,5 @@ Uint8List localExtrinsicHash(Uint8List extrinsic) {
 /// extrinsic is submitted again.
 bool isAlreadyImportedError(Object error) {
   final message = error.toString().toLowerCase();
-  return message.contains('1013') ||
-      message.contains('already imported') ||
-      message.contains('already in pool');
+  return message.contains('1013') || message.contains('already imported') || message.contains('already in pool');
 }

--- a/quantus_sdk/lib/src/services/extrinsic_submission_utils.dart
+++ b/quantus_sdk/lib/src/services/extrinsic_submission_utils.dart
@@ -1,0 +1,19 @@
+import 'dart:typed_data';
+
+import 'package:polkadart/polkadart.dart';
+
+/// Returns the Blake2b-256 hash of a signed extrinsic payload.
+Uint8List localExtrinsicHash(Uint8List extrinsic) {
+  return Hasher.blake2b256.hash(extrinsic);
+}
+
+/// Whether an RPC error indicates the extrinsic is already in the pool.
+///
+/// Substrate returns code 1013 ("Already Imported") when the same signed
+/// extrinsic is submitted again.
+bool isAlreadyImportedError(Object error) {
+  final message = error.toString().toLowerCase();
+  return message.contains('1013') ||
+      message.contains('already imported') ||
+      message.contains('already in pool');
+}

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -177,20 +177,20 @@ class SubstrateService {
     for (var attempt = 0; attempt < maxRetries; attempt++) {
       try {
         final result = await _submitExtrinsic(extrinsic);
-        print('result: $result');
+        debugPrint('result: $result');
         return result;
       } catch (e) {
         if (isAlreadyImportedError(e)) {
-          print('Extrinsic already in pool, returning local hash');
+          debugPrint('Extrinsic already in pool, returning local hash');
           return localExtrinsicHash(extrinsic);
         }
 
         if (attempt >= maxRetries - 1) {
-          print('Failed to submit extrinsic after $maxRetries retries: $e');
+          debugPrint('Failed to submit extrinsic after $maxRetries retries: $e');
           rethrow;
         }
 
-        print('Failed to submit extrinsic, retrying... ${attempt + 1} error: $e');
+        debugPrint('Failed to submit extrinsic, retrying... ${attempt + 1} error: $e');
         await Future.delayed(Duration(milliseconds: 500 * (attempt + 1)));
       }
     }

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -7,6 +7,7 @@ import 'package:polkadart/polkadart.dart';
 import 'package:quantus_sdk/generated/planck/planck.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:quantus_sdk/src/resonance_extrinsic_payload.dart';
+import 'package:quantus_sdk/src/services/extrinsic_submission_utils.dart';
 import 'package:quantus_sdk/src/rust/api/crypto.dart' as crypto;
 import 'package:ss58/ss58.dart';
 import 'package:quantus_sdk/src/extensions/address_extension.dart';
@@ -170,28 +171,30 @@ class SubstrateService {
   }
 
   Future<Uint8List> submitExtrinsic(Account account, RuntimeCall call, {int maxRetries = 3}) async {
-    int retryCount = 0;
-    while (retryCount < maxRetries) {
+    final extrinsicData = await getExtrinsicPayload(account, call);
+    final extrinsic = extrinsicData.payload;
+
+    for (var attempt = 0; attempt < maxRetries; attempt++) {
       try {
-        final extrinsicData = await getExtrinsicPayload(account, call);
-        Uint8List extrinsic = extrinsicData.payload;
-
-        // final result = await _authorApi!.submitExtrinsic(extrinsic);
         final result = await _submitExtrinsic(extrinsic);
-
         print('result: $result');
-
         return result;
       } catch (e) {
-        retryCount++;
-        if (retryCount >= maxRetries) {
+        if (isAlreadyImportedError(e)) {
+          print('Extrinsic already in pool, returning local hash');
+          return localExtrinsicHash(extrinsic);
+        }
+
+        if (attempt >= maxRetries - 1) {
           print('Failed to submit extrinsic after $maxRetries retries: $e');
           rethrow;
         }
-        print('Failed to submit extrinsic, retrying... $retryCount error: $e');
-        await Future.delayed(Duration(milliseconds: 500 * retryCount));
+
+        print('Failed to submit extrinsic, retrying... ${attempt + 1} error: $e');
+        await Future.delayed(Duration(milliseconds: 500 * (attempt + 1)));
       }
     }
+
     throw Exception('Failed to submit extrinsic after $maxRetries retries.');
   }
 

--- a/quantus_sdk/rust/Cargo.lock
+++ b/quantus_sdk/rust/Cargo.lock
@@ -2944,7 +2944,6 @@ dependencies = [
  "anyhow",
  "blake3",
  "flutter_rust_bridge",
- "getrandom 0.2.17",
  "hex",
  "nam-tiny-hderive",
  "qp-plonky2",

--- a/quantus_sdk/test/services/extrinsic_submission_utils_test.dart
+++ b/quantus_sdk/test/services/extrinsic_submission_utils_test.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quantus_sdk/src/services/extrinsic_submission_utils.dart';
+
+void main() {
+  group('isAlreadyImportedError', () {
+    test('returns true for Substrate error code 1013', () {
+      expect(
+        isAlreadyImportedError(Exception('RPC Error: 1013: Transaction Already Imported')),
+        isTrue,
+      );
+    });
+
+    test('returns true for already imported message', () {
+      expect(
+        isAlreadyImportedError(Exception('Already Imported')),
+        isTrue,
+      );
+    });
+
+    test('returns true for already in pool message', () {
+      expect(
+        isAlreadyImportedError(Exception('Transaction is already in pool')),
+        isTrue,
+      );
+    });
+
+    test('returns false for unrelated errors', () {
+      expect(
+        isAlreadyImportedError(Exception('Connection refused')),
+        isFalse,
+      );
+      expect(
+        isAlreadyImportedError(Exception('Invalid Transaction')),
+        isFalse,
+      );
+    });
+  });
+
+  group('localExtrinsicHash', () {
+    test('returns 32-byte hash for extrinsic bytes', () {
+      final extrinsic = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final hash = localExtrinsicHash(extrinsic);
+
+      expect(hash, hasLength(32));
+      expect(localExtrinsicHash(extrinsic), equals(hash));
+    });
+  });
+}

--- a/quantus_sdk/test/services/extrinsic_submission_utils_test.dart
+++ b/quantus_sdk/test/services/extrinsic_submission_utils_test.dart
@@ -6,35 +6,20 @@ import 'package:quantus_sdk/src/services/extrinsic_submission_utils.dart';
 void main() {
   group('isAlreadyImportedError', () {
     test('returns true for Substrate error code 1013', () {
-      expect(
-        isAlreadyImportedError(Exception('RPC Error: 1013: Transaction Already Imported')),
-        isTrue,
-      );
+      expect(isAlreadyImportedError(Exception('RPC Error: 1013: Transaction Already Imported')), isTrue);
     });
 
     test('returns true for already imported message', () {
-      expect(
-        isAlreadyImportedError(Exception('Already Imported')),
-        isTrue,
-      );
+      expect(isAlreadyImportedError(Exception('Already Imported')), isTrue);
     });
 
     test('returns true for already in pool message', () {
-      expect(
-        isAlreadyImportedError(Exception('Transaction is already in pool')),
-        isTrue,
-      );
+      expect(isAlreadyImportedError(Exception('Transaction is already in pool')), isTrue);
     });
 
     test('returns false for unrelated errors', () {
-      expect(
-        isAlreadyImportedError(Exception('Connection refused')),
-        isFalse,
-      );
-      expect(
-        isAlreadyImportedError(Exception('Invalid Transaction')),
-        isFalse,
-      );
+      expect(isAlreadyImportedError(Exception('Connection refused')), isFalse);
+      expect(isAlreadyImportedError(Exception('Invalid Transaction')), isFalse);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add early guard on confirmSend 
- Only send the same extrinsic without creating new one that cause nonce to be incremented
- Remove excessive looping on app level, only rely on SDK level

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core transaction submission and nonce handling for all sends; incorrect retry or hash logic could still drop or mis-track in-flight transfers.
> 
> **Overview**
> Fixes a **double-spend risk** where app-level submission retries re-ran the builder and signed **new** extrinsics (incrementing nonce) while an earlier attempt might already be in the pool.
> 
> **Mobile:** `TransactionSubmissionService` drops `maxRetries` and the recursive retry loop in `_submitAndTrackBackground`; each user action triggers a single `submissionBuilder()` call, with RPC resilience documented as living in `SubstrateService.submitExtrinsic`. **Review send** adds an early `if (_submitting) return` on confirm to block duplicate taps.
> 
> **SDK:** `submitExtrinsic` now builds and signs the payload **once**, then retries broadcasting the **same** signed bytes. New `extrinsic_submission_utils` treats Substrate **1013 / already imported** as success by returning `localExtrinsicHash(extrinsic)` so tracking can continue without re-signing. Unit tests cover the helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4eba5f84aa672ca8c1e633e05d7817b35f56512. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->