### PR TITLE
wait for RPC hash before showing success screen

### DIFF
--- a/mobile-app/lib/services/transaction_submission_service.dart
+++ b/mobile-app/lib/services/transaction_submission_service.dart
@@ -355,17 +355,15 @@ class TransactionSubmissionService {
     return pending;
   }
 
-  /// Submits a transaction in the background and tracks its status. Returns
-  /// immediately without waiting.
+  /// Submits a transaction, awaiting the network's acceptance and the returned
+  /// extrinsic hash before completing. Tracking/polling then continues in the
+  /// background. Rethrows on submission failure so callers can surface the
+  /// error instead of optimistically navigating away.
   ///
   /// Retries live in SubstrateService.submitExtrinsic, which resubmits the
   /// same signed bytes. Outer retries would re-sign with a fresh nonce and can
   /// double spend if a prior submit already reached the network.
   Future<void> submitAndTrackTransaction(Future<Uint8List> Function() submit, PendingTransactionEvent pendingTx) async {
-    unawaited(_submitAndTrackBackground(submit, pendingTx));
-  }
-
-  Future<void> _submitAndTrackBackground(Future<Uint8List> Function() submit, PendingTransactionEvent pendingTx) async {
     try {
       quantusDebugPrint('Submitting transaction: ${pendingTx.id}');
 
@@ -373,21 +371,17 @@ class TransactionSubmissionService {
       final extrinsicHash = '0x${hex.encode(extrinsicHashBytes)}';
       quantusDebugPrint('submission hash: $extrinsicHash');
 
-      final newState = TransactionState.pending;
-      quantusDebugPrint('updating tx ${pendingTx.amount} to $newState');
       _ref
           .read(pendingTransactionsProvider.notifier)
-          .updateState(pendingTx.id, newState, error: pendingTx.error, extrinsicHash: extrinsicHash);
+          .updateState(pendingTx.id, TransactionState.pending, error: pendingTx.error, extrinsicHash: extrinsicHash);
 
       _startPollingForTransaction(pendingTx.copyWith(extrinsicHash: extrinsicHash));
     } catch (e, stackTrace) {
       quantusDebugPrint('Failed to submit transaction ${pendingTx.id}: $e');
       quantusDebugPrint('Stack trace: $stackTrace');
 
-      _ref
-          .read(pendingTransactionsProvider.notifier)
-          .updateState(pendingTx.id, TransactionState.failed, error: 'Failed to submit: $e');
       _ref.read(pendingTransactionsProvider.notifier).remove(pendingTx.id);
+      rethrow;
     }
   }
 

--- a/mobile-app/lib/v2/screens/send/review_send_screen.dart
+++ b/mobile-app/lib/v2/screens/send/review_send_screen.dart
@@ -192,14 +192,13 @@ class _ReviewSendScreenState extends ConsumerState<ReviewSendScreen> {
 
   Widget _summarySection(AppLocalizations l10n, String addr, BigInt totalRaw) {
     final shownDecimals = AppConstants.decimals;
-    final shortAddr = AddressFormattingService.formatAddress(addr);
     final formattingService = ref.watch(numberFormattingServiceProvider);
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         const SizedBox(height: 7),
-        _summaryRow(label: l10n.sendReviewTo, value: shortAddr),
+        _summaryRow(label: l10n.sendReviewTo, value: addr),
         const SizedBox(height: 7),
         _summaryRow(
           label: l10n.sendReviewAmount,


### PR DESCRIPTION
- send without waiting for server was an over-optimization which led to bad edge cases - if a tx hash is returned, the tx will most likely work 
- show full address in send confirmation - this is a security feature

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 17e - 2026-06-14 at 11 09 31" src="https://github.com/user-attachments/assets/6351fb13-8bbf-4f91-92d0-8172716fb266" />
