### PR TITLE
feat: silent refresh when receiving notification

### DIFF
--- a/mobile-app/lib/services/firebase_messaging_service.dart
+++ b/mobile-app/lib/services/firebase_messaging_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -6,6 +7,7 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/models/notification_models.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/notification_provider.dart';
+import 'package:resonance_network_wallet/services/history_polling_manager.dart';
 import 'package:resonance_network_wallet/services/transaction_service.dart';
 import 'package:resonance_network_wallet/shared/utils/print.dart';
 
@@ -130,9 +132,15 @@ class FirebaseMessagingService {
   /// Listen for messages when the app is in the foreground.
   /// FCM does NOT show a system notification in this case, so we convert
   /// the message to a NotificationData and show it via local notifications.
+  ///
+  /// Background/terminated resume is already covered by the app lifecycle
+  /// manager (silent refresh on resume), so here we only refresh historical
+  /// data (balance, activity, proposals) for the foreground case.
   void _setupForegroundMessageListener() {
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
       quantusDebugPrint('FCM foreground message: ${message.messageId}');
+
+      unawaited(_ref.read(historyPollingManagerProvider).triggerSilentRefresh());
 
       final notification = _remoteMessageToNotificationData(message);
       if (notification == null) return;

--- a/mobile-app/lib/services/history_polling_manager.dart
+++ b/mobile-app/lib/services/history_polling_manager.dart
@@ -13,6 +13,7 @@ class HistoryPollingManager {
   late final GlobalHistoryPollingService _globalPoller;
   late final ReversibleTransferMonitoringService _reversibleMonitor;
   bool _initialized = false;
+  bool _isRefreshing = false;
 
   HistoryPollingManager(this._ref) {
     _globalPoller = _ref.read(globalHistoryPollingServiceProvider);
@@ -43,13 +44,30 @@ class HistoryPollingManager {
     _globalPoller.stopPolling();
   }
 
-  /// Trigger a silent refresh of all data (no loading indicators)
+  /// Trigger a silent refresh of all data (no loading indicators).
+  ///
+  /// Invalidating providers only schedules a reload; it does not wait for it.
+  /// To avoid flipping [_isRefreshing] back to false while balance, history, and
+  /// multisig providers are still re-fetching, this awaits each reload to
+  /// completion so concurrent triggers are correctly suppressed.
   Future<void> triggerSilentRefresh() async {
-    quantusDebugPrint('History polling manager: Silent Refresh!');
+    if (_isRefreshing) {
+      quantusDebugPrint('History polling manager: refresh in progress, skipping');
+      return;
+    }
 
-    invalidateActiveAccountBalance(_ref);
-    await silentRefreshActiveAccount(_ref);
-    invalidateActiveMultisigProposals(_ref);
+    _isRefreshing = true;
+    try {
+      quantusDebugPrint('History polling manager: Silent Refresh!');
+
+      await Future.wait([
+        refreshActiveAccountBalance(_ref),
+        silentRefreshActiveAccount(_ref),
+        refreshActiveMultisigProposals(_ref),
+      ]);
+    } finally {
+      _isRefreshing = false;
+    }
   }
 
   void dispose() {

--- a/mobile-app/lib/shared/utils/polling_refresh_scope.dart
+++ b/mobile-app/lib/shared/utils/polling_refresh_scope.dart
@@ -55,6 +55,15 @@ void invalidateActiveAccountBalance(Ref ref) {
   ref.invalidate(balanceProviderFamily(accountId));
 }
 
+/// Invalidates the active account balance and waits for it to reload.
+Future<void> refreshActiveAccountBalance(Ref ref) async {
+  final accountId = activeAccountId(ref);
+  if (accountId == null) return;
+
+  ref.invalidate(balanceProviderFamily(accountId));
+  await ref.read(balanceProviderFamily(accountId).future);
+}
+
 /// Invalidates balance for the given account IDs.
 void invalidateAccountBalances(Ref ref, Iterable<String> accountIds) {
   for (final accountId in accountIds) {


### PR DESCRIPTION
## Summary
Silent refresh!!!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single fire-and-forget call on foreground FCM with existing refresh logic; no auth or push registration changes.
> 
> **Overview**
> When the app is **open and receives an FCM message**, it now kicks off the same **silent refresh** path used on resume (`HistoryPollingManager.triggerSilentRefresh()`), so balance, activity history, and multisig proposals update without loading spinners before the local notification is shown.
> 
> **Background/terminated** delivery is unchanged—resume still refreshes via the app lifecycle manager; this PR only closes the **foreground** gap where lifecycle resume does not run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd688b463cf7228a4d66b5a189d4e77cc4765d29. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->