### PR TITLE
Guard success-path setState with mounted check in review send

### DIFF
--- a/mobile-app/lib/v2/screens/send/review_send_screen.dart
+++ b/mobile-app/lib/v2/screens/send/review_send_screen.dart
@@ -83,24 +83,23 @@ class _ReviewSendScreenState extends ConsumerState<ReviewSendScreen> {
             .addAddress(widget.recipientAddress.trim())
             .catchError((Object e) => debugPrint('Failed to save recent address: $e')),
       );
+      if (!mounted) return;
       setState(() {
         _submitting = false;
         _errorMessage = null;
       });
 
-      if (mounted) {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TxSubmittedScreen(
-              amount: widget.amount,
-              recipientAddress: widget.recipientAddress,
-              recipientChecksum: widget.recipientChecksum,
-              isPayMode: widget.isPayMode,
-            ),
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TxSubmittedScreen(
+            amount: widget.amount,
+            recipientAddress: widget.recipientAddress,
+            recipientChecksum: widget.recipientChecksum,
+            isPayMode: widget.isPayMode,
           ),
-        );
-      }
+        ),
+      );
     } catch (e) {
       debugPrint('Transfer failed: $e');
 


### PR DESCRIPTION
## Summary

Follow-up to #524. Now that the send flow blocks on the RPC submission before navigating, the await in `_confirmSend` can take a real network round-trip (plus retries). This widens the window for the screen to unmount mid-submission.

The success-path `setState` was not guarded by `mounted`. If the widget unmounted during submission, that `setState` threw, the exception was caught by the failure handler, and a **successful** send was reported as failed (`sendReviewSubmitFailed`) while navigation to the success screen was skipped.

This adds an early `if (!mounted) return;` before the success `setState` and removes the now-redundant `if (mounted)` wrapper around `Navigator.push` (no awaits between the guard and the push). The failure handler already guards its `setState` with `mounted`.

## Test plan

- [x] Send a transfer normally → success screen still shows.
- [x] Trigger a submission failure → error message shows, no navigation.
- [x] Navigate away (back) while the confirm button is loading → no `setState after dispose`, no false failure logged.