### PR TITLE
feat: secure seed phrase field

### DIFF
--- a/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
+++ b/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
@@ -24,8 +24,25 @@ class ImportWalletScreenV2 extends ConsumerStatefulWidget {
   ConsumerState<ImportWalletScreenV2> createState() => _ImportWalletScreenV2State();
 }
 
+/// Renders the seed phrase as `x` characters while keeping the real text
+/// intact, since [TextField.obscureText] is unsupported for multiline fields.
+///
+/// The mask must keep the same character count as the real text so the caret
+/// and selection positions stay accurate while typing.
+class _ObscuringMnemonicController extends TextEditingController {
+  bool obscured = true;
+
+  @override
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
+    if (!obscured) {
+      return super.buildTextSpan(context: context, style: style, withComposing: withComposing);
+    }
+    return TextSpan(style: style, text: 'x' * text.length);
+  }
+}
+
 class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
-  final _controller = TextEditingController();
+  final _controller = _ObscuringMnemonicController();
   final _focusNode = FocusNode();
   final _buttonKey = GlobalKey();
   final _settingsService = SettingsService();
@@ -147,18 +164,40 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
                   borderRadius: BorderRadius.circular(14),
                   border: Border.all(color: colors.borderButton, width: 1),
                 ),
-                child: TextField(
-                  controller: _controller,
-                  focusNode: _focusNode,
-                  onChanged: (_) => setState(() {}),
-                  style: fieldTextStyle,
-                  decoration: InputDecoration.collapsed(
-                    hintText: l10n.importWalletHint,
-                    hintStyle: fieldTextStyle?.copyWith(color: colors.textSecondary),
-                  ),
-                  maxLines: null,
-                  keyboardType: TextInputType.multiline,
-                  textInputAction: TextInputAction.done,
+                child: Stack(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(right: 36),
+                      child: TextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        onChanged: (_) => setState(() {}),
+                        style: fieldTextStyle,
+                        decoration: InputDecoration.collapsed(
+                          hintText: l10n.importWalletHint,
+                          hintStyle: fieldTextStyle?.copyWith(color: colors.textSecondary),
+                        ),
+                        maxLines: null,
+                        keyboardType: TextInputType.multiline,
+                        textInputAction: TextInputAction.done,
+                        autocorrect: false,
+                        enableSuggestions: false,
+                      ),
+                    ),
+                    Positioned(
+                      top: 0,
+                      right: 0,
+                      child: GestureDetector(
+                        onTap: () => setState(() => _controller.obscured = !_controller.obscured),
+                        behavior: HitTestBehavior.opaque,
+                        child: Icon(
+                          _controller.obscured ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+                          size: 22,
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
               if (_error != null) ...[


### PR DESCRIPTION
## Summary
Hide seed phrase input by default.

## Screenshot
<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/35f46c68-3d6d-4d6a-a99c-cc5c041a9cf1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only privacy improvement on import; import logic still reads the same controller text with no auth or storage changes.
> 
> **Overview**
> The import wallet screen now **masks the seed phrase by default** while typing, since multiline `TextField` cannot use `obscureText`.
> 
> A custom `_ObscuringMnemonicController` paints the same-length `x` mask via `buildTextSpan` so caret/selection stay correct; the real mnemonic remains in controller text for validation and import. A **visibility toggle** in the field corner switches between masked and plain text. **Autocorrect and keyboard suggestions are disabled** on the mnemonic field to reduce accidental leakage via the OS keyboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d8ffb75cbaabb00745dd9c60246b31f9a7c3d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->