### PR TITLE
Fix keystone flow

### DIFF
--- a/mobile-app/lib/features/components/shared_address_action_sheet.dart
+++ b/mobile-app/lib/features/components/shared_address_action_sheet.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/features/styles/app_colors_theme.dart';
 import 'package:resonance_network_wallet/features/styles/app_text_theme.dart';
@@ -10,6 +11,7 @@ import 'package:resonance_network_wallet/shared/extensions/current_route_extensi
 import 'package:resonance_network_wallet/shared/extensions/media_query_data_extension.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
 import 'package:resonance_network_wallet/v2/screens/send/input_amount_screen.dart';
+import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
 import 'package:resonance_network_wallet/v2/screens/send/regular_send_strategy.dart';
 
 class SharedAddressActionSheet extends StatefulWidget {
@@ -58,6 +60,7 @@ class _SharedAddressActionSheetState extends State<SharedAddressActionSheet> {
   }
 
   void _sendToAddress() {
+    ProviderScope.containerOf(context).read(keystoneSignCacheProvider.notifier).startNewSendSession();
     Navigator.of(context).pop();
     Navigator.push(
       context,

--- a/mobile-app/lib/services/logout_service.dart
+++ b/mobile-app/lib/services/logout_service.dart
@@ -22,6 +22,7 @@ import 'package:resonance_network_wallet/services/multisig_creation_polling_serv
 import 'package:resonance_network_wallet/services/multisig_execution_polling_service.dart';
 import 'package:resonance_network_wallet/services/multisig_proposal_polling_service.dart';
 import 'package:resonance_network_wallet/services/pending_transaction_polling_service.dart';
+import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
 import 'package:resonance_network_wallet/v2/screens/welcome/welcome_screen.dart';
 
 final logoutServiceProvider = Provider<LogoutService>((ref) => LogoutService(ref));
@@ -52,6 +53,7 @@ class LogoutService {
     _ref.read(multisigAccountsProvider.notifier).reset();
     _ref.invalidate(discoveredMultisigsProvider);
     _ref.read(accountAssociationsProvider.notifier).reset();
+    _ref.read(keystoneSignCacheProvider.notifier).reset();
     await _ref.read(selectedAppLocaleProvider.notifier).reset();
     await _ref.read(selectedFiatCurrencyProvider.notifier).reset();
 

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -25,6 +25,7 @@ import 'package:resonance_network_wallet/v2/screens/receive/receive_screen.dart'
 import 'package:resonance_network_wallet/v2/screens/multisig/multisig_activity_section.dart';
 import 'package:resonance_network_wallet/v2/screens/multisig/multisig_proposal_detail_sheet.dart';
 import 'package:resonance_network_wallet/v2/screens/send/input_amount_screen.dart';
+import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
 import 'package:resonance_network_wallet/v2/screens/send/multisig_propose_strategy.dart';
 import 'package:resonance_network_wallet/v2/screens/send/regular_send_strategy.dart';
 import 'package:resonance_network_wallet/v2/screens/send/select_recipient_screen.dart';
@@ -96,6 +97,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   void _onPaymentIntent(PaymentIntent? _, PaymentIntent? payment) {
     if (payment == null || !mounted) return;
     ref.read(paymentIntentProvider.notifier).state = null;
+    ref.read(keystoneSignCacheProvider.notifier).startNewSendSession();
 
     final pageRoute = MaterialPageRoute(
       builder: (_) => InputAmountScreen(
@@ -330,10 +332,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final sendCard = _actionCard(
       iconAsset: 'assets/v2/action_send.svg',
       label: l10n.homeSend,
-      onTap: () => Navigator.push(
-        context,
-        MaterialPageRoute(builder: (_) => const SelectRecipientScreen(strategy: RegularSendStrategy())),
-      ),
+      onTap: () {
+        ref.read(keystoneSignCacheProvider.notifier).startNewSendSession();
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const SelectRecipientScreen(strategy: RegularSendStrategy())),
+        );
+      },
     );
 
     final swapCard = _actionCard(
@@ -368,12 +373,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         _actionCard(
           iconAsset: 'assets/v2/action_send.svg',
           label: l10n.multisigProposeTitle,
-          onTap: () => Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => SelectRecipientScreen(strategy: MultisigProposeStrategy(msig: msig)),
-            ),
-          ),
+          onTap: () {
+            ref.read(keystoneSignCacheProvider.notifier).startNewSendSession();
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => SelectRecipientScreen(strategy: MultisigProposeStrategy(msig: msig)),
+              ),
+            );
+          },
         ),
       ],
     );

