### PR TITLE
fix: disable Android Auto Backup (L2)

### DIFF
--- a/mobile-app/android/app/src/main/AndroidManifest.xml
+++ b/mobile-app/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="Quantus"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
-        android:roundIcon="@mipmap/launcher_icon">
+        android:roundIcon="@mipmap/launcher_icon"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
Sets `android:allowBackup="false"` on the `<application>` element in `mobile-app/android/app/src/main/AndroidManifest.xml`.

Android Auto Backup was left at its default (enabled), which backs up plaintext SharedPreferences (account metadata, settings) to Google Drive and restores them onto other devices. `allowBackup="false"` disables both legacy ADB backup and Auto Backup / data extraction in one attribute.

Verified no plugin manifest (including `flutter_secure_storage`) sets `allowBackup`, so no `tools:replace` is needed and no manifest merge conflict can occur. XML validated well-formed with `xmllint`.

Addresses finding L2 of the 2026-07-22 mobile wallet security audit.