### PR TITLE
Onboarding flow update

### DIFF
--- a/mobile-app/lib/services/wallet_creation_service.dart
+++ b/mobile-app/lib/services/wallet_creation_service.dart
@@ -15,6 +15,26 @@ class CreatedWalletDetails {
   final String checksumPhrase;
 }
 
+class GeneratedWalletPreview {
+  const GeneratedWalletPreview({
+    required this.mnemonic,
+    required this.accountId,
+    required this.accountName,
+    required this.checksumPhrase,
+  });
+
+  final String mnemonic;
+  final String accountId;
+  final String accountName;
+  final String checksumPhrase;
+
+  CreatedWalletDetails toCreatedWalletDetails() => CreatedWalletDetails(
+    accountId: accountId,
+    accountName: accountName,
+    checksumPhrase: checksumPhrase,
+  );
+}
+
 class WalletCreationService {
   final SettingsService _settings;
   final AccountsService _accounts;
@@ -38,11 +58,9 @@ class WalletCreationService {
   final HdWalletService _hdWallet;
   final HumanReadableChecksumService _checksum;
 
-  /// Generates a mnemonic, persists the wallet, and returns display metadata.
-  Future<CreatedWalletDetails> createWalletWithGeneratedMnemonic({
-    required List<Account> existingAccounts,
+  /// Generates a mnemonic and display metadata without persisting.
+  Future<GeneratedWalletPreview> generateWalletPreview({
     String accountName = 'Account 1',
-    int walletIndex = 0,
   }) async {
     final mnemonic = await _substrate.generateMnemonic();
     if (mnemonic.isEmpty) {
@@ -52,18 +70,42 @@ class WalletCreationService {
     final accountId = _hdWallet.keyPairAtIndex(mnemonic, 0).ss58Address;
     final checksumPhrase = await _checksum.getHumanReadableName(accountId);
 
-    await createNewWallet(
-      name: accountName,
+    return GeneratedWalletPreview(
       mnemonic: mnemonic,
-      walletIndex: walletIndex,
-      accountId: accountId,
-      existingAccounts: existingAccounts,
-    );
-
-    return CreatedWalletDetails(
       accountId: accountId,
       accountName: accountName,
       checksumPhrase: checksumPhrase,
+    );
+  }
+
+  /// Persists a previously generated wallet and returns display metadata.
+  Future<CreatedWalletDetails> persistWalletPreview({
+    required GeneratedWalletPreview preview,
+    required List<Account> existingAccounts,
+    int walletIndex = 0,
+  }) async {
+    await createNewWallet(
+      name: preview.accountName,
+      mnemonic: preview.mnemonic,
+      walletIndex: walletIndex,
+      accountId: preview.accountId,
+      existingAccounts: existingAccounts,
+    );
+
+    return preview.toCreatedWalletDetails();
+  }
+
+  /// Generates a mnemonic, persists the wallet, and returns display metadata.
+  Future<CreatedWalletDetails> createWalletWithGeneratedMnemonic({
+    required List<Account> existingAccounts,
+    String accountName = 'Account 1',
+    int walletIndex = 0,
+  }) async {
+    final preview = await generateWalletPreview(accountName: accountName);
+    return persistWalletPreview(
+      preview: preview,
+      existingAccounts: existingAccounts,
+      walletIndex: walletIndex,
     );
   }
 

--- a/mobile-app/lib/services/wallet_creation_service.dart
+++ b/mobile-app/lib/services/wallet_creation_service.dart
@@ -4,11 +4,7 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/services/referral_service.dart';
 
 class CreatedWalletDetails {
-  const CreatedWalletDetails({
-    required this.accountId,
-    required this.accountName,
-    required this.checksumPhrase,
-  });
+  const CreatedWalletDetails({required this.accountId, required this.accountName, required this.checksumPhrase});
 
   final String accountId;
   final String accountName;
@@ -28,11 +24,8 @@ class GeneratedWalletPreview {
   final String accountName;
   final String checksumPhrase;
 
-  CreatedWalletDetails toCreatedWalletDetails() => CreatedWalletDetails(
-    accountId: accountId,
-    accountName: accountName,
-    checksumPhrase: checksumPhrase,
-  );
+  CreatedWalletDetails toCreatedWalletDetails() =>
+      CreatedWalletDetails(accountId: accountId, accountName: accountName, checksumPhrase: checksumPhrase);
 }
 
 class WalletCreationService {
@@ -59,9 +52,7 @@ class WalletCreationService {
   final HumanReadableChecksumService _checksum;
 
   /// Generates a mnemonic and display metadata without persisting.
-  Future<GeneratedWalletPreview> generateWalletPreview({
-    String accountName = 'Account 1',
-  }) async {
+  Future<GeneratedWalletPreview> generateWalletPreview({String accountName = 'Account 1'}) async {
     final mnemonic = await _substrate.generateMnemonic();
     if (mnemonic.isEmpty) {
       throw Exception('Mnemonic generation returned empty.');
@@ -102,11 +93,7 @@ class WalletCreationService {
     int walletIndex = 0,
   }) async {
     final preview = await generateWalletPreview(accountName: accountName);
-    return persistWalletPreview(
-      preview: preview,
-      existingAccounts: existingAccounts,
-      walletIndex: walletIndex,
-    );
+    return persistWalletPreview(preview: preview, existingAccounts: existingAccounts, walletIndex: walletIndex);
   }
 
   /// Saves [mnemonic] for [walletIndex], adds the root account when missing,

--- a/mobile-app/lib/services/wallet_creation_service.dart
+++ b/mobile-app/lib/services/wallet_creation_service.dart
@@ -3,6 +3,18 @@ import 'dart:async';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/services/referral_service.dart';
 
+class CreatedWalletDetails {
+  const CreatedWalletDetails({
+    required this.accountId,
+    required this.accountName,
+    required this.checksumPhrase,
+  });
+
+  final String accountId;
+  final String accountName;
+  final String checksumPhrase;
+}
+
 class WalletCreationService {
   final SettingsService _settings;
   final AccountsService _accounts;
@@ -12,9 +24,48 @@ class WalletCreationService {
     SettingsService? settingsService,
     AccountsService? accountsService,
     ReferralService? referralService,
+    SubstrateService? substrateService,
+    HdWalletService? hdWalletService,
+    HumanReadableChecksumService? checksumService,
   }) : _settings = settingsService ?? SettingsService(),
        _accounts = accountsService ?? AccountsService(),
-       _referral = referralService ?? ReferralService();
+       _referral = referralService ?? ReferralService(),
+       _substrate = substrateService ?? SubstrateService(),
+       _hdWallet = hdWalletService ?? HdWalletService(),
+       _checksum = checksumService ?? HumanReadableChecksumService();
+
+  final SubstrateService _substrate;
+  final HdWalletService _hdWallet;
+  final HumanReadableChecksumService _checksum;
+
+  /// Generates a mnemonic, persists the wallet, and returns display metadata.
+  Future<CreatedWalletDetails> createWalletWithGeneratedMnemonic({
+    required List<Account> existingAccounts,
+    String accountName = 'Account 1',
+    int walletIndex = 0,
+  }) async {
+    final mnemonic = await _substrate.generateMnemonic();
+    if (mnemonic.isEmpty) {
+      throw Exception('Mnemonic generation returned empty.');
+    }
+
+    final accountId = _hdWallet.keyPairAtIndex(mnemonic, 0).ss58Address;
+    final checksumPhrase = await _checksum.getHumanReadableName(accountId);
+
+    await createNewWallet(
+      name: accountName,
+      mnemonic: mnemonic,
+      walletIndex: walletIndex,
+      accountId: accountId,
+      existingAccounts: existingAccounts,
+    );
+
+    return CreatedWalletDetails(
+      accountId: accountId,
+      accountName: accountName,
+      checksumPhrase: checksumPhrase,
+    );
+  }
 
   /// Saves [mnemonic] for [walletIndex], adds the root account when missing,
   /// and runs referral registration for brand-new roots.

--- a/mobile-app/lib/v2/components/seed_phrase_controller.dart
+++ b/mobile-app/lib/v2/components/seed_phrase_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Masks seed phrase input while keeping the underlying [text] intact.
+class SeedPhraseController extends TextEditingController {
+  bool obscure = true;
+
+  static String _mask(String text) => text.replaceAllMapped(RegExp(r'\S'), (_) => '*');
+
+  @override
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
+    final text = value.text;
+    final display = obscure ? _mask(text) : text;
+
+    if (!withComposing || !value.composing.isValid) {
+      return TextSpan(style: style, text: display);
+    }
+
+    final composingStart = value.composing.start;
+    final composingEnd = value.composing.end;
+
+    return TextSpan(
+      style: style,
+      children: [
+        TextSpan(text: display.substring(0, composingStart)),
+        TextSpan(
+          style: style?.copyWith(decoration: TextDecoration.underline, decorationColor: style.color),
+          text: display.substring(composingStart, composingEnd),
+        ),
+        TextSpan(text: display.substring(composingEnd)),
+      ],
+    );
+  }
+}

--- a/mobile-app/lib/v2/screens/accounts/wallet_onboarding_flow.dart
+++ b/mobile-app/lib/v2/screens/accounts/wallet_onboarding_flow.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:resonance_network_wallet/providers/account_providers.dart';
+import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
+import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
+import 'package:resonance_network_wallet/services/wallet_creation_service.dart';
+import 'package:resonance_network_wallet/v2/screens/accounts/account_ready_screen.dart';
+
+/// Refreshes providers, registers notifications, and opens the overview screen.
+Future<void> completeWalletOnboarding({
+  required WidgetRef ref,
+  required BuildContext context,
+  required CreatedWalletDetails wallet,
+}) async {
+  ref.invalidate(accountsProvider);
+  ref.invalidate(activeAccountProvider);
+
+  if (ref.read(remoteConfigProvider).enableRemoteNotifications) {
+    ref.read(firebaseMessagingServiceProvider).registerDeviceIfPossible();
+  }
+
+  if (!context.mounted) return;
+
+  Navigator.pushAndRemoveUntil(
+    context,
+    MaterialPageRoute<void>(
+      builder: (_) => AccountReadyScreen(
+        accountId: wallet.accountId,
+        accountName: wallet.accountName,
+        checksumPhrase: wallet.checksumPhrase,
+        origin: AccountReadyOverviewOrigin.walletCreated,
+      ),
+    ),
+    (_) => false,
+  );
+}

--- a/mobile-app/lib/v2/screens/create/new_wallet_recovery_phrase_screen.dart
+++ b/mobile-app/lib/v2/screens/create/new_wallet_recovery_phrase_screen.dart
@@ -3,12 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/l10n_provider.dart';
-import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
-import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
 import 'package:resonance_network_wallet/services/wallet_creation_service.dart';
 import 'package:resonance_network_wallet/shared/extensions/toaster_extensions.dart';
 import 'package:resonance_network_wallet/v2/components/recovery_phrase_body.dart';
-import 'package:resonance_network_wallet/v2/screens/accounts/account_ready_screen.dart';
+import 'package:resonance_network_wallet/v2/screens/accounts/wallet_onboarding_flow.dart';
 
 class NewWalletRecoveryPhraseScreen extends ConsumerStatefulWidget {
   const NewWalletRecoveryPhraseScreen({super.key});
@@ -19,32 +17,26 @@ class NewWalletRecoveryPhraseScreen extends ConsumerStatefulWidget {
 
 class _NewWalletRecoveryPhraseScreenState extends ConsumerState<NewWalletRecoveryPhraseScreen> {
   final WalletCreationService _walletCreationService = WalletCreationService();
-  final HdWalletService _hdWalletService = HdWalletService();
 
-  final String _accountName = 'Account 1';
-  final int _walletIndex = 0;
-  List<String> _words = [];
-  String _mnemonic = '';
+  GeneratedWalletPreview? _preview;
   bool _isLoading = true;
   bool _isSubmitting = false;
   bool _errorOccurred = false;
 
-  late String _address;
-  late String _checksum;
+  List<String> get _words => _preview?.mnemonic.split(' ') ?? const [];
 
   Future<void> _generateMnemonic() async {
     if (!mounted) return;
     setState(() => _isLoading = true);
 
     try {
-      _mnemonic = await SubstrateService().generateMnemonic();
-      if (_mnemonic.isEmpty) throw Exception('Mnemonic generation returned empty.');
-
-      _words = _mnemonic.split(' ');
-      _address = _hdWalletService.keyPairAtIndex(_mnemonic, 0).ss58Address;
-      _checksum = await HumanReadableChecksumService().getHumanReadableName(_address);
-
-      if (mounted) setState(() => _isLoading = false);
+      final preview = await _walletCreationService.generateWalletPreview();
+      if (mounted) {
+        setState(() {
+          _preview = preview;
+          _isLoading = false;
+        });
+      }
     } catch (e) {
       if (mounted) {
         setState(() {
@@ -59,39 +51,19 @@ class _NewWalletRecoveryPhraseScreenState extends ConsumerState<NewWalletRecover
   }
 
   Future<void> _continue() async {
-    if (_words.isEmpty) return;
+    final preview = _preview;
+    if (preview == null) return;
 
     setState(() => _isSubmitting = true);
     try {
       final accounts = ref.read(accountsProvider).value ?? <Account>[];
-      await _walletCreationService.createNewWallet(
-        name: _accountName,
-        mnemonic: _mnemonic,
-        walletIndex: _walletIndex,
-        accountId: _address,
+      final wallet = await _walletCreationService.persistWalletPreview(
+        preview: preview,
         existingAccounts: accounts,
       );
 
-      ref.invalidate(accountsProvider);
-      ref.invalidate(activeAccountProvider);
-
-      if (ref.read(remoteConfigProvider).enableRemoteNotifications) {
-        ref.read(firebaseMessagingServiceProvider).registerDeviceIfPossible();
-      }
-
       if (!mounted) return;
-      Navigator.pushAndRemoveUntil(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AccountReadyScreen(
-            accountId: _address,
-            accountName: _accountName,
-            checksumPhrase: _checksum,
-            origin: AccountReadyOverviewOrigin.walletCreated,
-          ),
-        ),
-        (route) => false,
-      );
+      await completeWalletOnboarding(ref: ref, context: context, wallet: wallet);
     } catch (e) {
       if (mounted) {
         final l10n = ref.read(l10nProvider);

--- a/mobile-app/lib/v2/screens/create/new_wallet_recovery_phrase_screen.dart
+++ b/mobile-app/lib/v2/screens/create/new_wallet_recovery_phrase_screen.dart
@@ -57,10 +57,7 @@ class _NewWalletRecoveryPhraseScreenState extends ConsumerState<NewWalletRecover
     setState(() => _isSubmitting = true);
     try {
       final accounts = ref.read(accountsProvider).value ?? <Account>[];
-      final wallet = await _walletCreationService.persistWalletPreview(
-        preview: preview,
-        existingAccounts: accounts,
-      );
+      final wallet = await _walletCreationService.persistWalletPreview(preview: preview, existingAccounts: accounts);
 
       if (!mounted) return;
       await completeWalletOnboarding(ref: ref, context: context, wallet: wallet);

--- a/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
+++ b/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
@@ -8,6 +8,7 @@ import 'package:resonance_network_wallet/services/firebase_messaging_service.dar
 import 'package:resonance_network_wallet/services/telemetry_service.dart';
 import 'package:resonance_network_wallet/shared/utils/print.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
+import 'package:resonance_network_wallet/v2/components/seed_phrase_controller.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base_bottom_content.dart';
 import 'package:resonance_network_wallet/v2/components/v2_app_bar.dart';
@@ -25,7 +26,7 @@ class ImportWalletScreenV2 extends ConsumerStatefulWidget {
 }
 
 class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
-  final _controller = _SeedPhraseController();
+  final _controller = SeedPhraseController();
   final _focusNode = FocusNode();
   final _buttonKey = GlobalKey();
   final _settingsService = SettingsService();
@@ -219,36 +220,5 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
     _focusNode.dispose();
     _controller.dispose();
     super.dispose();
-  }
-}
-
-class _SeedPhraseController extends TextEditingController {
-  bool obscure = true;
-
-  static String _mask(String text) => text.replaceAllMapped(RegExp(r'\S'), (_) => '*');
-
-  @override
-  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
-    final text = value.text;
-    final display = obscure ? _mask(text) : text;
-
-    if (!withComposing || !value.composing.isValid) {
-      return TextSpan(style: style, text: display);
-    }
-
-    final composingStart = value.composing.start;
-    final composingEnd = value.composing.end;
-
-    return TextSpan(
-      style: style,
-      children: [
-        TextSpan(text: display.substring(0, composingStart)),
-        TextSpan(
-          style: style?.copyWith(decoration: TextDecoration.underline, decorationColor: style.color),
-          text: display.substring(composingStart, composingEnd),
-        ),
-        TextSpan(text: display.substring(composingEnd)),
-      ],
-    );
   }
 }

--- a/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
+++ b/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
@@ -25,7 +25,7 @@ class ImportWalletScreenV2 extends ConsumerStatefulWidget {
 }
 
 class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
-  final _controller = TextEditingController();
+  final _controller = _SeedPhraseController();
   final _focusNode = FocusNode();
   final _buttonKey = GlobalKey();
   final _settingsService = SettingsService();
@@ -53,6 +53,10 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
   }
 
   bool get _hasInput => _controller.text.trim().isNotEmpty;
+
+  void _toggleSeedPhraseVisibility() {
+    setState(() => _controller.obscure = !_controller.obscure);
+  }
 
   Future<void> _import() async {
     final accounts = ref.read(accountsProvider).value ?? <Account>[];
@@ -147,18 +151,42 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
                   borderRadius: BorderRadius.circular(14),
                   border: Border.all(color: colors.borderButton, width: 1),
                 ),
-                child: TextField(
-                  controller: _controller,
-                  focusNode: _focusNode,
-                  onChanged: (_) => setState(() {}),
-                  style: fieldTextStyle,
-                  decoration: InputDecoration.collapsed(
-                    hintText: l10n.importWalletHint,
-                    hintStyle: fieldTextStyle?.copyWith(color: colors.textSecondary),
-                  ),
-                  maxLines: null,
-                  keyboardType: TextInputType.multiline,
-                  textInputAction: TextInputAction.done,
+                child: Stack(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(right: 32),
+                      child: TextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        onChanged: (_) => setState(() {}),
+                        style: fieldTextStyle,
+                        cursorColor: colors.checksum,
+                        enableSuggestions: false,
+                        autocorrect: false,
+                        decoration: InputDecoration.collapsed(
+                          hintText: l10n.importWalletHint,
+                          hintStyle: fieldTextStyle?.copyWith(color: colors.textSecondary),
+                        ),
+                        maxLines: null,
+                        keyboardType: TextInputType.multiline,
+                        textInputAction: TextInputAction.done,
+                      ),
+                    ),
+                    Positioned(
+                      top: 0,
+                      right: 0,
+                      child: IconButton(
+                        icon: Icon(
+                          _controller.obscure ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+                          color: colors.textSecondary,
+                          size: 20,
+                        ),
+                        onPressed: _toggleSeedPhraseVisibility,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+                      ),
+                    ),
+                  ],
                 ),
               ),
               if (_error != null) ...[
@@ -191,5 +219,36 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
     _focusNode.dispose();
     _controller.dispose();
     super.dispose();
+  }
+}
+
+class _SeedPhraseController extends TextEditingController {
+  bool obscure = true;
+
+  static String _mask(String text) => text.replaceAllMapped(RegExp(r'\S'), (_) => '*');
+
+  @override
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
+    final text = value.text;
+    final display = obscure ? _mask(text) : text;
+
+    if (!withComposing || !value.composing.isValid) {
+      return TextSpan(style: style, text: display);
+    }
+
+    final composingStart = value.composing.start;
+    final composingEnd = value.composing.end;
+
+    return TextSpan(
+      style: style,
+      children: [
+        TextSpan(text: display.substring(0, composingStart)),
+        TextSpan(
+          style: style?.copyWith(decoration: TextDecoration.underline, decorationColor: style.color),
+          text: display.substring(composingStart, composingEnd),
+        ),
+        TextSpan(text: display.substring(composingEnd)),
+      ],
+    );
   }
 }

--- a/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
+++ b/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
@@ -29,9 +29,7 @@ class _WelcomeScreenV2State extends ConsumerState<WelcomeScreenV2> {
 
     try {
       final accounts = ref.read(accountsProvider).value ?? <Account>[];
-      final wallet = await _walletCreationService.createWalletWithGeneratedMnemonic(
-        existingAccounts: accounts,
-      );
+      final wallet = await _walletCreationService.createWalletWithGeneratedMnemonic(existingAccounts: accounts);
 
       if (!mounted) return;
       await completeWalletOnboarding(ref: ref, context: context, wallet: wallet);

--- a/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
+++ b/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
@@ -1,18 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/l10n_provider.dart';
+import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
+import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
+import 'package:resonance_network_wallet/services/wallet_creation_service.dart';
+import 'package:resonance_network_wallet/shared/extensions/toaster_extensions.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
-import 'package:resonance_network_wallet/v2/screens/create/wallet_ready_screen.dart';
+import 'package:resonance_network_wallet/v2/screens/accounts/account_ready_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/import/import_wallet_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/welcome/onboarding_background.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
 
-class WelcomeScreenV2 extends ConsumerWidget {
+class WelcomeScreenV2 extends ConsumerStatefulWidget {
   const WelcomeScreenV2({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<WelcomeScreenV2> createState() => _WelcomeScreenV2State();
+}
+
+class _WelcomeScreenV2State extends ConsumerState<WelcomeScreenV2> {
+  final WalletCreationService _walletCreationService = WalletCreationService();
+  bool _isCreatingWallet = false;
+
+  Future<void> _createWallet() async {
+    setState(() => _isCreatingWallet = true);
+
+    try {
+      final accounts = ref.read(accountsProvider).value ?? <Account>[];
+      final wallet = await _walletCreationService.createWalletWithGeneratedMnemonic(
+        existingAccounts: accounts,
+      );
+
+      ref.invalidate(accountsProvider);
+      ref.invalidate(activeAccountProvider);
+
+      if (ref.read(remoteConfigProvider).enableRemoteNotifications) {
+        ref.read(firebaseMessagingServiceProvider).registerDeviceIfPossible();
+      }
+
+      if (!mounted) return;
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(
+          builder: (_) => AccountReadyScreen(
+            accountId: wallet.accountId,
+            accountName: wallet.accountName,
+            checksumPhrase: wallet.checksumPhrase,
+            origin: AccountReadyOverviewOrigin.walletCreated,
+          ),
+        ),
+        (route) => false,
+      );
+    } catch (e) {
+      if (mounted) {
+        final l10n = ref.read(l10nProvider);
+        context.showErrorToaster(message: l10n.createWalletRecoveryPhraseSaveError(e.toString()));
+      }
+    } finally {
+      if (mounted) setState(() => _isCreatingWallet = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final l10n = ref.watch(l10nProvider);
 
     return ScaffoldBase(
@@ -29,13 +82,9 @@ class WelcomeScreenV2 extends ConsumerWidget {
           const SizedBox(height: 56),
           QuantusButton.simple(
             label: l10n.welcomeCreateNewWallet,
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                settings: const RouteSettings(name: 'create_wallet'),
-                builder: (_) => const WalletReadyScreenV2(),
-              ),
-            ),
+            onTap: _createWallet,
+            isLoading: _isCreatingWallet,
+            isDisabled: _isCreatingWallet,
           ),
           const SizedBox(height: 24),
           QuantusButton.simple(
@@ -48,6 +97,7 @@ class WelcomeScreenV2 extends ConsumerWidget {
               ),
             ),
             variant: ButtonVariant.secondary,
+            isDisabled: _isCreatingWallet,
           ),
           const SizedBox(height: 40),
         ],

--- a/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
+++ b/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
@@ -3,13 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/l10n_provider.dart';
-import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
-import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
 import 'package:resonance_network_wallet/services/wallet_creation_service.dart';
 import 'package:resonance_network_wallet/shared/extensions/toaster_extensions.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
-import 'package:resonance_network_wallet/v2/screens/accounts/account_ready_screen.dart';
+import 'package:resonance_network_wallet/v2/screens/accounts/wallet_onboarding_flow.dart';
 import 'package:resonance_network_wallet/v2/screens/import/import_wallet_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/welcome/onboarding_background.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
@@ -26,6 +24,7 @@ class _WelcomeScreenV2State extends ConsumerState<WelcomeScreenV2> {
   bool _isCreatingWallet = false;
 
   Future<void> _createWallet() async {
+    if (_isCreatingWallet) return;
     setState(() => _isCreatingWallet = true);
 
     try {
@@ -34,26 +33,8 @@ class _WelcomeScreenV2State extends ConsumerState<WelcomeScreenV2> {
         existingAccounts: accounts,
       );
 
-      ref.invalidate(accountsProvider);
-      ref.invalidate(activeAccountProvider);
-
-      if (ref.read(remoteConfigProvider).enableRemoteNotifications) {
-        ref.read(firebaseMessagingServiceProvider).registerDeviceIfPossible();
-      }
-
       if (!mounted) return;
-      Navigator.pushAndRemoveUntil(
-        context,
-        MaterialPageRoute(
-          builder: (_) => AccountReadyScreen(
-            accountId: wallet.accountId,
-            accountName: wallet.accountName,
-            checksumPhrase: wallet.checksumPhrase,
-            origin: AccountReadyOverviewOrigin.walletCreated,
-          ),
-        ),
-        (route) => false,
-      );
+      await completeWalletOnboarding(ref: ref, context: context, wallet: wallet);
     } catch (e) {
       if (mounted) {
         final l10n = ref.read(l10nProvider);

--- a/quantus_sdk/rust/Cargo.lock
+++ b/quantus_sdk/rust/Cargo.lock
@@ -2944,7 +2944,6 @@ dependencies = [
  "anyhow",
  "blake3",
  "flutter_rust_bridge",
- "getrandom 0.2.17",
  "hex",
  "nam-tiny-hderive",
  "qp-plonky2",


### PR DESCRIPTION
## Summary
- Remove seed phrase display
- Make import field hide text by default unless toggled

## Screenshot
- Import field
<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/5c1bb1dd-d479-4985-8d65-a4832c3a6021" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Skipping the recovery phrase/caution flow means new users may not back up their mnemonic before use, and wallet persistence now runs directly from welcome—behavior change in sensitive onboarding paths.
> 
> **Overview**
> **Welcome “create wallet”** now generates and persists a mnemonic in one step (loading state on the button) and routes through shared **`completeWalletOnboarding`** to **Account ready**, skipping the previous **Wallet ready → recovery phrase** navigation.
> 
> **`WalletCreationService`** gains preview/persist helpers (`GeneratedWalletPreview`, `generateWalletPreview`, `persistWalletPreview`, `createWalletWithGeneratedMnemonic`) so screens can split “show mnemonic” from “save wallet”; the recovery phrase screen is refactored to use these instead of calling substrate/HD services directly.
> 
> **Import wallet** uses a new **`SeedPhraseController`** that masks input with `*` by default, plus a visibility toggle; suggestions/autocorrect are disabled on the field.
> 
> A small **`quantus_sdk` `Cargo.lock`** tweak removes an unused `getrandom` dependency from the Rust wallet crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90735a398f77a1840de31b106129a89d0268afc8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->