### PR TITLE
fix: encode demo warning in swap deposit QR and address

### DIFF
--- a/mobile-app/lib/v2/screens/swap/deposit_screen.dart
+++ b/mobile-app/lib/v2/screens/swap/deposit_screen.dart
@@ -155,35 +155,35 @@ class _DepositScreenState extends ConsumerState<DepositScreen> {
           ),
         ),
         const SizedBox(height: 16),
-        SizedBox(
-          width: 264,
-          child: Stack(
-            children: [
-              Text(
-                _demoWarningPayload,
-                style: text.smallParagraph?.copyWith(
-                  color: colors.textPrimary,
-                  fontWeight: FontWeight.w500,
-                  height: 1.35,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              Positioned(
-                right: 0,
-                top: 19,
-                child: GestureDetector(
-                  onTap: () => _copyAddress(l10n),
-                  child: Container(
-                    width: 20,
-                    height: 20,
-                    decoration: BoxDecoration(color: colors.surfaceGlass, borderRadius: BorderRadius.circular(4)),
-                    child: Center(child: Icon(Icons.copy, color: colors.textPrimary, size: 12)),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+        // SizedBox(
+        //   width: 264,
+        //   child: Stack(
+        //     children: [
+        //       Text(
+        //         _demoWarningPayload,
+        //         style: text.smallParagraph?.copyWith(
+        //           color: colors.textPrimary,
+        //           fontWeight: FontWeight.w500,
+        //           height: 1.35,
+        //         ),
+        //         textAlign: TextAlign.center,
+        //       ),
+        //       Positioned(
+        //         right: 0,
+        //         top: 19,
+        //         child: GestureDetector(
+        //           onTap: () => _copyAddress(l10n),
+        //           child: Container(
+        //             width: 20,
+        //             height: 20,
+        //             decoration: BoxDecoration(color: colors.surfaceGlass, borderRadius: BorderRadius.circular(4)),
+        //             child: Center(child: Icon(Icons.copy, color: colors.textPrimary, size: 12)),
+        //           ),
+        //         ),
+        //       ),
+        //     ],
+        //   ),
+        // ),
         const SizedBox(height: 16),
         Text(
           l10n.swapDepositDemoWarning,

--- a/mobile-app/lib/v2/screens/swap/deposit_screen.dart
+++ b/mobile-app/lib/v2/screens/swap/deposit_screen.dart
@@ -28,6 +28,13 @@ class _DepositScreenState extends ConsumerState<DepositScreen> {
   late SwapOrder _order;
   bool _confirming = false;
 
+  /// This swap flow is demo-only — no real deposit is ever expected. To make it
+  /// impossible to accidentally send funds, the QR code, the on-screen address,
+  /// and the copy/share actions all surface this warning instead of the real
+  /// deposit address. Scanning the QR decodes to this plain text, not an
+  /// address, so no wallet can act on it.
+  static const String _demoWarningPayload = 'demo only - do not send funds';
+
   @override
   void initState() {
     super.initState();
@@ -65,7 +72,8 @@ class _DepositScreenState extends ConsumerState<DepositScreen> {
   }
 
   void _copyAddress(AppLocalizations l10n) {
-    context.copyTextWithToaster(_order.depositAddress);
+    // Demo-only: never expose the real deposit address (see _demoWarningPayload).
+    context.copyTextWithToaster(_demoWarningPayload);
   }
 
   @override
@@ -143,7 +151,7 @@ class _DepositScreenState extends ConsumerState<DepositScreen> {
           child: Container(
             color: Colors.white,
             padding: const EdgeInsets.all(8),
-            child: QrImageView(data: _order.depositAddress, version: QrVersions.auto, size: 184),
+            child: QrImageView(data: _demoWarningPayload, version: QrVersions.auto, size: 184),
           ),
         ),
         const SizedBox(height: 16),
@@ -152,7 +160,7 @@ class _DepositScreenState extends ConsumerState<DepositScreen> {
           child: Stack(
             children: [
               Text(
-                _order.depositAddress,
+                _demoWarningPayload,
                 style: text.smallParagraph?.copyWith(
                   color: colors.textPrimary,
                   fontWeight: FontWeight.w500,
@@ -209,7 +217,7 @@ class _DepositScreenState extends ConsumerState<DepositScreen> {
                     l10n.swapDepositShareContent(
                       _order.quote.fromToken.network,
                       _order.quote.fromToken.symbol,
-                      _order.depositAddress,
+                      _demoWarningPayload,
                     ),
                   );
                 },


### PR DESCRIPTION
Swap is demo-only. Encode "demo only - do not send funds" in the deposit QR, address text, copy and share so no real deposit address leaks.
![Uploading Simulator Screenshot - iPhone 17 - 2026-07-25 at 13.49.00.png…]()
