### PR TITLE
Scope backup nudge to wallets created on-device

### DIFF
--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -1935,6 +1935,10 @@
     "@settingsRecoveryPhraseDone": {
       "description": "Done button on recovery phrase screen"
     },
+    "settingsRecoveryAlreadyBackedUp": "I already backed up my wallet",
+    "@settingsRecoveryAlreadyBackedUp": {
+      "description": "Secondary action on the recovery phrase caution screen that dismisses the backup reminder without revealing the phrase"
+    },
 
     "settingsResetTitle": "Reset Wallet",
     "@settingsResetTitle": {

--- a/mobile-app/lib/l10n/app_id.arb
+++ b/mobile-app/lib/l10n/app_id.arb
@@ -440,6 +440,7 @@
 
   "settingsRecoveryPhraseTitle": "Frasa Pemulihan",
   "settingsRecoveryPhraseDone": "Selesai",
+  "settingsRecoveryAlreadyBackedUp": "Saya sudah mencadangkan dompet saya",
 
   "settingsResetTitle": "Reset Dompet",
   "settingsResetAuthReason": "Autentikasi untuk mereset dompet",

--- a/mobile-app/lib/l10n/app_localizations.dart
+++ b/mobile-app/lib/l10n/app_localizations.dart
@@ -2534,6 +2534,12 @@ abstract class AppLocalizations {
   /// **'Done'**
   String get settingsRecoveryPhraseDone;
 
+  /// Secondary action on the recovery phrase caution screen that dismisses the backup reminder without revealing the phrase
+  ///
+  /// In en, this message translates to:
+  /// **'I already backed up my wallet'**
+  String get settingsRecoveryAlreadyBackedUp;
+
   /// App bar on reset wallet caution screen
   ///
   /// In en, this message translates to:

--- a/mobile-app/lib/l10n/app_localizations_en.dart
+++ b/mobile-app/lib/l10n/app_localizations_en.dart
@@ -1339,6 +1339,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsRecoveryPhraseDone => 'Done';
 
   @override
+  String get settingsRecoveryAlreadyBackedUp => 'I already backed up my wallet';
+
+  @override
   String get settingsResetTitle => 'Reset Wallet';
 
   @override

--- a/mobile-app/lib/l10n/app_localizations_id.dart
+++ b/mobile-app/lib/l10n/app_localizations_id.dart
@@ -1342,6 +1342,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsRecoveryPhraseDone => 'Selesai';
 
   @override
+  String get settingsRecoveryAlreadyBackedUp => 'I already backed up my wallet';
+
+  @override
   String get settingsResetTitle => 'Reset Dompet';
 
   @override

--- a/mobile-app/lib/l10n/app_localizations_id.dart
+++ b/mobile-app/lib/l10n/app_localizations_id.dart
@@ -1342,7 +1342,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsRecoveryPhraseDone => 'Selesai';
 
   @override
-  String get settingsRecoveryAlreadyBackedUp => 'I already backed up my wallet';
+  String get settingsRecoveryAlreadyBackedUp => 'Saya sudah mencadangkan dompet saya';
 
   @override
   String get settingsResetTitle => 'Reset Dompet';

--- a/mobile-app/lib/providers/wallet_providers.dart
+++ b/mobile-app/lib/providers/wallet_providers.dart
@@ -241,17 +241,26 @@ final recoveryPhraseViewedProvider = Provider.family<bool, int>((ref, walletInde
   return ref.watch(settingsServiceProvider).recoveryPhraseViewed(walletIndex);
 });
 
+final walletOriginProvider = Provider.family<WalletOrigin?, int>((ref, walletIndex) {
+  return ref.watch(settingsServiceProvider).getWalletOrigin(walletIndex);
+});
+
 /// 0.0001 QUAN in raw units; dust below this doesn't warrant a backup nudge.
 final _backupNudgeBalanceThreshold = BigInt.from(10).pow(AppConstants.decimals - 4);
 
 /// Wallet index needing a recovery phrase backup reminder, or null when none.
+/// Only nudges mnemonic-backed wallets created on this device (or legacy wallets
+/// of unknown origin). Never nudges multisig/entrusted accounts (not
+/// [RegularAccount]), hardware (keystone) wallets, or imported wallets.
 final backupReminderWalletIndexProvider = Provider<int?>((ref) {
   final active = ref.watch(activeAccountProvider).value;
   if (active is! RegularAccount) return null;
+  if (active.account.accountType != AccountType.local) return null;
 
   final walletIndex = active.account.walletIndex;
   if (AppConstants.debugAlwaysShowBackupNudge) return walletIndex;
 
+  if (ref.watch(walletOriginProvider(walletIndex)) == WalletOrigin.imported) return null;
   if (ref.watch(recoveryPhraseViewedProvider(walletIndex))) return null;
 
   final balance = ref.watch(balanceProvider).value ?? BigInt.zero;

--- a/mobile-app/lib/services/logout_service.dart
+++ b/mobile-app/lib/services/logout_service.dart
@@ -14,6 +14,7 @@ import 'package:resonance_network_wallet/providers/pending_multisig_executions_p
 import 'package:resonance_network_wallet/providers/pending_multisig_proposals_provider.dart';
 import 'package:resonance_network_wallet/providers/pending_transactions_provider.dart';
 import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
+import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
 import 'package:resonance_network_wallet/services/multisig_approval_polling_service.dart';
 import 'package:resonance_network_wallet/services/multisig_cancellation_polling_service.dart';
@@ -46,6 +47,8 @@ class LogoutService {
     _ref.invalidate(miningRewardsProvider);
     _ref.read(accountsProvider.notifier).reset();
     _ref.read(activeAccountProvider.notifier).reset();
+    _ref.invalidate(recoveryPhraseViewedProvider);
+    _ref.invalidate(walletOriginProvider);
     _ref.read(multisigAccountsProvider.notifier).reset();
     _ref.invalidate(discoveredMultisigsProvider);
     _ref.read(accountAssociationsProvider.notifier).reset();

--- a/mobile-app/lib/services/wallet_creation_service.dart
+++ b/mobile-app/lib/services/wallet_creation_service.dart
@@ -32,6 +32,7 @@ class WalletCreationService {
 
     final hasRoot = existingAccounts.any((a) => a.walletIndex == walletIndex && a.index == 0);
     if (!hasRoot) {
+      _settings.setWalletOrigin(walletIndex, WalletOrigin.created);
       final account = Account(walletIndex: walletIndex, index: 0, name: name, accountId: accountId);
       await _accounts.addAccount(account);
       unawaited(_referral.submitAddressToBackend());

--- a/mobile-app/lib/v2/screens/home/backup_reminder_banner.dart
+++ b/mobile-app/lib/v2/screens/home/backup_reminder_banner.dart
@@ -19,7 +19,9 @@ class BackupReminderBanner extends ConsumerWidget {
     return GestureDetector(
       onTap: () => Navigator.push(
         context,
-        MaterialPageRoute(builder: (_) => RecoveryPhraseConfirmationScreen(walletIndex: walletIndex)),
+        MaterialPageRoute(
+          builder: (_) => RecoveryPhraseConfirmationScreen(walletIndex: walletIndex, showAlreadyBackedUp: true),
+        ),
       ),
       child: Container(
         padding: const EdgeInsets.all(16),

--- a/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
+++ b/mobile-app/lib/v2/screens/import/import_wallet_screen.dart
@@ -112,8 +112,8 @@ class _ImportWalletScreenV2State extends ConsumerState<ImportWalletScreenV2> {
       ref.invalidate(activeAccountProvider);
       _settingsService.setReferralCheckCompleted();
       _settingsService.setExistingUserSeenPromoVideo();
-      _settingsService.setRecoveryPhraseViewed(widget.walletIndex);
-      ref.invalidate(recoveryPhraseViewedProvider(widget.walletIndex));
+      _settingsService.setWalletOrigin(widget.walletIndex, WalletOrigin.imported);
+      ref.invalidate(walletOriginProvider(widget.walletIndex));
 
       if (ref.read(remoteConfigProvider).enableRemoteNotifications && widget.walletIndex == 0) {
         ref.read(firebaseMessagingServiceProvider).registerDeviceIfPossible();

--- a/mobile-app/lib/v2/screens/settings/recovery_phrase_confirmation_screen.dart
+++ b/mobile-app/lib/v2/screens/settings/recovery_phrase_confirmation_screen.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:resonance_network_wallet/providers/l10n_provider.dart';
+import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/services/local_auth_service.dart';
 import 'package:resonance_network_wallet/shared/extensions/toaster_extensions.dart';
 import 'package:resonance_network_wallet/v2/screens/settings/recovery_phrase_screen.dart';
 import 'package:resonance_network_wallet/v2/screens/settings/settings_caution_scaffold.dart';
 
 class RecoveryPhraseConfirmationScreen extends ConsumerStatefulWidget {
-  const RecoveryPhraseConfirmationScreen({super.key, required this.walletIndex});
+  const RecoveryPhraseConfirmationScreen({super.key, required this.walletIndex, this.showAlreadyBackedUp = false});
 
   final int walletIndex;
+
+  /// When true (the home backup nudge), offers an "I already backed up" action
+  /// that dismisses the nudge without revealing the phrase.
+  final bool showAlreadyBackedUp;
 
   @override
   ConsumerState<RecoveryPhraseConfirmationScreen> createState() => _RecoveryPhraseConfirmationScreenState();
@@ -31,6 +36,12 @@ class _RecoveryPhraseConfirmationScreenState extends ConsumerState<RecoveryPhras
     }
   }
 
+  void _onAlreadyBackedUp() {
+    ref.read(settingsServiceProvider).setRecoveryPhraseViewed(widget.walletIndex);
+    ref.invalidate(recoveryPhraseViewedProvider(widget.walletIndex));
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = ref.watch(l10nProvider);
@@ -40,6 +51,8 @@ class _RecoveryPhraseConfirmationScreenState extends ConsumerState<RecoveryPhras
       data: SettingsCautionScaffoldData.recoveryPhrase(l10n),
       continueLabel: l10n.commonContinue,
       onContinue: _onContinue,
+      secondaryLabel: widget.showAlreadyBackedUp ? l10n.settingsRecoveryAlreadyBackedUp : null,
+      onSecondary: widget.showAlreadyBackedUp ? _onAlreadyBackedUp : null,
     );
   }
 }

--- a/mobile-app/lib/v2/screens/settings/settings_caution_scaffold.dart
+++ b/mobile-app/lib/v2/screens/settings/settings_caution_scaffold.dart
@@ -46,6 +46,8 @@ class SettingsCautionScaffold extends StatelessWidget {
   final SettingsCautionScaffoldData data;
   final SettingsDividerStyle betweenBulletsStyle;
   final bool continueButtonLoading;
+  final String? secondaryLabel;
+  final VoidCallback? onSecondary;
 
   const SettingsCautionScaffold({
     super.key,
@@ -57,6 +59,8 @@ class SettingsCautionScaffold extends StatelessWidget {
     this.onCheckboxChanged,
     this.betweenBulletsStyle = SettingsDividerStyle.list,
     this.continueButtonLoading = false,
+    this.secondaryLabel,
+    this.onSecondary,
   });
 
   @override
@@ -90,6 +94,8 @@ class SettingsCautionScaffold extends StatelessWidget {
         onCheckboxChanged: onCheckboxChanged,
         onContinue: onContinue,
         continueButtonLoading: continueButtonLoading,
+        secondaryLabel: secondaryLabel,
+        onSecondary: onSecondary,
       ),
     );
   }
@@ -103,6 +109,8 @@ class _SettingsCautionBottom extends StatelessWidget {
     required this.onCheckboxChanged,
     required this.onContinue,
     required this.continueButtonLoading,
+    required this.secondaryLabel,
+    required this.onSecondary,
   });
 
   final String? checkboxLabel;
@@ -111,6 +119,8 @@ class _SettingsCautionBottom extends StatelessWidget {
   final VoidCallback? onCheckboxChanged;
   final VoidCallback onContinue;
   final bool continueButtonLoading;
+  final String? secondaryLabel;
+  final VoidCallback? onSecondary;
 
   @override
   Widget build(BuildContext context) {
@@ -129,6 +139,10 @@ class _SettingsCautionBottom extends StatelessWidget {
             isDisabled: checkboxLabel != null && !checked,
             isLoading: continueButtonLoading,
           ),
+          if (secondaryLabel != null) ...[
+            const SizedBox(height: 12),
+            QuantusButton.simple(label: secondaryLabel!, onTap: onSecondary, variant: ButtonVariant.transparent),
+          ],
         ],
       ),
     );

--- a/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
+++ b/mobile-app/lib/v2/screens/welcome/welcome_screen.dart
@@ -4,6 +4,7 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/providers/account_providers.dart';
 import 'package:resonance_network_wallet/providers/l10n_provider.dart';
 import 'package:resonance_network_wallet/providers/remote_config_provider.dart';
+import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
 import 'package:resonance_network_wallet/services/wallet_creation_service.dart';
 import 'package:resonance_network_wallet/shared/extensions/toaster_extensions.dart';
@@ -48,6 +49,8 @@ class _WelcomeScreenV2State extends ConsumerState<WelcomeScreenV2> {
 
       ref.invalidate(accountsProvider);
       ref.invalidate(activeAccountProvider);
+      ref.invalidate(walletOriginProvider(_walletIndex));
+      ref.invalidate(recoveryPhraseViewedProvider(_walletIndex));
 
       if (ref.read(remoteConfigProvider).enableRemoteNotifications) {
         ref.read(firebaseMessagingServiceProvider).registerDeviceIfPossible();

--- a/quantus_sdk/lib/src/models/account.dart
+++ b/quantus_sdk/lib/src/models/account.dart
@@ -3,6 +3,10 @@ import 'package:quantus_sdk/src/models/base_account.dart';
 
 enum AccountType { local, keystone, external, encrypted }
 
+/// How the mnemonic-backed wallet at a given walletIndex came to exist.
+/// Absent (legacy wallets) is treated as unknown.
+enum WalletOrigin { created, imported }
+
 @immutable
 class Account implements BaseAccount {
   final int walletIndex;

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -166,6 +166,8 @@ class SettingsService {
     }
     await saveAccounts(remaining);
     await deleteMnemonic(walletIndex);
+    await _prefs.remove(_walletOriginKey(walletIndex));
+    await _prefs.remove(_recoveryPhraseViewedKey(walletIndex));
   }
 
   Future<void> setActiveAccount(DisplayAccount account) async {

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -571,6 +571,17 @@ class SettingsService {
     _prefs.setBool(_recoveryPhraseViewedKey(walletIndex), true);
   }
 
+  String _walletOriginKey(int walletIndex) => 'wallet_origin_$walletIndex';
+
+  WalletOrigin? getWalletOrigin(int walletIndex) {
+    final value = _prefs.getString(_walletOriginKey(walletIndex));
+    return value == null ? null : WalletOrigin.values.asNameMap()[value];
+  }
+
+  void setWalletOrigin(int walletIndex, WalletOrigin origin) {
+    _prefs.setString(_walletOriginKey(walletIndex), origin.name);
+  }
+
   bool existingUserSeenPromoVideo() {
     return _prefs.getBool(existingUserSeenPromoVideoKey) ?? false;
   }


### PR DESCRIPTION
## Summary
- Only show the recovery-phrase backup nudge for mnemonic-backed wallets **created on this device** (or legacy wallets of unknown origin, for backwards compatibility).
- Never nudge **keystone/hardware** wallets, **multisig/entrusted** accounts, or **imported** wallets (you already have the phrase when importing).
- Track wallet origin (`created` vs `imported`) via a new `WalletOrigin`, persisted per `walletIndex` in `SettingsService`.
- Add an **"I already backed up my wallet"** action on the recovery-phrase caution screen (shown from the home nudge) so users who already backed up can dismiss without viewing/copying the phrase again.

## Test plan
- [ ] Create a new wallet on-device, fund it above the threshold → nudge appears on home.
- [ ] Tap nudge → "I already backed up my wallet" → nudge disappears (no phrase reveal needed).
- [ ] View/copy the phrase → nudge also disappears (existing behavior).
- [ ] Import a wallet → no nudge.
- [ ] Keystone (hardware) wallet active → no nudge.
- [ ] Multisig/entrusted account active → no nudge.
- [ ] Legacy wallet (no stored origin) still nudges.