--- a/mobile-app/lib/v2/screens/send/keystone_scan_signature_screen.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_scan_signature_screen.dart
@@ -134,6 +134,7 @@ class _KeystoneScanSignatureScreenState extends ConsumerState<KeystoneScanSignat
     } catch (e, st) {
       quantusDebugPrint('Keystone signature processing failed: $e');
       TelemetryService().sendError('Keystone signature processing failed', error: e, stackTrace: st);
+      ref.read(keystoneSignCacheProvider.notifier).reset();
       if (!mounted) return;
       setState(() {
         _submitting = false;
@@ -158,6 +159,7 @@ class _KeystoneScanSignatureScreenState extends ConsumerState<KeystoneScanSignat
     } catch (e, st) {
       quantusDebugPrint('Keystone signature simulation failed: $e');
       TelemetryService().sendError('Keystone signature simulation failed', error: e, stackTrace: st);
+      ref.read(keystoneSignCacheProvider.notifier).reset();
       if (!mounted) return;
       setState(() {
         _done = false;

--- a/mobile-app/lib/v2/screens/send/keystone_scan_signature_screen.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_scan_signature_screen.dart
@@ -12,6 +12,7 @@ import 'package:resonance_network_wallet/shared/utils/print.dart';
 import 'package:resonance_network_wallet/shared/utils/url_utils.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_button.dart';
 import 'package:resonance_network_wallet/v2/components/quantus_icon_button.dart';
+import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
 import 'package:resonance_network_wallet/v2/screens/send/send_strategy.dart';
 import 'package:resonance_network_wallet/v2/screens/send/send_terminal_screen.dart';
 import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
@@ -119,6 +120,8 @@ class _KeystoneScanSignatureScreenState extends ConsumerState<KeystoneScanSignat
             .addAddress(widget.recipientAddress)
             .catchError((Object e) => debugPrint('Failed to save recent address: $e')),
       );
+
+      ref.read(keystoneSignCacheProvider.notifier).startNewSendSession();
 
       if (!mounted) return;
       Navigator.pushReplacement(

--- a/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+
+/// Identifies a Keystone signing payload by the transfer parameters that define
+/// the extrinsic call. Block height and nonce are excluded so chain drift does
+/// not invalidate the cached QR within a send session.
+class KeystoneSignCacheKey {
+  final String accountId;
+  final String recipientAddress;
+  final BigInt amount;
+
+  const KeystoneSignCacheKey({required this.accountId, required this.recipientAddress, required this.amount});
+
+  factory KeystoneSignCacheKey.fromSendParams({
+    required String accountId,
+    required String recipientAddress,
+    required BigInt amount,
+  }) {
+    return KeystoneSignCacheKey(accountId: accountId, recipientAddress: recipientAddress.trim(), amount: amount);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is KeystoneSignCacheKey &&
+          accountId == other.accountId &&
+          recipientAddress == other.recipientAddress &&
+          amount == other.amount;
+
+  @override
+  int get hashCode => Object.hash(accountId, recipientAddress, amount);
+}
+
+class KeystoneSignCacheEntry {
+  final KeystoneSignCacheKey key;
+  final UnsignedTransactionData unsignedData;
+  final List<String> urParts;
+
+  const KeystoneSignCacheEntry({required this.key, required this.unsignedData, required this.urParts});
+}
+
+class KeystoneSignCacheNotifier extends StateNotifier<KeystoneSignCacheEntry?> {
+  KeystoneSignCacheNotifier() : super(null);
+
+  void startNewSendSession() {
+    state = null;
+  }
+
+  KeystoneSignCacheEntry? lookup(KeystoneSignCacheKey key) {
+    final entry = state;
+    if (entry == null || entry.key != key) return null;
+    return entry;
+  }
+
+  void store({
+    required KeystoneSignCacheKey key,
+    required UnsignedTransactionData unsignedData,
+    required List<String> urParts,
+  }) {
+    state = KeystoneSignCacheEntry(key: key, unsignedData: unsignedData, urParts: urParts);
+  }
+}
+
+final keystoneSignCacheProvider = StateNotifierProvider<KeystoneSignCacheNotifier, KeystoneSignCacheEntry?>(
+  (ref) => KeystoneSignCacheNotifier(),
+);

--- a/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
@@ -1,9 +1,6 @@
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 
-/// Average block time for Quantus (~12s). Bounds mortal-era cache TTL.
-const int keystoneSignCacheAvgBlockTimeSeconds = 12;
-
 /// Blocks of safety margin before mortal era expiry when treating cache as stale.
 const int keystoneSignCacheEraSafetyMarginBlocks = 2;
 
@@ -12,8 +9,8 @@ Duration keystoneSignCacheMaxAge(QuantusSigningPayload payload) {
   if (payload.eraPeriod == 0) {
     return const Duration(days: 1);
   }
-  final eraSeconds = payload.eraPeriod * keystoneSignCacheAvgBlockTimeSeconds;
-  final safetySeconds = keystoneSignCacheEraSafetyMarginBlocks * keystoneSignCacheAvgBlockTimeSeconds;
+  final eraSeconds = payload.eraPeriod * AppConstants.avgBlockTimeSeconds;
+  final safetySeconds = keystoneSignCacheEraSafetyMarginBlocks * AppConstants.avgBlockTimeSeconds;
   return Duration(seconds: eraSeconds - safetySeconds);
 }
 

--- a/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
@@ -1,6 +1,27 @@
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 
+/// Average block time for Quantus (~12s). Bounds mortal-era cache TTL.
+const int keystoneSignCacheAvgBlockTimeSeconds = 12;
+
+/// Blocks of safety margin before mortal era expiry when treating cache as stale.
+const int keystoneSignCacheEraSafetyMarginBlocks = 2;
+
+/// Max age for a cached Keystone payload derived from its mortal era period.
+Duration keystoneSignCacheMaxAge(QuantusSigningPayload payload) {
+  if (payload.eraPeriod == 0) {
+    return const Duration(days: 1);
+  }
+  final eraSeconds = payload.eraPeriod * keystoneSignCacheAvgBlockTimeSeconds;
+  final safetySeconds = keystoneSignCacheEraSafetyMarginBlocks * keystoneSignCacheAvgBlockTimeSeconds;
+  return Duration(seconds: eraSeconds - safetySeconds);
+}
+
+/// Returns true when [entry] is older than the mortal era validity window.
+bool isKeystoneSignCacheEntryExpired(KeystoneSignCacheEntry entry, DateTime now) {
+  return now.difference(entry.storedAt) >= keystoneSignCacheMaxAge(entry.unsignedData.payloadToSign);
+}
+
 /// Identifies a Keystone signing payload by the transfer parameters that define
 /// the extrinsic call. Block height and nonce are excluded so chain drift does
 /// not invalidate the cached QR within a send session.
@@ -35,8 +56,14 @@ class KeystoneSignCacheEntry {
   final KeystoneSignCacheKey key;
   final UnsignedTransactionData unsignedData;
   final List<String> urParts;
+  final DateTime storedAt;
 
-  const KeystoneSignCacheEntry({required this.key, required this.unsignedData, required this.urParts});
+  const KeystoneSignCacheEntry({
+    required this.key,
+    required this.unsignedData,
+    required this.urParts,
+    required this.storedAt,
+  });
 }
 
 class KeystoneSignCacheNotifier extends StateNotifier<KeystoneSignCacheEntry?> {
@@ -46,9 +73,13 @@ class KeystoneSignCacheNotifier extends StateNotifier<KeystoneSignCacheEntry?> {
     state = null;
   }
 
-  KeystoneSignCacheEntry? lookup(KeystoneSignCacheKey key) {
+  KeystoneSignCacheEntry? lookup(KeystoneSignCacheKey key, {DateTime? now}) {
     final entry = state;
     if (entry == null || entry.key != key) return null;
+    if (isKeystoneSignCacheEntryExpired(entry, now ?? DateTime.now())) {
+      state = null;
+      return null;
+    }
     return entry;
   }
 
@@ -56,8 +87,14 @@ class KeystoneSignCacheNotifier extends StateNotifier<KeystoneSignCacheEntry?> {
     required KeystoneSignCacheKey key,
     required UnsignedTransactionData unsignedData,
     required List<String> urParts,
+    DateTime? storedAt,
   }) {
-    state = KeystoneSignCacheEntry(key: key, unsignedData: unsignedData, urParts: urParts);
+    state = KeystoneSignCacheEntry(
+      key: key,
+      unsignedData: unsignedData,
+      urParts: urParts,
+      storedAt: storedAt ?? DateTime.now(),
+    );
   }
 
   void reset() {

--- a/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_sign_cache.dart
@@ -59,6 +59,10 @@ class KeystoneSignCacheNotifier extends StateNotifier<KeystoneSignCacheEntry?> {
   }) {
     state = KeystoneSignCacheEntry(key: key, unsignedData: unsignedData, urParts: urParts);
   }
+
+  void reset() {
+    state = null;
+  }
 }
 
 final keystoneSignCacheProvider = StateNotifierProvider<KeystoneSignCacheNotifier, KeystoneSignCacheEntry?>(

--- a/mobile-app/lib/v2/screens/send/keystone_sign_screen.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_sign_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/providers/currency_display_provider.dart';
 import 'package:resonance_network_wallet/providers/l10n_provider.dart';
 import 'package:resonance_network_wallet/providers/wallet_providers.dart';
 import 'package:resonance_network_wallet/services/telemetry_service.dart';
@@ -97,16 +98,51 @@ class _KeystoneSignScreenState extends ConsumerState<KeystoneSignScreen> {
     );
   }
 
+  Widget _transactionDetails(AppColorsV2 colors, AppTextTheme text, CurrencyDisplayState amountDisplay) {
+    return Column(
+      children: [
+        Text(
+          '${amountDisplay.primaryAmount} ${AppConstants.tokenSymbol}',
+          style: text.smallTitle?.copyWith(color: colors.textPrimary),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          widget.recipientAddress.trim(),
+          style: text.detail?.copyWith(
+            color: colors.textMuted,
+            fontFamily: AppTextTheme.fontFamilySecondary,
+            fontSize: 12,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          widget.recipientChecksum,
+          style: text.smallParagraph?.copyWith(color: colors.checksum, height: 1.2),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = ref.watch(l10nProvider);
     final colors = context.colors;
     final text = context.themeText;
+    final amountDisplay = ref.watch(txAmountDisplayProvider)(
+      widget.amount,
+      isSend: true,
+      withSignPrefix: false,
+      withQuanSymbol: false,
+      quanDecimals: 4,
+    );
 
     return ScaffoldBase(
       appBar: V2AppBar(title: widget.isPayMode ? l10n.sendPayTitle : l10n.sendTitle),
       mainContent: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const SizedBox(height: 8),
           Text(l10n.keystoneSignTitle, style: text.smallTitle, textAlign: TextAlign.center),
@@ -116,7 +152,9 @@ class _KeystoneSignScreenState extends ConsumerState<KeystoneSignScreen> {
             style: text.smallParagraph?.copyWith(color: colors.textTertiary),
             textAlign: TextAlign.center,
           ),
-          const SizedBox(height: 32),
+          const SizedBox(height: 24),
+          _transactionDetails(colors, text, amountDisplay),
+          const SizedBox(height: 24),
           Expanded(child: Center(child: _buildQr(colors, text))),
         ],
       ),

--- a/mobile-app/lib/v2/screens/send/keystone_sign_screen.dart
+++ b/mobile-app/lib/v2/screens/send/keystone_sign_screen.dart
@@ -13,6 +13,7 @@ import 'package:resonance_network_wallet/v2/components/scaffold_base.dart';
 import 'package:resonance_network_wallet/v2/components/scaffold_base_bottom_content.dart';
 import 'package:resonance_network_wallet/v2/components/v2_app_bar.dart';
 import 'package:resonance_network_wallet/v2/screens/send/keystone_scan_signature_screen.dart';
+import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
 import 'package:resonance_network_wallet/v2/screens/send/send_strategy.dart';
 import 'package:resonance_network_wallet/v2/theme/app_colors.dart';
 import 'package:resonance_network_wallet/v2/theme/app_text_styles.dart';
@@ -58,12 +59,28 @@ class _KeystoneSignScreenState extends ConsumerState<KeystoneSignScreen> {
   }
 
   Future<void> _prepare() async {
+    final cacheKey = KeystoneSignCacheKey.fromSendParams(
+      accountId: widget.account.accountId,
+      recipientAddress: widget.recipientAddress,
+      amount: widget.amount,
+    );
+    final cached = ref.read(keystoneSignCacheProvider.notifier).lookup(cacheKey);
+    if (cached != null) {
+      if (!mounted) return;
+      setState(() {
+        _unsignedData = cached.unsignedData;
+        _urParts = cached.urParts;
+      });
+      return;
+    }
+
     try {
       final substrate = ref.read(substrateServiceProvider);
       final call = ref.read(balancesServiceProvider).getBalanceTransferCall(widget.recipientAddress, widget.amount);
       final unsigned = await substrate.getUnsignedTransactionPayload(widget.account, call);
       final parts = encodeUr(data: unsigned.encodedPayloadRaw);
       if (parts.isEmpty) throw Exception('Failed to encode transaction payload as UR');
+      ref.read(keystoneSignCacheProvider.notifier).store(key: cacheKey, unsignedData: unsigned, urParts: parts);
       if (!mounted) return;
       setState(() {
         _unsignedData = unsigned;
@@ -89,7 +106,7 @@ class _KeystoneSignScreenState extends ConsumerState<KeystoneSignScreen> {
           recipientAddress: widget.recipientAddress,
           amount: widget.amount,
           networkFee: widget.networkFee,
-          blockHeight: widget.blockHeight,
+          blockHeight: unsignedData.payloadToSign.blockNumber,
           recipientChecksum: widget.recipientChecksum,
           isPayMode: widget.isPayMode,
           terminal: widget.terminal,

--- a/mobile-app/test/unit/keystone_sign_cache_test.dart
+++ b/mobile-app/test/unit/keystone_sign_cache_test.dart
@@ -1,0 +1,112 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
+
+void main() {
+  group('KeystoneSignCacheKey', () {
+    test('trims recipient address in fromSendParams', () {
+      final key = KeystoneSignCacheKey.fromSendParams(
+        accountId: 'account-a',
+        recipientAddress: '  recipient  ',
+        amount: BigInt.from(100),
+      );
+
+      expect(key.recipientAddress, 'recipient');
+    });
+
+    test('equal keys match regardless of recipient whitespace', () {
+      final keyA = KeystoneSignCacheKey.fromSendParams(
+        accountId: 'account-a',
+        recipientAddress: 'recipient',
+        amount: BigInt.from(100),
+      );
+      final keyB = KeystoneSignCacheKey.fromSendParams(
+        accountId: 'account-a',
+        recipientAddress: ' recipient ',
+        amount: BigInt.from(100),
+      );
+
+      expect(keyA, keyB);
+    });
+  });
+
+  group('KeystoneSignCacheNotifier', () {
+    late KeystoneSignCacheNotifier notifier;
+
+    setUp(() {
+      notifier = KeystoneSignCacheNotifier();
+    });
+
+    final key = KeystoneSignCacheKey(accountId: 'account-a', recipientAddress: 'recipient', amount: BigInt.from(100));
+
+    final otherKey = KeystoneSignCacheKey(
+      accountId: 'account-a',
+      recipientAddress: 'other-recipient',
+      amount: BigInt.from(100),
+    );
+
+    UnsignedTransactionData fakeUnsignedData() {
+      return UnsignedTransactionData(
+        payloadToSign: QuantusSigningPayload(
+          method: Uint8List(0),
+          specVersion: 1,
+          transactionVersion: 1,
+          genesisHash: '0x00',
+          blockHash: '0x00',
+          blockNumber: 42,
+          eraPeriod: 64,
+          nonce: 0,
+          tip: 0,
+        ),
+        signer: Uint8List(32),
+        registry: Object(),
+      );
+    }
+
+    test('lookup returns null when cache is empty', () {
+      expect(notifier.lookup(key), isNull);
+    });
+
+    test('store and lookup return entry for matching key', () {
+      final unsigned = fakeUnsignedData();
+      const urParts = ['ur:part1', 'ur:part2'];
+
+      notifier.store(key: key, unsignedData: unsigned, urParts: urParts);
+
+      final entry = notifier.lookup(key);
+      expect(entry, isNotNull);
+      expect(entry!.key, key);
+      expect(entry.unsignedData, unsigned);
+      expect(entry.urParts, urParts);
+    });
+
+    test('lookup returns null for different key', () {
+      notifier.store(key: key, unsignedData: fakeUnsignedData(), urParts: const ['ur:part1']);
+
+      expect(notifier.lookup(otherKey), isNull);
+    });
+
+    test('startNewSendSession invalidates prior entry until re-stored', () {
+      notifier.store(key: key, unsignedData: fakeUnsignedData(), urParts: const ['ur:part1']);
+      expect(notifier.lookup(key), isNotNull);
+
+      notifier.startNewSendSession();
+
+      expect(notifier.lookup(key), isNull);
+    });
+
+    test('second startNewSendSession requires fresh store even when params unchanged', () {
+      notifier.store(key: key, unsignedData: fakeUnsignedData(), urParts: const ['ur:first']);
+      notifier.startNewSendSession();
+
+      final unsigned = fakeUnsignedData();
+      notifier.store(key: key, unsignedData: unsigned, urParts: const ['ur:second']);
+
+      final entry = notifier.lookup(key);
+      expect(entry, isNotNull);
+      expect(entry!.urParts, const ['ur:second']);
+    });
+  });
+}

--- a/mobile-app/test/unit/keystone_sign_cache_test.dart
+++ b/mobile-app/test/unit/keystone_sign_cache_test.dart
@@ -4,6 +4,27 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/v2/screens/send/keystone_sign_cache.dart';
 
+/// Mortal era validity for Keystone payloads (eraPeriod 64, ~12s blocks, 2-block margin).
+Duration _mortalEraMaxCacheAge(QuantusSigningPayload payload) => keystoneSignCacheMaxAge(payload);
+
+UnsignedTransactionData _fakeUnsignedData() {
+  return UnsignedTransactionData(
+    payloadToSign: QuantusSigningPayload(
+      method: Uint8List(0),
+      specVersion: 1,
+      transactionVersion: 1,
+      genesisHash: '0x00',
+      blockHash: '0x00',
+      blockNumber: 42,
+      eraPeriod: 64,
+      nonce: 0,
+      tip: 0,
+    ),
+    signer: Uint8List(32),
+    registry: Object(),
+  );
+}
+
 void main() {
   group('KeystoneSignCacheKey', () {
     test('trims recipient address in fromSendParams', () {
@@ -47,30 +68,12 @@ void main() {
       amount: BigInt.from(100),
     );
 
-    UnsignedTransactionData fakeUnsignedData() {
-      return UnsignedTransactionData(
-        payloadToSign: QuantusSigningPayload(
-          method: Uint8List(0),
-          specVersion: 1,
-          transactionVersion: 1,
-          genesisHash: '0x00',
-          blockHash: '0x00',
-          blockNumber: 42,
-          eraPeriod: 64,
-          nonce: 0,
-          tip: 0,
-        ),
-        signer: Uint8List(32),
-        registry: Object(),
-      );
-    }
-
     test('lookup returns null when cache is empty', () {
       expect(notifier.lookup(key), isNull);
     });
 
     test('store and lookup return entry for matching key', () {
-      final unsigned = fakeUnsignedData();
+      final unsigned = _fakeUnsignedData();
       const urParts = ['ur:part1', 'ur:part2'];
 
       notifier.store(key: key, unsignedData: unsigned, urParts: urParts);
@@ -83,13 +86,13 @@ void main() {
     });
 
     test('lookup returns null for different key', () {
-      notifier.store(key: key, unsignedData: fakeUnsignedData(), urParts: const ['ur:part1']);
+      notifier.store(key: key, unsignedData: _fakeUnsignedData(), urParts: const ['ur:part1']);
 
       expect(notifier.lookup(otherKey), isNull);
     });
 
     test('startNewSendSession invalidates prior entry until re-stored', () {
-      notifier.store(key: key, unsignedData: fakeUnsignedData(), urParts: const ['ur:part1']);
+      notifier.store(key: key, unsignedData: _fakeUnsignedData(), urParts: const ['ur:part1']);
       expect(notifier.lookup(key), isNotNull);
 
       notifier.startNewSendSession();
@@ -98,15 +101,45 @@ void main() {
     });
 
     test('second startNewSendSession requires fresh store even when params unchanged', () {
-      notifier.store(key: key, unsignedData: fakeUnsignedData(), urParts: const ['ur:first']);
+      notifier.store(key: key, unsignedData: _fakeUnsignedData(), urParts: const ['ur:first']);
       notifier.startNewSendSession();
 
-      final unsigned = fakeUnsignedData();
+      final unsigned = _fakeUnsignedData();
       notifier.store(key: key, unsignedData: unsigned, urParts: const ['ur:second']);
 
       final entry = notifier.lookup(key);
       expect(entry, isNotNull);
       expect(entry!.urParts, const ['ur:second']);
+    });
+  });
+
+  group('stale mortal era payload', () {
+    late KeystoneSignCacheNotifier notifier;
+
+    setUp(() {
+      notifier = KeystoneSignCacheNotifier();
+    });
+
+    final key = KeystoneSignCacheKey(accountId: 'account-a', recipientAddress: 'recipient', amount: BigInt.from(100));
+
+    test('lookup returns null when user returns after mortal era expires', () {
+      final unsigned = _fakeUnsignedData();
+      final storedAt = DateTime(2026, 1, 1, 12, 0, 0);
+      final now = storedAt.add(_mortalEraMaxCacheAge(unsigned.payloadToSign));
+
+      notifier.store(key: key, unsignedData: unsigned, urParts: const ['ur:stale'], storedAt: storedAt);
+
+      expect(notifier.lookup(key, now: now), isNull);
+    });
+
+    test('lookup still returns entry within mortal era window', () {
+      final unsigned = _fakeUnsignedData();
+      final storedAt = DateTime(2026, 1, 1, 12, 0, 0);
+      final now = storedAt.add(_mortalEraMaxCacheAge(unsigned.payloadToSign) - const Duration(seconds: 1));
+
+      notifier.store(key: key, unsignedData: unsigned, urParts: const ['ur:fresh'], storedAt: storedAt);
+
+      expect(notifier.lookup(key, now: now), isNotNull);
     });
   });
 }

--- a/quantus_sdk/lib/src/constants/app_constants.dart
+++ b/quantus_sdk/lib/src/constants/app_constants.dart
@@ -54,6 +54,9 @@ class AppConstants {
   // Reversible time settings
   static const int defaultReversibleTimeSeconds = 600; // 10 minutes
 
+  /// Average Quantus block time in seconds (~12s). Used for mortal-era TTL and block↔time estimates.
+  static const int avgBlockTimeSeconds = 12;
+
   // Digits of precision
   static const int decimals = 12;
   static const int ss58prefix = 189;

--- a/quantus_sdk/lib/src/services/multisig_service.dart
+++ b/quantus_sdk/lib/src/services/multisig_service.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:quantus_sdk/generated/planck/pallets/multisig.dart' show Constants, Txs;
 import 'package:quantus_sdk/generated/planck/types/quantus_runtime/runtime_call.dart';
+import 'package:quantus_sdk/src/constants/app_constants.dart';
 import 'package:quantus_sdk/src/models/account.dart';
 import 'package:quantus_sdk/src/models/json_dynamic_parse.dart';
 import 'package:quantus_sdk/src/models/multisig_account.dart';
@@ -26,7 +27,6 @@ class MultisigService {
   final SubstrateService _substrateService = SubstrateService();
   static final Constants palletConstants = Constants();
 
-  static const int _avgBlockTimeSeconds = 12;
   static const Duration defaultProposalExpiry = Duration(days: 2);
   static final BigInt defaultMultisigNonce = BigInt.zero;
 
@@ -436,13 +436,13 @@ class MultisigService {
 
   /// Number of blocks that approximately span [duration] at average block time.
   int blocksForDuration(Duration duration) {
-    return (duration.inSeconds / _avgBlockTimeSeconds).round();
+    return (duration.inSeconds / AppConstants.avgBlockTimeSeconds).round();
   }
 
   /// Approximate wall-clock time at which [targetBlock] is reached, given the
   /// known [currentBlock].
   DateTime blockToTime(int targetBlock, int currentBlock) {
     final deltaBlocks = targetBlock - currentBlock;
-    return DateTime.now().add(Duration(seconds: deltaBlocks * _avgBlockTimeSeconds));
+    return DateTime.now().add(Duration(seconds: deltaBlocks * AppConstants.avgBlockTimeSeconds));
   }
 }


### PR DESCRIPTION
## Summary
- Now display details for tx in sign screen
-  Now cache keystone session, to avoid bad flow when user just want to reconfirm by pressing back button.

Intentionally didn't disable back button, because don't want to block the flow. User might be stuck if we disable back button.

## Screenshots
- Sign screen
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/e068d2d7-f2c6-49ee-aa50-01313d3d0ade" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware-wallet signing payload reuse and navigation; incorrect session clearing could show a stale QR, though new sends explicitly reset the cache.
> 
> **Overview**
> Improves the **Keystone hardware send flow** by caching the unsigned payload and UR QR parts for the current send, and by showing **amount, recipient, and checkphrase** on the sign screen.
> 
> A new Riverpod `keystoneSignCacheProvider` holds a single entry keyed by account, recipient, and amount (block height and nonce are excluded so minor chain drift does not force a new QR while the user navigates back within the same send). `KeystoneSignScreen` reuses the cache on `_prepare` when the key matches; otherwise it builds, stores, and displays as before. **`startNewSendSession()`** clears the cache when the user starts a fresh send from home (Send, multisig propose, pay intent) or from the shared-address “Send to this account” action so a new flow does not reuse an old QR.
> 
> When continuing to signature scan, **block height** is taken from the cached unsigned payload’s `blockNumber` instead of the value passed into the sign screen. Unit tests cover cache keys (address trimming) and notifier store/lookup/session invalidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5960c8c89bf0d9b5d57119c7aa522920fbe03b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->