### PR TITLE
Implement BIP-44 gap-limit account discovery

### DIFF
--- a/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
+++ b/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
@@ -48,7 +48,7 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
   final _buttonKey = GlobalKey();
   final _settingsService = SettingsService();
   final _accountsService = AccountsService();
-  final _discoveryService = AccountDiscoveryService(HdWalletService(), SubstrateService());
+  final _discoveryService = AccountDiscoveryService(HdWalletService());
   bool _isLoading = false;
   String? _error;
 

--- a/quantus_sdk/lib/src/services/account_discovery_service.dart
+++ b/quantus_sdk/lib/src/services/account_discovery_service.dart
@@ -18,7 +18,11 @@ class AccountDiscoveryService {
   /// Discovers on-chain HD accounts using the BIP-44 gap-limit algorithm:
   /// scan HD indices in batches and keep going as long as accounts exist,
   /// stopping once [gapLimit] consecutive indices have no on-chain account.
-  Future<List<Account>> discoverAccounts({required String mnemonic, required int walletIndex, int gapLimit = 20}) async {
+  Future<List<Account>> discoverAccounts({
+    required String mnemonic,
+    required int walletIndex,
+    int gapLimit = 20,
+  }) async {
     final discovered = <Account>[];
 
     var consecutiveMissing = 0;
@@ -28,12 +32,7 @@ class AccountDiscoveryService {
       for (var i = index; i < index + gapLimit; i++) {
         final keyPair = _hdWalletService.keyPairAtIndex(mnemonic, i);
         batch.add(
-          Account(
-            walletIndex: walletIndex,
-            index: i,
-            name: 'Account ${i + 1}',
-            accountId: keyPair.ss58Address,
-          ),
+          Account(walletIndex: walletIndex, index: i, name: 'Account ${i + 1}', accountId: keyPair.ss58Address),
         );
       }
 

--- a/quantus_sdk/lib/src/services/account_discovery_service.dart
+++ b/quantus_sdk/lib/src/services/account_discovery_service.dart
@@ -4,9 +4,8 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 
 class AccountDiscoveryService {
   final HdWalletService _hdWalletService;
-  final SubstrateService _substrateService;
 
-  AccountDiscoveryService(this._hdWalletService, this._substrateService);
+  AccountDiscoveryService(this._hdWalletService);
 
   static const String _accountsQuery = r'''
     query AccountsQuery($ids: [String!]) {
@@ -16,68 +15,72 @@ class AccountDiscoveryService {
     }
   ''';
 
-  Future<List<Account>> discoverAccounts({required String mnemonic, required int walletIndex, int count = 20}) async {
-    final allPossibleAccounts = <Account>[];
+  /// Discovers on-chain HD accounts using the BIP-44 gap-limit algorithm:
+  /// scan HD indices in batches and keep going as long as accounts exist,
+  /// stopping once [gapLimit] consecutive indices have no on-chain account.
+  Future<List<Account>> discoverAccounts({required String mnemonic, required int walletIndex, int gapLimit = 20}) async {
+    final discovered = <Account>[];
 
-    // Add raw account
-    final rawKeyPair = _substrateService.nonHDdilithiumKeypairFromMnemonic(mnemonic);
-    final rawAccount = Account(
-      walletIndex: walletIndex,
-      index: -1, //  indicator for a raw account
-      name: 'Primary Account',
-      accountId: rawKeyPair.ss58Address,
-    );
-    allPossibleAccounts.add(rawAccount);
+    var consecutiveMissing = 0;
+    var index = 0;
+    while (consecutiveMissing < gapLimit) {
+      final batch = <Account>[];
+      for (var i = index; i < index + gapLimit; i++) {
+        final keyPair = _hdWalletService.keyPairAtIndex(mnemonic, i);
+        batch.add(
+          Account(
+            walletIndex: walletIndex,
+            index: i,
+            name: 'Account ${i + 1}',
+            accountId: keyPair.ss58Address,
+          ),
+        );
+      }
 
-    // Add HD accounts
-    for (var i = 0; i < count; i++) {
-      final keyPair = _hdWalletService.keyPairAtIndex(mnemonic, i);
-      final account = Account(
-        walletIndex: walletIndex,
-        index: i,
-        name: 'Account ${i + 1}',
-        accountId: keyPair.ss58Address,
-      );
-      allPossibleAccounts.add(account);
+      final existingIds = await _findExistingAccountIds(batch.map((a) => a.accountId).toList());
+
+      for (final account in batch) {
+        if (existingIds.contains(account.accountId)) {
+          discovered.add(account);
+          consecutiveMissing = 0;
+        } else {
+          consecutiveMissing++;
+          if (consecutiveMissing >= gapLimit) break;
+        }
+      }
+
+      index += gapLimit;
     }
 
-    final accountIds = allPossibleAccounts.map((a) => a.accountId).toList();
+    return discovered;
+  }
+
+  Future<Set<String>> _findExistingAccountIds(List<String> accountIds) async {
+    if (accountIds.isEmpty) return {};
 
     final graphQlEndpoint = GraphQlEndpointService();
-
     final Map<String, dynamic> requestBody = {
       'query': _accountsQuery,
       'variables': {'ids': accountIds},
     };
 
-    try {
-      final response = await graphQlEndpoint.post(
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(requestBody),
-      );
+    final response = await graphQlEndpoint.post(
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(requestBody),
+    );
 
-      if (response.statusCode != 200) {
-        throw Exception('GraphQL request failed with status: ${response.statusCode}. Body: ${response.body}');
-      }
-
-      final Map<String, dynamic> responseBody = jsonDecode(response.body);
-      if (responseBody['errors'] != null) {
-        throw Exception('GraphQL errors: ${responseBody['errors']}');
-      }
-
-      final List<dynamic>? foundAccountsData = responseBody['data']?['accounts'];
-
-      if (foundAccountsData == null) {
-        return [];
-      }
-
-      final foundAccountIds = foundAccountsData.map((a) => a['id'] as String).toSet();
-
-      return allPossibleAccounts.where((account) => foundAccountIds.contains(account.accountId)).toList();
-    } catch (e, stackTrace) {
-      print('Error discovering accounts: $e');
-      print(stackTrace);
-      rethrow;
+    if (response.statusCode != 200) {
+      throw Exception('GraphQL request failed with status: ${response.statusCode}. Body: ${response.body}');
     }
+
+    final Map<String, dynamic> responseBody = jsonDecode(response.body);
+    if (responseBody['errors'] != null) {
+      throw Exception('GraphQL errors: ${responseBody['errors']}');
+    }
+
+    final List<dynamic>? foundAccountsData = responseBody['data']?['accounts'];
+    if (foundAccountsData == null) return {};
+
+    return foundAccountsData.map((a) => a['id'] as String).toSet();
   }
 }


### PR DESCRIPTION
## Summary
- Replace the single fixed batch of 20 HD indices with a proper BIP-44 gap-limit scan: keep scanning in batches until `gapLimit` (20) consecutive indices have no on-chain account.
- Remove the obsolete legacy raw account (`index -1`) check; rewards now go to a wormhole account, so no `index 0` rewards account exists anymore. This also drops the now-unused `SubstrateService` dependency.

## Test plan
- [ ] Import a wallet with >20 used HD accounts and confirm all are discovered.
- [ ] Import a wallet with sparse usage (gaps) and confirm discovery stops after 20 consecutive empty indices.
- [ ] Import a fresh mnemonic and confirm no extra accounts are added.