### PR TITLE
Properly handle fcm error

### DIFF
--- a/mobile-app/lib/providers/remote_config_provider.dart
+++ b/mobile-app/lib/providers/remote_config_provider.dart
@@ -6,6 +6,7 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/firebase_options.dart';
 import 'package:resonance_network_wallet/services/remote_config_service.dart';
 import 'package:resonance_network_wallet/services/firebase_messaging_service.dart';
+import 'package:resonance_network_wallet/services/telemetry_service.dart';
 import 'package:resonance_network_wallet/shared/utils/print.dart';
 
 final remoteConfigServiceProvider = Provider<RemoteConfigService>((ref) {
@@ -60,16 +61,21 @@ class RemoteConfigNotifier extends StateNotifier<RemoteConfigModel> {
     if (_isEnablingRemoteNotifications) return;
     _isEnablingRemoteNotifications = true;
 
-    // If Firebase wasn't initialized at startup (because cached flags were false),
-    // do it now.
-    if (Firebase.apps.isEmpty) {
-      await Firebase.initializeApp(options: DefaultFirebaseOptions.getOptionsForEnvironment());
+    try {
+      // If Firebase wasn't initialized at startup (because cached flags were false),
+      // do it now.
+      if (Firebase.apps.isEmpty) {
+        await Firebase.initializeApp(options: DefaultFirebaseOptions.getOptionsForEnvironment());
+      }
+
+      final fcmService = ref.read(firebaseMessagingServiceProvider);
+      await fcmService.init(); // This requests notification permission.
+      fcmService.setupNotificationTapHandlers();
+    } catch (e, st) {
+      quantusDebugPrint('Failed to enable remote notifications: $e');
+      TelemetryService().sendError('fcm_enable_remote_notifications_failed', error: e, stackTrace: st);
+    } finally {
+      _isEnablingRemoteNotifications = false;
     }
-
-    final fcmService = ref.read(firebaseMessagingServiceProvider);
-    await fcmService.init(); // This requests notification permission.
-    fcmService.setupNotificationTapHandlers();
-
-    _isEnablingRemoteNotifications = false;
   }
 }

--- a/mobile-app/lib/services/firebase_messaging_service.dart
+++ b/mobile-app/lib/services/firebase_messaging_service.dart
@@ -35,8 +35,15 @@ class FirebaseMessagingService {
 
   /// Returns the cached FCM device token, fetching from Firebase if not yet available.
   Future<String?> getDeviceToken() async {
-    _cachedToken ??= await _messaging.getToken();
-    quantusDebugPrint('FCM token: $_cachedToken');
+    if (_cachedToken != null) return _cachedToken;
+
+    try {
+      _cachedToken = await _messaging.getToken();
+      quantusDebugPrint('FCM token: $_cachedToken');
+    } catch (e, st) {
+      quantusDebugPrint('Failed to get FCM device token: $e');
+      TelemetryService().sendError('fcm_get_device_token_failed', error: e, stackTrace: st);
+    }
 
     return _cachedToken;
   }


### PR DESCRIPTION
## Summary
Small fix for handling fcm error instead of throwing unhandled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive error handling around push setup with no change to happy-path behavior; reduces risk of stuck notification-enable state on failure.
> 
> **Overview**
> FCM failures no longer surface as unhandled async errors. **Remote notification enablement** (lazy Firebase init, `init()`, tap handlers) is wrapped in `try/catch/finally` so failures are logged and sent to telemetry as `fcm_enable_remote_notifications_failed`, and the `_isEnablingRemoteNotifications` guard is always cleared in `finally` (previously it could stay stuck on error).
> 
> **Device token fetch** in `getDeviceToken()` is similarly guarded: errors are logged, reported as `fcm_get_device_token_failed`, and the method returns `null` instead of throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2420cb46e724288dd1e62dcfa6d7333b2e115dcd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->