### PR TITLE
Optimize multisig tx submission

### DIFF
--- a/mobile-app/lib/providers/multisig_approval_toast_provider.dart
+++ b/mobile-app/lib/providers/multisig_approval_toast_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum MultisigApprovalToastKind { timeout, submitFailed }
+enum MultisigApprovalToastKind { timeout }
 
 class MultisigApprovalToastEvent {
   const MultisigApprovalToastEvent(this.kind);

--- a/mobile-app/lib/providers/multisig_cancellation_toast_provider.dart
+++ b/mobile-app/lib/providers/multisig_cancellation_toast_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum MultisigCancellationToastKind { timeout, submitFailed }
+enum MultisigCancellationToastKind { timeout }
 
 class MultisigCancellationToastEvent {
   const MultisigCancellationToastEvent(this.kind);

--- a/mobile-app/lib/providers/multisig_creation_toast_provider.dart
+++ b/mobile-app/lib/providers/multisig_creation_toast_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/legacy.dart';
 
-enum MultisigCreationToastKind { ready, timeout, submitFailed }
+enum MultisigCreationToastKind { ready, timeout }
 
 class MultisigCreationToastEvent {
   const MultisigCreationToastEvent(this.kind);

--- a/mobile-app/lib/providers/multisig_execution_toast_provider.dart
+++ b/mobile-app/lib/providers/multisig_execution_toast_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum MultisigExecutionToastKind { timeout, submitFailed, executedByOther }
+enum MultisigExecutionToastKind { timeout, executedByOther }
 
 class MultisigExecutionToastEvent {
   const MultisigExecutionToastEvent(this.kind);

--- a/mobile-app/lib/providers/multisig_proposal_toast_provider.dart
+++ b/mobile-app/lib/providers/multisig_proposal_toast_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum MultisigProposalToastKind { timeout, submitFailed }
+enum MultisigProposalToastKind { timeout }
 
 class MultisigProposalToastEvent {
   const MultisigProposalToastEvent(this.kind);

--- a/mobile-app/lib/services/multisig_submission_service.dart
+++ b/mobile-app/lib/services/multisig_submission_service.dart
@@ -61,13 +61,7 @@ class MultisigSubmissionService {
         .read(pendingMultisigCreationsProvider.notifier)
         .add(PendingMultisigCreationEvent.fromDraft(draft, networkFee: networkFee), draft);
 
-    await _submitAndTrack(
-      creator: creator,
-      signers: signers,
-      threshold: threshold,
-      nonce: draft.nonce,
-      draft: draft,
-    );
+    await _submitAndTrack(creator: creator, signers: signers, threshold: threshold, nonce: draft.nonce, draft: draft);
   }
 
   Future<void> _submitAndTrack({

--- a/mobile-app/lib/services/multisig_submission_service.dart
+++ b/mobile-app/lib/services/multisig_submission_service.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:convert/convert.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
-import 'package:resonance_network_wallet/providers/multisig_creation_toast_provider.dart';
 import 'package:resonance_network_wallet/providers/multisig_providers.dart';
 import 'package:resonance_network_wallet/providers/pending_multisig_creations_provider.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
@@ -98,9 +97,6 @@ class MultisigSubmissionService {
       quantusDebugPrint('Stack trace: $stackTrace');
       TelemetryService().sendError('multisig_create_submit_failed', error: e, stackTrace: stackTrace);
       removePendingMultisigCreation(_ref, draft.accountId);
-      _ref.read(multisigCreationToastProvider.notifier).state = const MultisigCreationToastEvent(
-        MultisigCreationToastKind.submitFailed,
-      );
       rethrow;
     }
   }

--- a/mobile-app/lib/services/multisig_submission_service.dart
+++ b/mobile-app/lib/services/multisig_submission_service.dart
@@ -30,12 +30,14 @@ class MultisigSubmissionService {
     await _runCreationPreflight(name: '', signers: signers, threshold: threshold, creator: creator, nonce: nonce);
   }
 
-  /// Preflight on-chain state, then submit and track creation in the background.
+  /// Preflight on-chain state, then submit and track creation.
   ///
-  /// Returns when preflight passes and background work is scheduled. Throws
+  /// Awaits acceptance of the creation extrinsic by the chain before
+  /// completing; indexer polling then continues in the background. Throws
   /// [MultisigAlreadyExistsException] if the predicted address already exists,
   /// or [MultisigInsufficientBalanceException] if the creator cannot afford
-  /// the total creation cost.
+  /// the total creation cost. Rethrows on submission failure so callers can
+  /// surface the error instead of optimistically navigating away.
   Future<void> startMultisigCreation({
     required String name,
     required List<String> signers,
@@ -59,18 +61,16 @@ class MultisigSubmissionService {
         .read(pendingMultisigCreationsProvider.notifier)
         .add(PendingMultisigCreationEvent.fromDraft(draft, networkFee: networkFee), draft);
 
-    unawaited(
-      _submitAndTrackBackground(
-        creator: creator,
-        signers: signers,
-        threshold: threshold,
-        nonce: draft.nonce,
-        draft: draft,
-      ),
+    await _submitAndTrack(
+      creator: creator,
+      signers: signers,
+      threshold: threshold,
+      nonce: draft.nonce,
+      draft: draft,
     );
   }
 
-  Future<void> _submitAndTrackBackground({
+  Future<void> _submitAndTrack({
     required Account creator,
     required List<String> signers,
     required int threshold,
@@ -107,6 +107,7 @@ class MultisigSubmissionService {
       _ref.read(multisigCreationToastProvider.notifier).state = const MultisigCreationToastEvent(
         MultisigCreationToastKind.submitFailed,
       );
+      rethrow;
     }
   }
 

--- a/mobile-app/lib/services/transaction_submission_service.dart
+++ b/mobile-app/lib/services/transaction_submission_service.dart
@@ -1,6 +1,5 @@
 // mobile-app/lib/services/transaction_submission_service.dart
 
-import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
@@ -129,8 +128,12 @@ class TransactionSubmissionService {
     );
   }
 
-  /// Submits a multisig transfer proposal, tracks it optimistically, and polls
-  /// the indexer until the proposal is visible.
+  /// Submits a multisig transfer proposal and tracks it optimistically.
+  ///
+  /// Awaits acceptance of the extrinsic by the chain before completing;
+  /// indexer polling then continues in the background. Rethrows on submission
+  /// failure so callers can surface the error instead of optimistically
+  /// navigating away.
   Future<void> proposeTransfer({
     required MultisigAccount msig,
     required Account signer,
@@ -154,20 +157,21 @@ class TransactionSubmissionService {
 
     TelemetryService().sendEvent('multisig_propose');
 
-    unawaited(
-      _submitProposalBackground(
-        msig: msig,
-        signer: signer,
-        recipient: recipient,
-        amount: amount,
-        expiryBlock: expiryBlock,
-        pending: pending,
-      ),
+    await _submitProposal(
+      msig: msig,
+      signer: signer,
+      recipient: recipient,
+      amount: amount,
+      expiryBlock: expiryBlock,
+      pending: pending,
     );
   }
 
-  /// Submits a multisig proposal approval, tracks it optimistically, and polls
-  /// the indexer until the approval appears on the proposal.
+  /// Submits a multisig proposal approval and tracks it optimistically.
+  ///
+  /// Awaits acceptance of the extrinsic by the chain before completing;
+  /// indexer polling then continues in the background. Rethrows on submission
+  /// failure so callers can surface the error.
   Future<void> approveProposal({
     required MultisigAccount msig,
     required Account signer,
@@ -183,10 +187,10 @@ class TransactionSubmissionService {
 
     TelemetryService().sendEvent('multisig_approve');
 
-    unawaited(_submitApproveBackground(msig: msig, signer: signer, proposalId: proposal.id, pending: pending));
+    await _submitApprove(msig: msig, signer: signer, proposalId: proposal.id, pending: pending);
   }
 
-  Future<void> _submitApproveBackground({
+  Future<void> _submitApprove({
     required MultisigAccount msig,
     required Account signer,
     required int proposalId,
@@ -205,11 +209,15 @@ class TransactionSubmissionService {
       quantusDebugPrint('[Approve] submit failed: $e\n$stackTrace');
       removePendingMultisigApproval(_ref, pending.id);
       _ref.read(multisigApprovalToastProvider.notifier).show(MultisigApprovalToastKind.submitFailed);
+      rethrow;
     }
   }
 
-  /// Submits a multisig proposal execution, tracks it optimistically, and polls
-  /// the indexer until the proposal status becomes executed.
+  /// Submits a multisig proposal execution and tracks it optimistically.
+  ///
+  /// Awaits acceptance of the extrinsic by the chain before completing;
+  /// indexer polling then continues in the background. Rethrows on submission
+  /// failure so callers can surface the error.
   Future<void> executeProposal({
     required MultisigAccount msig,
     required Account signer,
@@ -227,10 +235,10 @@ class TransactionSubmissionService {
 
     TelemetryService().sendEvent('multisig_execute');
 
-    unawaited(_submitExecuteBackground(msig: msig, signer: signer, proposalId: proposal.id, pending: pending));
+    await _submitExecute(msig: msig, signer: signer, proposalId: proposal.id, pending: pending);
   }
 
-  Future<void> _submitExecuteBackground({
+  Future<void> _submitExecute({
     required MultisigAccount msig,
     required Account signer,
     required int proposalId,
@@ -249,11 +257,15 @@ class TransactionSubmissionService {
       quantusDebugPrint('[Execute] submit failed: $e\n$stackTrace');
       removePendingMultisigExecution(_ref, pending.id);
       _ref.read(multisigExecutionToastProvider.notifier).show(MultisigExecutionToastKind.submitFailed);
+      rethrow;
     }
   }
 
-  /// Submits a multisig proposal cancellation, tracks it optimistically, and polls
-  /// the indexer until the proposal status becomes cancelled.
+  /// Submits a multisig proposal cancellation and tracks it optimistically.
+  ///
+  /// Awaits acceptance of the extrinsic by the chain before completing;
+  /// indexer polling then continues in the background. Rethrows on submission
+  /// failure so callers can surface the error.
   Future<void> cancelProposal({
     required MultisigAccount msig,
     required Account proposer,
@@ -271,10 +283,10 @@ class TransactionSubmissionService {
 
     TelemetryService().sendEvent('multisig_cancel');
 
-    unawaited(_submitCancelBackground(msig: msig, proposer: proposer, proposalId: proposal.id, pending: pending));
+    await _submitCancel(msig: msig, proposer: proposer, proposalId: proposal.id, pending: pending);
   }
 
-  Future<void> _submitCancelBackground({
+  Future<void> _submitCancel({
     required MultisigAccount msig,
     required Account proposer,
     required int proposalId,
@@ -294,10 +306,11 @@ class TransactionSubmissionService {
       quantusDebugPrint('[Cancel] submit failed: $e\n$stackTrace');
       removePendingMultisigCancellation(_ref, pending.id);
       _ref.read(multisigCancellationToastProvider.notifier).show(MultisigCancellationToastKind.submitFailed);
+      rethrow;
     }
   }
 
-  Future<void> _submitProposalBackground({
+  Future<void> _submitProposal({
     required MultisigAccount msig,
     required Account signer,
     required String recipient,
@@ -327,6 +340,7 @@ class TransactionSubmissionService {
       quantusDebugPrint('[Propose] submit failed: $e\n$stackTrace');
       removePendingMultisigProposal(_ref, pending.id);
       _ref.read(multisigProposalToastProvider.notifier).show(MultisigProposalToastKind.submitFailed);
+      rethrow;
     }
   }
 

--- a/mobile-app/lib/services/transaction_submission_service.dart
+++ b/mobile-app/lib/services/transaction_submission_service.dart
@@ -7,10 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/notification_provider.dart';
-import 'package:resonance_network_wallet/providers/multisig_approval_toast_provider.dart';
-import 'package:resonance_network_wallet/providers/multisig_cancellation_toast_provider.dart';
-import 'package:resonance_network_wallet/providers/multisig_execution_toast_provider.dart';
-import 'package:resonance_network_wallet/providers/multisig_proposal_toast_provider.dart';
 import 'package:resonance_network_wallet/providers/multisig_providers.dart';
 import 'package:resonance_network_wallet/providers/pending_multisig_approvals_provider.dart';
 import 'package:resonance_network_wallet/providers/pending_multisig_cancellations_provider.dart';
@@ -208,7 +204,6 @@ class TransactionSubmissionService {
     } catch (e, stackTrace) {
       quantusDebugPrint('[Approve] submit failed: $e\n$stackTrace');
       removePendingMultisigApproval(_ref, pending.id);
-      _ref.read(multisigApprovalToastProvider.notifier).show(MultisigApprovalToastKind.submitFailed);
       rethrow;
     }
   }
@@ -256,7 +251,6 @@ class TransactionSubmissionService {
     } catch (e, stackTrace) {
       quantusDebugPrint('[Execute] submit failed: $e\n$stackTrace');
       removePendingMultisigExecution(_ref, pending.id);
-      _ref.read(multisigExecutionToastProvider.notifier).show(MultisigExecutionToastKind.submitFailed);
       rethrow;
     }
   }
@@ -305,7 +299,6 @@ class TransactionSubmissionService {
     } catch (e, stackTrace) {
       quantusDebugPrint('[Cancel] submit failed: $e\n$stackTrace');
       removePendingMultisigCancellation(_ref, pending.id);
-      _ref.read(multisigCancellationToastProvider.notifier).show(MultisigCancellationToastKind.submitFailed);
       rethrow;
     }
   }
@@ -339,7 +332,6 @@ class TransactionSubmissionService {
       // deposit-reserving proposals if a prior submit already landed.
       quantusDebugPrint('[Propose] submit failed: $e\n$stackTrace');
       removePendingMultisigProposal(_ref, pending.id);
-      _ref.read(multisigProposalToastProvider.notifier).show(MultisigProposalToastKind.submitFailed);
       rethrow;
     }
   }

--- a/mobile-app/lib/v2/components/multisig_approval_toast_listener.dart
+++ b/mobile-app/lib/v2/components/multisig_approval_toast_listener.dart
@@ -19,7 +19,6 @@ class MultisigApprovalToastListener extends ConsumerWidget {
       final l10n = ref.read(l10nProvider);
       final message = switch (next.kind) {
         MultisigApprovalToastKind.timeout => l10n.multisigApprovalTimeoutToast,
-        MultisigApprovalToastKind.submitFailed => l10n.multisigApproveFailed,
       };
       context.showErrorToaster(message: message);
       ref.read(multisigApprovalToastProvider.notifier).clear();
@@ -31,8 +30,6 @@ class MultisigApprovalToastListener extends ConsumerWidget {
       switch (next.kind) {
         case MultisigExecutionToastKind.timeout:
           context.showErrorToaster(message: l10n.multisigExecutionTimeoutToast);
-        case MultisigExecutionToastKind.submitFailed:
-          context.showErrorToaster(message: l10n.multisigExecuteFailed);
         case MultisigExecutionToastKind.executedByOther:
           context.showInfoToaster(message: l10n.multisigExecutedByOtherToast);
       }
@@ -44,7 +41,6 @@ class MultisigApprovalToastListener extends ConsumerWidget {
       final l10n = ref.read(l10nProvider);
       final message = switch (next.kind) {
         MultisigCancellationToastKind.timeout => l10n.multisigCancelTimeoutToast,
-        MultisigCancellationToastKind.submitFailed => l10n.multisigCancelFailed,
       };
       context.showErrorToaster(message: message);
       ref.read(multisigCancellationToastProvider.notifier).clear();

--- a/mobile-app/lib/v2/components/multisig_creation_toast_listener.dart
+++ b/mobile-app/lib/v2/components/multisig_creation_toast_listener.dart
@@ -18,7 +18,6 @@ class MultisigCreationToastListener extends ConsumerWidget {
       final message = switch (next.kind) {
         MultisigCreationToastKind.ready => l10n.multisigCreateReadyToast,
         MultisigCreationToastKind.timeout => l10n.multisigCreateTimeoutToast,
-        MultisigCreationToastKind.submitFailed => l10n.multisigCreateErrorCouldNotCreate,
       };
       if (next.kind == MultisigCreationToastKind.ready) {
         context.showSuccessToaster(message: message);

--- a/mobile-app/lib/v2/components/multisig_proposal_toast_listener.dart
+++ b/mobile-app/lib/v2/components/multisig_proposal_toast_listener.dart
@@ -17,7 +17,6 @@ class MultisigProposalToastListener extends ConsumerWidget {
       final l10n = ref.read(l10nProvider);
       final message = switch (next.kind) {
         MultisigProposalToastKind.timeout => l10n.multisigProposeTimeoutToast,
-        MultisigProposalToastKind.submitFailed => l10n.multisigProposeSubmitFailed,
       };
       context.showErrorToaster(message: message);
       ref.read(multisigProposalToastProvider.notifier).clear();

--- a/mobile-app/lib/v2/screens/multisig/add_multisig_screen.dart
+++ b/mobile-app/lib/v2/screens/multisig/add_multisig_screen.dart
@@ -269,10 +269,13 @@ class _AddMultisigScreenState extends ConsumerState<AddMultisigScreen> {
         context.showErrorToaster(message: l10n.multisigCreateInsufficientBalance);
       }
     } catch (e) {
-      // Submission failures already surface a toast via the creation toast
-      // listener (MultisigCreationToastKind.submitFailed), so avoid showing a
-      // duplicate here. We still catch to stop loading and skip navigation.
+      // The submission service rethrows without surfacing UI; the caller owns
+      // user feedback. Show a single error toast for any failure (submission or
+      // otherwise) and skip navigation.
       quantusDebugPrint('[AddMultisigScreen] createMultisig error: $e');
+      if (mounted) {
+        context.showErrorToaster(message: l10n.multisigCreateErrorCouldNotCreate);
+      }
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }

--- a/mobile-app/lib/v2/screens/multisig/add_multisig_screen.dart
+++ b/mobile-app/lib/v2/screens/multisig/add_multisig_screen.dart
@@ -269,11 +269,10 @@ class _AddMultisigScreenState extends ConsumerState<AddMultisigScreen> {
         context.showErrorToaster(message: l10n.multisigCreateInsufficientBalance);
       }
     } catch (e) {
+      // Submission failures already surface a toast via the creation toast
+      // listener (MultisigCreationToastKind.submitFailed), so avoid showing a
+      // duplicate here. We still catch to stop loading and skip navigation.
       quantusDebugPrint('[AddMultisigScreen] createMultisig error: $e');
-
-      if (mounted) {
-        context.showErrorToaster(message: l10n.multisigCreateErrorCouldNotCreate);
-      }
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }


### PR DESCRIPTION
## Summary
Make extrinsic submission awaited. Display error toast on failed submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and error handling for on-chain multisig flows; incorrect await/rethrow behavior could block navigation or leave pending UI state inconsistent, though scope is limited to submission orchestration.
> 
> **Overview**
> Multisig **creation** and **proposal lifecycle** submissions (propose, approve, execute, cancel) no longer fire extrinsics in the background with `unawaited`. Public APIs now **await chain acceptance** of the signed extrinsic; indexer polling still runs afterward as before.
> 
> On submit failure, services still clear optimistic pending state and show the existing **submit-failed toasts**, but they also **`rethrow`** so UI layers can stay on the current screen instead of navigating away as if submission succeeded.
> 
> **Add multisig** stops showing a second generic error toaster when submission fails, since the creation toast listener already handles that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4283483ff9bf976df7af5b65d2de364d1a59b67. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->