### PR TITLE
Bump quantus_ur to 1.4.0 (drops yanked core2)

### DIFF
--- a/quantus_sdk/rust/Cargo.lock
+++ b/quantus_sdk/rust/Cargo.lock
@@ -849,15 +849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +995,12 @@ checksum = "57967e4b200d767d091b961d6ab42cc7d0cc14fe9e052e75d0d3cf9eb732d895"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "dashmap"
@@ -1973,6 +1970,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keystone-ur"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a08a7e0ccd113dac19485c5c0fe87c70b663f896c48e4493814e446175078d4"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "crc",
+ "minicbor",
+ "phf",
+ "rand_xoshiro",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,22 +2002,25 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libflate"
-version = "1.3.0"
-source = "git+https://github.com/KeystoneHQ/libflate.git?tag=1.3.1#e6236f7417b9bd34dbbd4b3c821be10299c44a73"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f7ef5c7e3c2ed51f0fbc40e016c66558b699f16593521f30b98713bbb99cb8"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
+ "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "1.2.0"
-source = "git+https://github.com/KeystoneHQ/libflate.git?tag=1.3.1#e6236f7417b9bd34dbbd4b3c821be10299c44a73"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
- "hashbrown 0.13.2",
+ "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -2178,6 +2191,15 @@ dependencies = [
  "k256",
  "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3045,13 +3067,12 @@ dependencies = [
 [[package]]
 name = "quantus_ur"
 version = "0.1.0"
-source = "git+https://github.com/Quantus-Network/quantus_ur.git?tag=1.1.0#672d6a40170c3ab66bcd9c12966ff072e27cc4ac"
+source = "git+https://github.com/Quantus-Network/quantus_ur.git?tag=1.4.0#f3929da023e9c8081b8e9944b5b665871980fa79"
 dependencies = [
  "hex",
+ "keystone-ur",
  "minicbor",
- "ur",
  "ur-parse-lib",
- "ur-registry",
 ]
 
 [[package]]
@@ -4135,6 +4156,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-core"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,44 +4518,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "ur"
-version = "0.3.0"
-source = "git+https://github.com/KeystoneHQ/ur-rs?tag=0.3.3#81b8bb3b6b3a823128489c81ffee5bb4001ba2ae"
-dependencies = [
- "bitcoin_hashes 0.12.0",
- "crc",
- "minicbor",
- "phf",
- "rand_xoshiro",
-]
-
-[[package]]
 name = "ur-parse-lib"
-version = "0.2.0"
-source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust?tag=0.0.52#12c4d08dad2e0fb7b7dd05c4c11540dccc2f63bc"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7208ca6353acee95f8ff76d0fabd3a8b8e6f7bc460d71d7e0b3b52c470f8ef5"
 dependencies = [
  "hex",
- "ur",
+ "keystone-ur",
  "ur-registry",
 ]
 
 [[package]]
 name = "ur-registry"
-version = "0.1.1"
-source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust?tag=0.0.52#12c4d08dad2e0fb7b7dd05c4c11540dccc2f63bc"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46020e79f25a631d560b081c6d690a84665b94e71b77ab3d03c0134b456f5eba"
 dependencies = [
  "bs58",
- "core2",
  "hex",
+ "keystone-ur",
  "libflate",
  "minicbor",
+ "no_std_io2",
  "paste",
  "prost",
  "prost-build",
  "prost-types",
  "serde",
  "thiserror 1.0.69",
- "ur",
+ "thiserror-core",
 ]
 
 [[package]]

--- a/quantus_sdk/rust/Cargo.toml
+++ b/quantus_sdk/rust/Cargo.toml
@@ -18,7 +18,7 @@ nam-tiny-hderive = "0.3.1-nam.0"
 sp-core = { version = "39.0.0", default-features = true }
 parity-scale-codec = { version = "3.7.4", default-features = false, features = ["std"] }
 sp-runtime = { version = "39.0.0", default-features = false, features = ["std"] }
-quantus_ur = { git = "https://github.com/Quantus-Network/quantus_ur.git", tag = "1.1.0" }
+quantus_ur = { git = "https://github.com/Quantus-Network/quantus_ur.git", tag = "1.4.0" }
 
 # ZK proof generation (aligned with quantus-cli / chain)
 anyhow = "1.0"


### PR DESCRIPTION
Bumps `quantus_ur` 1.1.0 → 1.4.0 (Quantus-Network/quantus_ur#1), which switches to Keystone's crates.io releases and removes the yanked `core2` crate from the dependency tree.

Verified: `cargo build --locked`, 13/13 Rust tests, 85/85 SDK Flutter tests.