### PR TITLE
feat: add missing l10n keys

### DIFF
--- a/mobile-app/lib/l10n/app_id.arb
+++ b/mobile-app/lib/l10n/app_id.arb
@@ -538,5 +538,30 @@
 
   "commonLoading": "Memuat...",
   "commonAmountBalance": "{balance} {symbol}",
-  "commonContinue": "Lanjutkan"
+  "commonContinue": "Lanjutkan",
+
+  "redeemToLabel": "Tukar Ke",
+  "redeemAddressHint": "Tempel Alamat {symbol}",
+  "redeemAmountCta": "Tukar {amount}",
+  "redeemConfirmTitle": "Konfirmasi Penukaran",
+  "redeemConfirmAmount": "Jumlah",
+  "redeemConfirmTo": "Ke",
+  "redeemConfirmFee": "Biaya",
+  "redeemFeeValue": "Biaya volume 0,1%",
+  "redeemProgressTitle": "Menukar...",
+  "redeemCompleteTitle": "Penukaran Selesai",
+  "redeemFailedTitle": "Penukaran Gagal",
+  "redeemingLabel": "MENUKAR",
+  "redeemStepCircuits": "Menyiapkan sirkuit",
+  "redeemStepTransfers": "Mengambil transfer",
+  "redeemStepNullifiers": "Menghitung nullifier",
+  "redeemStepCheckNullifiers": "Memeriksa nullifier",
+  "redeemStepProofs": "Membuat bukti ZK",
+  "redeemStepAggregate": "Mengagregasi & mengirim",
+  "redeemFetchedCount": "{count} diambil",
+  "redeemCancel": "Batal",
+  "redeemRetry": "Coba Lagi",
+  "redeemClose": "Tutup",
+  "redeemDone": "Selesai",
+  "redeemSuccessBanner": "{amount} ditukar dalam {count} batch"
 }

--- a/mobile-app/lib/l10n/app_localizations_id.dart
+++ b/mobile-app/lib/l10n/app_localizations_id.dart
@@ -1600,82 +1600,82 @@ class AppLocalizationsId extends AppLocalizations {
   String get commonContinue => 'Lanjutkan';
 
   @override
-  String get redeemToLabel => 'Redeem To';
+  String get redeemToLabel => 'Tukar Ke';
 
   @override
   String redeemAddressHint(String symbol) {
-    return 'Paste a $symbol Address';
+    return 'Tempel Alamat $symbol';
   }
 
   @override
   String redeemAmountCta(String amount) {
-    return 'Redeem $amount';
+    return 'Tukar $amount';
   }
 
   @override
-  String get redeemConfirmTitle => 'Confirm Redeem';
+  String get redeemConfirmTitle => 'Konfirmasi Penukaran';
 
   @override
-  String get redeemConfirmAmount => 'Amount';
+  String get redeemConfirmAmount => 'Jumlah';
 
   @override
-  String get redeemConfirmTo => 'To';
+  String get redeemConfirmTo => 'Ke';
 
   @override
-  String get redeemConfirmFee => 'Fee';
+  String get redeemConfirmFee => 'Biaya';
 
   @override
-  String get redeemFeeValue => '0.1% volume fee';
+  String get redeemFeeValue => 'Biaya volume 0,1%';
 
   @override
-  String get redeemProgressTitle => 'Redeeming...';
+  String get redeemProgressTitle => 'Menukar...';
 
   @override
-  String get redeemCompleteTitle => 'Redeem Complete';
+  String get redeemCompleteTitle => 'Penukaran Selesai';
 
   @override
-  String get redeemFailedTitle => 'Redeem Failed';
+  String get redeemFailedTitle => 'Penukaran Gagal';
 
   @override
-  String get redeemingLabel => 'REDEEMING';
+  String get redeemingLabel => 'MENUKAR';
 
   @override
-  String get redeemStepCircuits => 'Preparing circuits';
+  String get redeemStepCircuits => 'Menyiapkan sirkuit';
 
   @override
-  String get redeemStepTransfers => 'Fetching transfers';
+  String get redeemStepTransfers => 'Mengambil transfer';
 
   @override
-  String get redeemStepNullifiers => 'Computing nullifiers';
+  String get redeemStepNullifiers => 'Menghitung nullifier';
 
   @override
-  String get redeemStepCheckNullifiers => 'Checking nullifiers';
+  String get redeemStepCheckNullifiers => 'Memeriksa nullifier';
 
   @override
-  String get redeemStepProofs => 'Generating ZK proofs';
+  String get redeemStepProofs => 'Membuat bukti ZK';
 
   @override
-  String get redeemStepAggregate => 'Aggregating & submitting';
+  String get redeemStepAggregate => 'Mengagregasi & mengirim';
 
   @override
   String redeemFetchedCount(int count) {
-    return '$count fetched';
+    return '$count diambil';
   }
 
   @override
-  String get redeemCancel => 'Cancel';
+  String get redeemCancel => 'Batal';
 
   @override
-  String get redeemRetry => 'Retry';
+  String get redeemRetry => 'Coba Lagi';
 
   @override
-  String get redeemClose => 'Close';
+  String get redeemClose => 'Tutup';
 
   @override
-  String get redeemDone => 'Done';
+  String get redeemDone => 'Selesai';
 
   @override
   String redeemSuccessBanner(String amount, int count) {
-    return '$amount redeemed in $count batch(es)';
+    return '$amount ditukar dalam $count batch';
   }
 }


### PR DESCRIPTION
## Summary
Add missing translations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only localization changes with no logic or API impact.
> 
> **Overview**
> Adds **Indonesian (`id`) strings** for the mining-rewards **redeem** UI so Indonesian locale users no longer see English copy on that flow.
> 
> **`app_id.arb`** gains the full set of `redeem*` keys (destination, confirm sheet, fee, progress steps, cancel/retry/done, success banner) and fixes the trailing comma after `commonContinue`. **`app_localizations_id.dart`** replaces the previous English placeholder values for those getters with the new Indonesian text (e.g. *Tukar Ke*, *Konfirmasi Penukaran*, ZK step labels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b684326831d444133d9f0f18296c4491cb47814. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->