### PR TITLE
chore: upgrade telemetrydecksdk to 4.0.0

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -52,7 +52,7 @@ dependency_overrides:
 #   flutter_svg          ^2.3.0
 #   flash                ^3.1.1
 #   collection           ^1.19.1
-#   telemetrydecksdk     ^3.0.0
+#   telemetrydecksdk     ^4.0.0
 #   flutter_lints        ^6.0.0
 
 scripts:

--- a/miner-app/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/miner-app/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swiftsdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TelemetryDeck/SwiftSDK",
+      "state" : {
+        "revision" : "ad4a03ec7ea7416a4081370f21c86e55b02a5b88",
+        "version" : "2.14.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/miner-app/pubspec.lock
+++ b/miner-app/pubspec.lock
@@ -951,10 +951,10 @@ packages:
     dependency: "direct main"
     description:
       name: telemetrydecksdk
-      sha256: a25daf7f85a3c17da26b0b794a2c66feb4fcd4065a0891fe26f2c9ac23dde1a6
+      sha256: "0f28f90bf70cb69327927666ccd2fb0639c958133fbad101088741960e234c3a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1125,4 +1125,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.0"

--- a/miner-app/pubspec.yaml
+++ b/miner-app/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path: ^1.9.1
   flutter_svg: ^2.3.0
   flash: ^3.1.1
-  telemetrydecksdk: ^3.0.0
+  telemetrydecksdk: ^4.0.0
 
   # Miner-only
   go_router: ^17.2.2

--- a/mobile-app/android/build.gradle
+++ b/mobile-app/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/mobile-app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile-app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -116,6 +116,15 @@
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
       }
+    },
+    {
+      "identity" : "swiftsdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TelemetryDeck/SwiftSDK",
+      "state" : {
+        "revision" : "ad4a03ec7ea7416a4081370f21c86e55b02a5b88",
+        "version" : "2.14.1"
+      }
     }
   ],
   "version" : 2

--- a/mobile-app/pubspec.lock
+++ b/mobile-app/pubspec.lock
@@ -1645,10 +1645,10 @@ packages:
     dependency: "direct main"
     description:
       name: telemetrydecksdk
-      sha256: a25daf7f85a3c17da26b0b794a2c66feb4fcd4065a0891fe26f2c9ac23dde1a6
+      sha256: "0f28f90bf70cb69327927666ccd2fb0639c958133fbad101088741960e234c3a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1931,4 +1931,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.0"

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter_svg: ^2.3.0
   flash: ^3.1.1
   collection: ^1.19.1
-  telemetrydecksdk: ^3.0.0
+  telemetrydecksdk: ^4.0.0
 
   # State management
   flutter_riverpod: ^3.3.1


### PR DESCRIPTION
## Summary
- Bump `telemetrydecksdk` from `^3.0.0` to `^4.0.0` in `mobile-app` and `miner-app` (lockfiles + the canonical-version note in `melos.yaml`).
- `4.0.0` has **no Dart API changes** ([changelog](https://pub.dev/packages/telemetrydecksdk/changelog)); it raises native minimums and ships the iOS/macOS plugins as Swift packages.
- Existing config already satisfies every new minimum, so no platform changes were required:
  - Flutter `3.44` ≥ `3.41.0`
  - iOS `15.0` ≥ `13.0`
  - macOS `10.15` ≥ `10.15`
  - Android `minSdk 24` (Flutter default) ≥ `23`, Kotlin already `2.3.21`
- Bumped Android AGP `9.2.0` → `9.2.1` in `mobile-app/android/build.gradle` to match the migration notes (Gradle wrapper `9.5.1` already supports it).
- Updated SwiftPM `Package.resolved` pins for the new `TelemetryDeck/SwiftSDK 2.14.1` dependency (`mobile-app/ios` updated; `miner-app/macos` newly generated, both projects are already SwiftPM-migrated).

## Test plan
- [x] `melos bootstrap` resolves both apps to `telemetrydecksdk 4.0.0`
- [x] `melos analyze` (CI parity: `flutter analyze --fatal-infos`) passes with no issues
- [x] iOS build (`mobile-app`)
- [x] macOS build (`miner-app`)
- [x] Android build (`mobile-app`)