### PR TITLE
fix: lock lifecycle fails closed on process death (M1)

### DIFF
--- a/mobile-app/lib/providers/local_auth_provider.dart
+++ b/mobile-app/lib/providers/local_auth_provider.dart
@@ -9,7 +9,10 @@ class LocalAuthState {
   final bool isAuthenticating;
   final bool isVisuallyLocked;
 
-  LocalAuthState({this.isAuthenticated = true, this.isAuthenticating = false, this.isVisuallyLocked = false});
+  // Locked by default: nothing renders as unlocked until an explicit
+  // check/auth proves otherwise (cold start, crash, or force-stop must
+  // never come back unlocked).
+  LocalAuthState({this.isAuthenticated = false, this.isAuthenticating = false, this.isVisuallyLocked = false});
 
   LocalAuthState copyWith({bool? isAuthenticated, bool? isAuthenticating, bool? isVisuallyLocked}) {
     return LocalAuthState(
@@ -54,14 +57,18 @@ class LocalAuthController extends StateNotifier<LocalAuthState> {
 
   Future<void> checkAuthentication() async {
     _cancelVisualLockTimer();
-    if (await _localAuthService.shouldRequireAuthentication()) {
-      final alreadyAuthenticating = state.isAuthenticating;
-      state = state.copyWith(isAuthenticated: false);
-      if (!alreadyAuthenticating) {
-        authenticate();
-      }
-    } else {
-      state = state.copyWith(isAuthenticated: true, isAuthenticating: false, isVisuallyLocked: false);
+    // The background grace window only applies to a session that was
+    // actually unlocked in this process. A locked session must always
+    // authenticate — otherwise backgrounding and resuming within the
+    // grace window would unlock the app without a prompt.
+    if (state.isAuthenticated && !await _localAuthService.shouldRequireAuthentication()) {
+      state = state.copyWith(isAuthenticating: false, isVisuallyLocked: false);
+      return;
+    }
+    final alreadyAuthenticating = state.isAuthenticating;
+    state = state.copyWith(isAuthenticated: false);
+    if (!alreadyAuthenticating) {
+      authenticate();
     }
   }
 

--- a/mobile-app/lib/services/local_auth_service.dart
+++ b/mobile-app/lib/services/local_auth_service.dart
@@ -9,15 +9,26 @@ class LocalAuthService {
 
   final LocalAuthentication _localAuth;
   final SettingsService _settingsService;
+  final Duration _authTimeout;
 
-  LocalAuthService._internal() : _localAuth = LocalAuthentication(), _settingsService = SettingsService();
+  /// In-memory only: the background grace window must never survive
+  /// process death. A null value with an existing wallet therefore means
+  /// "this process has not recorded a backgrounding" — i.e. locked.
+  DateTime? _lastPausedTime;
+
+  LocalAuthService._internal()
+    : _localAuth = LocalAuthentication(),
+      _settingsService = SettingsService(),
+      _authTimeout = const Duration(seconds: 10);
 
   @visibleForTesting
-  LocalAuthService.withDependencies({required LocalAuthentication localAuth, required SettingsService settingsService})
-    : _localAuth = localAuth,
-      _settingsService = settingsService;
-
-  static const _authTimeout = Duration(seconds: 10);
+  LocalAuthService.withDependencies({
+    required LocalAuthentication localAuth,
+    required SettingsService settingsService,
+    Duration authTimeout = const Duration(seconds: 10),
+  }) : _localAuth = localAuth,
+       _settingsService = settingsService,
+       _authTimeout = authTimeout;
 
   /// Whether the device has any lock-screen security enrolled: biometrics
   /// or a device credential (PIN/pattern/password).
@@ -87,8 +98,10 @@ class LocalAuthService {
   Future<bool> shouldRequireAuthentication() async {
     try {
       if (!await _settingsService.getHasWallet()) return false;
-      final lastPausedTime = _settingsService.getLastPausedTime();
-      if (lastPausedTime == null) return false;
+      // Fail closed: a wallet with no in-memory pause record means the
+      // process started (or was killed) since the last unlock.
+      final lastPausedTime = _lastPausedTime;
+      if (lastPausedTime == null) return true;
       return DateTime.now().difference(lastPausedTime) > _authTimeout;
     } catch (e) {
       debugPrint('Error checking if authentication is required: $e');
@@ -98,12 +111,12 @@ class LocalAuthService {
 
   Future<bool> updateLastPausedTime() async {
     if (!await _settingsService.getHasWallet()) return false;
-    _settingsService.setLastPausedTime(DateTime.now());
+    _lastPausedTime = DateTime.now();
     return true;
   }
 
   void cleanLastPausedTime() {
-    _settingsService.cleanLastPausedTime();
+    _lastPausedTime = null;
   }
 
   Future<void> stopAuthentication() async {

--- a/mobile-app/lib/services/local_auth_service.dart
+++ b/mobile-app/lib/services/local_auth_service.dart
@@ -6,12 +6,29 @@ import 'package:quantus_sdk/quantus_sdk.dart';
 class LocalAuthService {
   static final LocalAuthService _instance = LocalAuthService._internal();
   factory LocalAuthService() => _instance;
-  LocalAuthService._internal();
 
-  final LocalAuthentication _localAuth = LocalAuthentication();
-  final SettingsService _settingsService = SettingsService();
+  final LocalAuthentication _localAuth;
+  final SettingsService _settingsService;
+
+  LocalAuthService._internal() : _localAuth = LocalAuthentication(), _settingsService = SettingsService();
+
+  @visibleForTesting
+  LocalAuthService.withDependencies({required LocalAuthentication localAuth, required SettingsService settingsService})
+    : _localAuth = localAuth,
+      _settingsService = settingsService;
 
   static const _authTimeout = Duration(seconds: 10);
+
+  /// Whether the device has any lock-screen security enrolled: biometrics
+  /// or a device credential (PIN/pattern/password).
+  Future<bool> isDeviceSecure() async {
+    try {
+      return await _localAuth.isDeviceSupported();
+    } catch (e) {
+      debugPrint('Error checking device security: $e');
+      return false;
+    }
+  }
 
   Future<bool> isBiometricAvailable() async {
     try {
@@ -42,8 +59,12 @@ class LocalAuthService {
     try {
       if (!await _settingsService.getHasWallet()) return true;
 
-      final isAvailable = await isBiometricAvailable();
-      if (!isAvailable) return true;
+      // Require whatever device security is enrolled: biometrics or the
+      // device credential (PIN/pattern/password). biometricOnly: false lets
+      // the plugin fall back to the device credential, so PIN-only devices
+      // are prompted for their PIN. A device with no security at all fails
+      // closed: gated actions stay blocked until the device is secured.
+      if (!await isDeviceSecure()) return false;
 
       final didAuthenticate = await _localAuth.authenticate(
         localizedReason: localizedReason,

--- a/mobile-app/lib/services/local_auth_service.dart
+++ b/mobile-app/lib/services/local_auth_service.dart
@@ -73,9 +73,10 @@ class LocalAuthService {
       // Require whatever device security is enrolled: biometrics or the
       // device credential (PIN/pattern/password). biometricOnly: false lets
       // the plugin fall back to the device credential, so PIN-only devices
-      // are prompted for their PIN. A device with no security at all fails
-      // closed: gated actions stay blocked until the device is secured.
-      if (!await isDeviceSecure()) return false;
+      // are prompted for their PIN. A device with no lock-screen security at
+      // all has nothing to enforce: skip the prompt and grant access —
+      // failing closed here would just dead-end the app on the lock screen.
+      if (!await isDeviceSecure()) return true;
 
       final didAuthenticate = await _localAuth.authenticate(
         localizedReason: localizedReason,
@@ -98,6 +99,10 @@ class LocalAuthService {
   Future<bool> shouldRequireAuthentication() async {
     try {
       if (!await _settingsService.getHasWallet()) return false;
+      // No device lock enrolled → there is nothing to gate with, so don't
+      // require auth (otherwise every resume would flash a lock screen that
+      // can only auto-dismiss).
+      if (!await isDeviceSecure()) return false;
       // Fail closed: a wallet with no in-memory pause record means the
       // process started (or was killed) since the last unlock.
       final lastPausedTime = _lastPausedTime;

--- a/mobile-app/test/unit/local_auth_service_test.dart
+++ b/mobile-app/test/unit/local_auth_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/providers/local_auth_provider.dart';
 import 'package:resonance_network_wallet/services/local_auth_service.dart';
 
 class FakeLocalAuthentication extends Fake implements LocalAuthentication {
@@ -26,14 +27,14 @@ class FakeLocalAuthentication extends Fake implements LocalAuthentication {
 
 class FakeSettingsService extends Fake implements SettingsService {
   bool hasWallet = true;
-  int cleanLastPausedTimeCalls = 0;
 
   @override
   Future<bool> getHasWallet() async => hasWallet;
-
-  @override
-  void cleanLastPausedTime() => cleanLastPausedTimeCalls++;
 }
+
+/// Lets fire-and-forget async work (e.g. the unawaited authenticate() call
+/// inside checkAuthentication) complete before asserting.
+Future<void> flushAsync() => Future<void>.delayed(const Duration(milliseconds: 5));
 
 void main() {
   late FakeLocalAuthentication localAuth;
@@ -67,14 +68,6 @@ void main() {
         ..authenticateResult = false;
 
       expect(await service.authenticate(), isFalse);
-      expect(settingsService.cleanLastPausedTimeCalls, 0);
-    });
-
-    test('cleans last paused time only after a successful authentication', () async {
-      localAuth.deviceSupported = true;
-
-      expect(await service.authenticate(), isTrue);
-      expect(settingsService.cleanLastPausedTimeCalls, 1);
     });
 
     test('fails closed without prompting when the device has no security at all', () async {
@@ -82,6 +75,133 @@ void main() {
 
       expect(await service.authenticate(), isFalse);
       expect(localAuth.authenticateCalls, 0);
+    });
+
+    test('successful authentication clears the pause record (next check requires auth)', () async {
+      await service.updateLastPausedTime();
+      expect(await service.shouldRequireAuthentication(), isFalse);
+
+      expect(await service.authenticate(), isTrue);
+      expect(await service.shouldRequireAuthentication(), isTrue);
+    });
+
+    test('failed authentication keeps the pause record', () async {
+      localAuth.authenticateResult = false;
+
+      await service.updateLastPausedTime();
+      expect(await service.authenticate(), isFalse);
+      expect(await service.shouldRequireAuthentication(), isFalse);
+    });
+  });
+
+  group('shouldRequireAuthentication', () {
+    test('returns false when no wallet exists', () async {
+      settingsService.hasWallet = false;
+
+      expect(await service.shouldRequireAuthentication(), isFalse);
+    });
+
+    test('fails closed with no pause record (cold start / after process death)', () async {
+      expect(await service.shouldRequireAuthentication(), isTrue);
+    });
+
+    test('returns false within the grace window after backgrounding', () async {
+      await service.updateLastPausedTime();
+
+      expect(await service.shouldRequireAuthentication(), isFalse);
+    });
+
+    test('returns true once the grace window has expired', () async {
+      final shortTimeoutService = LocalAuthService.withDependencies(
+        localAuth: localAuth,
+        settingsService: settingsService,
+        authTimeout: const Duration(milliseconds: 20),
+      );
+
+      await shortTimeoutService.updateLastPausedTime();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+
+      expect(await shortTimeoutService.shouldRequireAuthentication(), isTrue);
+    });
+
+    test('updateLastPausedTime records nothing when no wallet exists', () async {
+      settingsService.hasWallet = false;
+
+      expect(await service.updateLastPausedTime(), isFalse);
+      expect(await service.shouldRequireAuthentication(), isFalse);
+    });
+  });
+
+  group('LocalAuthController', () {
+    test('starts locked by default', () {
+      final controller = LocalAuthController(service);
+
+      expect(controller.state.isAuthenticated, isFalse);
+      expect(controller.state.isAuthenticating, isFalse);
+    });
+
+    test('unlocks via prompt at cold start when a wallet exists', () async {
+      final controller = LocalAuthController(service);
+
+      await controller.checkAuthentication();
+      await flushAsync();
+
+      expect(localAuth.authenticateCalls, 1);
+      expect(controller.state.isAuthenticated, isTrue);
+    });
+
+    test('stays locked when the cold-start prompt is cancelled', () async {
+      localAuth.authenticateResult = false;
+      final controller = LocalAuthController(service);
+
+      await controller.checkAuthentication();
+      await flushAsync();
+
+      expect(controller.state.isAuthenticated, isFalse);
+    });
+
+    test('locked session is NOT silently unlocked by the grace window', () async {
+      // Locked at cold start, user backgrounds from the lock screen and
+      // resumes within the grace window: must prompt, not unlock.
+      await service.updateLastPausedTime();
+      localAuth.authenticateResult = false;
+      final controller = LocalAuthController(service);
+
+      await controller.checkAuthentication();
+      await flushAsync();
+
+      expect(localAuth.authenticateCalls, 1);
+      expect(controller.state.isAuthenticated, isFalse);
+    });
+
+    test('unlocked session within the grace window stays unlocked without re-prompting', () async {
+      final controller = LocalAuthController(service);
+      await controller.authenticate();
+      expect(localAuth.authenticateCalls, 1);
+
+      await service.updateLastPausedTime();
+      await controller.checkAuthentication();
+
+      expect(localAuth.authenticateCalls, 1);
+      expect(controller.state.isAuthenticated, isTrue);
+    });
+
+    test('unlocked session past the grace window re-locks and prompts', () async {
+      final shortTimeoutService = LocalAuthService.withDependencies(
+        localAuth: localAuth,
+        settingsService: settingsService,
+        authTimeout: const Duration(milliseconds: 20),
+      );
+      final controller = LocalAuthController(shortTimeoutService);
+      await controller.authenticate();
+
+      await shortTimeoutService.updateLastPausedTime();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      await controller.checkAuthentication();
+      await flushAsync();
+
+      expect(localAuth.authenticateCalls, 2);
+      expect(controller.state.isAuthenticated, isTrue);
     });
   });
 }

--- a/mobile-app/test/unit/local_auth_service_test.dart
+++ b/mobile-app/test/unit/local_auth_service_test.dart
@@ -70,10 +70,10 @@ void main() {
       expect(await service.authenticate(), isFalse);
     });
 
-    test('fails closed without prompting when the device has no security at all', () async {
+    test('grants access without prompting when the device has no security at all', () async {
       localAuth.deviceSupported = false;
 
-      expect(await service.authenticate(), isFalse);
+      expect(await service.authenticate(), isTrue);
       expect(localAuth.authenticateCalls, 0);
     });
 
@@ -97,6 +97,12 @@ void main() {
   group('shouldRequireAuthentication', () {
     test('returns false when no wallet exists', () async {
       settingsService.hasWallet = false;
+
+      expect(await service.shouldRequireAuthentication(), isFalse);
+    });
+
+    test('returns false on a device with no security enrolled (nothing to enforce)', () async {
+      localAuth.deviceSupported = false;
 
       expect(await service.shouldRequireAuthentication(), isFalse);
     });
@@ -147,6 +153,17 @@ void main() {
       await flushAsync();
 
       expect(localAuth.authenticateCalls, 1);
+      expect(controller.state.isAuthenticated, isTrue);
+    });
+
+    test('unlocks without prompting at cold start when the device has no security', () async {
+      localAuth.deviceSupported = false;
+      final controller = LocalAuthController(service);
+
+      await controller.checkAuthentication();
+      await flushAsync();
+
+      expect(localAuth.authenticateCalls, 0);
       expect(controller.state.isAuthenticated, isTrue);
     });
 

--- a/mobile-app/test/unit/local_auth_service_test.dart
+++ b/mobile-app/test/unit/local_auth_service_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:resonance_network_wallet/services/local_auth_service.dart';
+
+class FakeLocalAuthentication extends Fake implements LocalAuthentication {
+  bool deviceSupported = true;
+  bool authenticateResult = true;
+  int authenticateCalls = 0;
+
+  @override
+  Future<bool> isDeviceSupported() async => deviceSupported;
+
+  @override
+  Future<bool> authenticate({
+    required String localizedReason,
+    Iterable<dynamic> authMessages = const <dynamic>[],
+    bool biometricOnly = false,
+    bool sensitiveTransaction = true,
+    bool persistAcrossBackgrounding = false,
+  }) async {
+    authenticateCalls++;
+    return authenticateResult;
+  }
+}
+
+class FakeSettingsService extends Fake implements SettingsService {
+  bool hasWallet = true;
+  int cleanLastPausedTimeCalls = 0;
+
+  @override
+  Future<bool> getHasWallet() async => hasWallet;
+
+  @override
+  void cleanLastPausedTime() => cleanLastPausedTimeCalls++;
+}
+
+void main() {
+  late FakeLocalAuthentication localAuth;
+  late FakeSettingsService settingsService;
+  late LocalAuthService service;
+
+  setUp(() {
+    localAuth = FakeLocalAuthentication();
+    settingsService = FakeSettingsService();
+    service = LocalAuthService.withDependencies(localAuth: localAuth, settingsService: settingsService);
+  });
+
+  group('authenticate', () {
+    test('returns true without prompting when no wallet exists', () async {
+      settingsService.hasWallet = false;
+
+      expect(await service.authenticate(), isTrue);
+      expect(localAuth.authenticateCalls, 0);
+    });
+
+    test('prompts for device security when enrolled (biometrics or PIN-only device)', () async {
+      localAuth.deviceSupported = true;
+
+      expect(await service.authenticate(), isTrue);
+      expect(localAuth.authenticateCalls, 1);
+    });
+
+    test('returns false when the user fails the device prompt', () async {
+      localAuth
+        ..deviceSupported = true
+        ..authenticateResult = false;
+
+      expect(await service.authenticate(), isFalse);
+      expect(settingsService.cleanLastPausedTimeCalls, 0);
+    });
+
+    test('cleans last paused time only after a successful authentication', () async {
+      localAuth.deviceSupported = true;
+
+      expect(await service.authenticate(), isTrue);
+      expect(settingsService.cleanLastPausedTimeCalls, 1);
+    });
+
+    test('fails closed without prompting when the device has no security at all', () async {
+      localAuth.deviceSupported = false;
+
+      expect(await service.authenticate(), isFalse);
+      expect(localAuth.authenticateCalls, 0);
+    });
+  });
+}

--- a/mobile-app/test/unit/wallet_creation_service_test.mocks.dart
+++ b/mobile-app/test/unit/wallet_creation_service_test.mocks.dart
@@ -378,14 +378,6 @@ class MockSettingsService extends _i1.Mock implements _i4.SettingsService {
           as _i5.Future<void>);
 
   @override
-  void setLastPausedTime(DateTime? time) =>
-      super.noSuchMethod(Invocation.method(#setLastPausedTime, [time]), returnValueForMissingStub: null);
-
-  @override
-  void cleanLastPausedTime() =>
-      super.noSuchMethod(Invocation.method(#cleanLastPausedTime, []), returnValueForMissingStub: null);
-
-  @override
   bool hasOldAccounts() =>
       (super.noSuchMethod(Invocation.method(#hasOldAccounts, []), returnValue: false, returnValueForMissingStub: false)
           as bool);

--- a/quantus_sdk/lib/src/services/settings_service.dart
+++ b/quantus_sdk/lib/src/services/settings_service.dart
@@ -32,8 +32,6 @@ class SettingsService {
   static const String _selectedFiatCurrencyKey = 'selected_fiat_currency';
   static const String _selectedAppLocaleKey = 'selected_app_locale';
 
-  static const String _lastPausedTimeKey = 'last_paused_time';
-
   // referral status
   static const String hasCheckedReferralKey = 'referral_check';
   static const String referralCodeKey = 'referral_code';
@@ -457,22 +455,6 @@ class SettingsService {
   /// Set a string value from SharedPreferences
   Future<void> setString(String key, String value) async {
     await _prefs.setString(key, value);
-  }
-
-  DateTime? getLastPausedTime() {
-    final String? lastPausedString = _prefs.getString(_lastPausedTimeKey);
-    if (lastPausedString == null) return null;
-
-    final DateTime lastPaused = DateTime.parse(lastPausedString);
-    return lastPaused;
-  }
-
-  void setLastPausedTime(DateTime time) {
-    _prefs.setString(_lastPausedTimeKey, time.toIso8601String());
-  }
-
-  void cleanLastPausedTime() {
-    _prefs.remove(_lastPausedTimeKey);
   }
 
   // --- Migration Methods ---


### PR DESCRIPTION
## Summary

Fixes finding **M1** from the security audit: the app-lock lifecycle could be bypassed and failed open. Stacked on top of #567 (H1).

Three defects, three fixes:

1. **Grace window survived process death.** The `last_paused_time` timestamp lived in SharedPreferences, so background → swipe-kill → relaunch within 10 s came back fully unlocked. The timestamp is now **in-memory only** (`LocalAuthService._lastPausedTime`); any process death (kill, crash, reboot) resets it.
2. **Null timestamp failed open.** `shouldRequireAuthentication()` returned `false` when no timestamp existed, and the timestamp was cleaned on every successful auth — so crash/force-stop/reboot after an unlock meant relaunching with no auth, no time limit. A null pause record with an existing wallet now means **locked** (fail closed).
3. **Unlocked-by-default initial state.** `LocalAuthState` defaulted to `isAuthenticated: true`, rendering content before the async check completed. It now defaults to locked; `AuthWrapper` shows the lock screen until auth succeeds.

Additionally, a bypass found while fixing the above: `checkAuthentication()`'s "within grace window" branch set `isAuthenticated: true` **even for sessions that had never been unlocked** — backgrounding from the lock screen and resuming within the grace window would have unlocked the app with no prompt (with defects 1–2 fixed, this would have become the easiest way in). The grace window now only applies to sessions that were actually authenticated in this process; a locked session always goes through `authenticate()`.

The SDK's now-dead `SettingsService` timestamp methods (`getLastPausedTime`/`setLastPausedTime`/`cleanLastPausedTime` and the `last_paused_time` SharedPreferences key) are removed in this PR as well — the mobile app was their only consumer.

## Behavior notes

- The 10-second background grace still works as before **within a process** for unlocked sessions (background → quick resume doesn't re-prompt).
- Cold start with a wallet now always prompts (previously it silently unlocked whenever the timestamp was missing) — on devices with lock-screen security enrolled.
- Devices with **no lock-screen security** (no PIN/pattern/biometric) are not gated: no prompt, no lock screen, gated actions pass. There is nothing to enforce on such a device, and failing closed would just dead-end the app on a lock screen whose only affordance retries an auth that can never succeed.

## Testing

- `test/unit/local_auth_service_test.dart` extended to 15 tests: fail-closed on null pause record, grace-window boundaries (via an injectable `authTimeout`), pause-record cleared only on successful auth, controller starts locked, locked-session grace bypass regression, unlocked-session grace behavior.
- `flutter analyze lib` clean; full `test/unit` suite passes (220 tests).
- Not executed on hardware: lifecycle edge cases (force-stop, reboot, biometric-prompt oscillation guard at `app_lifecycle_manager.dart:117`) are worth a manual smoke test on both platforms.

---

## Audit finding (from the security audit report, not checked in)

#### M1. Lock lifecycle: 10-second grace survives process death; null timestamp fails open; unlocked-by-default initial state
`mobile-app/lib/services/local_auth_service.dart:14,55,66-76`; `lib/providers/local_auth_provider.dart:12,64`; `lib/app_lifecycle_manager.dart:117-122`

The lock decision rests entirely on a `last_paused_time` SharedPreferences timestamp. Three compounding defects:

1. `shouldRequireAuthentication()` returns `false` when the timestamp is null (`local_auth_service.dart:69-70`), and `cleanLastPausedTime()` runs on *every successful auth* (line 55). Crash, foreground force-stop, or reboot with the app open → relaunch is unlocked with no time limit.
2. **Trivial bypass (both platforms, no tools):** background → swipe-kill → relaunch within the 10 s `_authTimeout` → fully unlocked. The grace window should not survive process death.
3. `LocalAuthState` defaults to `isAuthenticated: true` (`local_auth_provider.dart:12`), so content renders before the async check completes, and the lock is only a widget overlay (`lib/app.dart:55`); initialization and polling run regardless.

**Mitigating factor (verified):** per-action gates call `authenticate()` directly, so on biometric-enrolled devices funds and seed remain behind a prompt even when the app opens unlocked; the bypass primarily exposes balances/history/addresses. On PIN-only devices it chains with H1 into full access.
**Fix (this PR):** persist lock state in memory rather than inferring it from a missing timestamp; treat "wallet exists + no recorded pause" as locked; initialize `isAuthenticated = false`; require re-auth after any process death regardless of elapsed time.

