### PR TITLE
fix: require device credential when no biometrics are enrolled (H1)

### DIFF
--- a/mobile-app/lib/services/local_auth_service.dart
+++ b/mobile-app/lib/services/local_auth_service.dart
@@ -6,12 +6,29 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 class LocalAuthService {
   static final LocalAuthService _instance = LocalAuthService._internal();
   factory LocalAuthService() => _instance;
-  LocalAuthService._internal();
 
-  final LocalAuthentication _localAuth = LocalAuthentication();
-  final SettingsService _settingsService = SettingsService();
+  final LocalAuthentication _localAuth;
+  final SettingsService _settingsService;
+
+  LocalAuthService._internal() : _localAuth = LocalAuthentication(), _settingsService = SettingsService();
+
+  @visibleForTesting
+  LocalAuthService.withDependencies({required LocalAuthentication localAuth, required SettingsService settingsService})
+    : _localAuth = localAuth,
+      _settingsService = settingsService;
 
   static const _authTimeout = Duration(seconds: 10);
+
+  /// Whether the device has any lock-screen security enrolled: biometrics
+  /// or a device credential (PIN/pattern/password).
+  Future<bool> isDeviceSecure() async {
+    try {
+      return await _localAuth.isDeviceSupported();
+    } catch (e) {
+      debugPrint('Error checking device security: $e');
+      return false;
+    }
+  }
 
   Future<bool> isBiometricAvailable() async {
     try {
@@ -42,8 +59,12 @@ class LocalAuthService {
     try {
       if (!await _settingsService.getHasWallet()) return true;
 
-      final isAvailable = await isBiometricAvailable();
-      if (!isAvailable) return true;
+      // Require whatever device security is enrolled: biometrics or the
+      // device credential (PIN/pattern/password). biometricOnly: false lets
+      // the plugin fall back to the device credential, so PIN-only devices
+      // are prompted for their PIN. A device with no security at all fails
+      // closed: gated actions stay blocked until the device is secured.
+      if (!await isDeviceSecure()) return false;
 
       final didAuthenticate = await _localAuth.authenticate(
         localizedReason: localizedReason,

--- a/mobile-app/test/unit/local_auth_service_test.dart
+++ b/mobile-app/test/unit/local_auth_service_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/services/local_auth_service.dart';
+
+class FakeLocalAuthentication extends Fake implements LocalAuthentication {
+  bool deviceSupported = true;
+  bool authenticateResult = true;
+  int authenticateCalls = 0;
+
+  @override
+  Future<bool> isDeviceSupported() async => deviceSupported;
+
+  @override
+  Future<bool> authenticate({
+    required String localizedReason,
+    Iterable<dynamic> authMessages = const <dynamic>[],
+    bool biometricOnly = false,
+    bool sensitiveTransaction = true,
+    bool persistAcrossBackgrounding = false,
+  }) async {
+    authenticateCalls++;
+    return authenticateResult;
+  }
+}
+
+class FakeSettingsService extends Fake implements SettingsService {
+  bool hasWallet = true;
+  int cleanLastPausedTimeCalls = 0;
+
+  @override
+  Future<bool> getHasWallet() async => hasWallet;
+
+  @override
+  void cleanLastPausedTime() => cleanLastPausedTimeCalls++;
+}
+
+void main() {
+  late FakeLocalAuthentication localAuth;
+  late FakeSettingsService settingsService;
+  late LocalAuthService service;
+
+  setUp(() {
+    localAuth = FakeLocalAuthentication();
+    settingsService = FakeSettingsService();
+    service = LocalAuthService.withDependencies(localAuth: localAuth, settingsService: settingsService);
+  });
+
+  group('authenticate', () {
+    test('returns true without prompting when no wallet exists', () async {
+      settingsService.hasWallet = false;
+
+      expect(await service.authenticate(), isTrue);
+      expect(localAuth.authenticateCalls, 0);
+    });
+
+    test('prompts for device security when enrolled (biometrics or PIN-only device)', () async {
+      localAuth.deviceSupported = true;
+
+      expect(await service.authenticate(), isTrue);
+      expect(localAuth.authenticateCalls, 1);
+    });
+
+    test('returns false when the user fails the device prompt', () async {
+      localAuth
+        ..deviceSupported = true
+        ..authenticateResult = false;
+
+      expect(await service.authenticate(), isFalse);
+      expect(settingsService.cleanLastPausedTimeCalls, 0);
+    });
+
+    test('cleans last paused time only after a successful authentication', () async {
+      localAuth.deviceSupported = true;
+
+      expect(await service.authenticate(), isTrue);
+      expect(settingsService.cleanLastPausedTimeCalls, 1);
+    });
+
+    test('fails closed without prompting when the device has no security at all', () async {
+      localAuth.deviceSupported = false;
+
+      expect(await service.authenticate(), isFalse);
+      expect(localAuth.authenticateCalls, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes finding **H1** from the security audit: on devices with a device credential (PIN/pattern/password) but **no enrolled biometrics**, every authentication gate silently succeeded without any prompt.

`LocalAuthService.authenticate()` short-circuited on `isBiometricAvailable()`, which requires enrolled biometrics. The `local_auth` plugin was already configured with `biometricOnly: false` (which falls back to the device PIN), but the pre-check returned `true` before the plugin ever ran — defeating its own configured fallback.

## Fix

- Gate on the new `isDeviceSecure()` (i.e. `LocalAuthentication.isDeviceSupported()`: true when the device has biometrics **or** a device credential) instead of `isBiometricAvailable()`.
- PIN-only devices are now prompted for their device PIN/pattern, on both Android (`BiometricManager` device-credential fallback) and iOS (`LAPolicy.deviceOwnerAuthentication`).
- Devices with **no security at all** now **fail closed**: gated actions (send, seed reveal, reset, multisig) stay blocked until the user secures the device. This was a deliberate product decision — no silent pass.
- Added a `@visibleForTesting` constructor so the plugin and settings service can be faked.

Gates affected (all now actually prompt on PIN-only devices): app unlock, send signing (regular + encrypted), multisig propose/approve/create, recovery-phrase reveal, wallet reset.

## Testing

- New `test/unit/local_auth_service_test.dart` (5 tests): no-wallet bypass, prompt on secured device, failed prompt, `cleanLastPausedTime` only on success, fail-closed on unsecured device.
- `flutter analyze lib` clean; full `test/unit` suite passes (208 tests).
- Not executed on hardware: PIN-fallback prompt behavior verified against `local_auth` 3.0.1 plugin source, worth a manual smoke test on a PIN-only device/emulator.

---

## Audit finding (from the security audit report, not checked in)

### H1. All authentication gates silently pass on devices without enrolled biometrics
`mobile-app/lib/services/local_auth_service.dart:41-53` — *verified against `local_auth` 3.0.1 plugin source*

```dart
final isAvailable = await isBiometricAvailable();
if (!isAvailable) return true;
```

`isBiometricAvailable()` requires `getAvailableBiometrics().isNotEmpty`. Per plugin source, Android only lists a biometric when `BiometricManager.canAuthenticate(...) == BIOMETRIC_SUCCESS` (requires enrollment); iOS requires `canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics)`. On a device with a PIN/pattern but **no enrolled fingerprint/face** — common on budget Android devices and for users who decline enrollment — every gate returns `true` with no prompt:

- app unlock (`lib/providers/local_auth_provider.dart:48-52`)
- send signing (`lib/v2/screens/send/regular_send_strategy.dart:167`, `encrypted_send_strategy.dart:132`, `multisig_propose_strategy.dart:197`, `multisig_action_confirm_sheet.dart:184`)
- recovery-phrase reveal (`recovery_phrase_confirmation_screen.dart:27`)
- wallet reset (`reset_confirmation_screen.dart:25`), multisig creation (`add_multisig_screen.dart:242`)

The call is configured with `biometricOnly: false`, so the plugin *itself* would fall back to the device PIN — the app-level pre-check short-circuits before the plugin ever runs. No app-level PIN exists anywhere in `lib/`. The user is never told their wallet has zero app-level authentication.

**Exploit scenario:** attacker with brief access to an unlocked PIN-only device opens Settings → Recovery Phrase and photographs the mnemonic, or sends funds — nothing challenges them.
**Impact:** total loss of funds/seed for all users on non-biometric devices.
**Fix (this PR):** removed the `return true` short-circuit; gate on `isDeviceSupported()` and let `authenticate(biometricOnly: false)` prompt for the device credential. Devices with no credential at all fail closed.
