### PR TITLE
Scanner UX - Safe Area Fix

### DIFF
--- a/mobile-app/lib/v2/components/qr_scanner_page.dart
+++ b/mobile-app/lib/v2/components/qr_scanner_page.dart
@@ -87,7 +87,18 @@ class _QrScannerPageState extends ConsumerState<QrScannerPage> {
               ],
             ),
           ),
-          Positioned(top: 20, left: 24, right: 24, child: V2AppBar(title: l10n.componentQrScannerTitle)),
+          Positioned(
+            top: 0,
+            left: 24,
+            right: 24,
+            child: SafeArea(
+              bottom: false,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 20),
+                child: V2AppBar(title: l10n.componentQrScannerTitle),
+              ),
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
Scanner would overlap the iphone camera  on top

Added safe area to prevent this on all devices
<img width="590" height="1278" alt="IMG_0150" src="https://github.com/user-attachments/assets/3b6bc39f-d9bd-4840-a6fd-00c088498dad" />
