### PR TITLE
feat: cold wallet decodes every chain call, no blind signing

### DIFF
--- a/cold-wallet-app/lib/components/call_detail_view.dart
+++ b/cold-wallet-app/lib/components/call_detail_view.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:quantus_cold_wallet/components/detail_row.dart';
+import 'package:quantus_cold_wallet/theme/app_colors.dart';
+import 'package:quantus_cold_wallet/theme/app_text_styles.dart';
+
+/// Resolves human checkphrases for every address on screen, not just a
+/// destination — an approval or a governance call can name several accounts, and
+/// each one needs to be verifiable by eye.
+final _checkphraseProvider = FutureProvider.family<String, String>((ref, address) async {
+  return HumanReadableChecksumService().getHumanReadableName(address);
+});
+
+/// Renders every parameter of a decoded call, recursing into nested calls.
+///
+/// This is the whole point of the signing screen: nothing is summarised away and
+/// nothing is hidden behind a "details" tap. If a field is in the bytes being
+/// signed, it is on this screen.
+class CallDetailView extends StatelessWidget {
+  final DecodedCall call;
+
+  /// Nesting depth; nested calls are boxed and indented.
+  final int depth;
+
+  const CallDetailView({super.key, required this.call, this.depth = 0});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final text = context.themeText;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          call.displayTitle,
+          style: text.transactionDetailRowValue?.copyWith(
+            color: depth == 0 ? colors.textPrimary : colors.checksum,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        for (final field in call.fields) _CallFieldView(field: field, depth: depth),
+      ],
+    );
+  }
+}
+
+class _CallFieldView extends ConsumerWidget {
+  final CallField field;
+  final int depth;
+
+  const _CallFieldView({required this.field, required this.depth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final text = context.themeText;
+
+    switch (field) {
+      case ValueField(:final label, :final value, :final kind, :final note):
+        if (kind == ValueKind.address) {
+          return _AddressField(label: label, address: value, note: note);
+        }
+        return DetailRow(
+          label: label,
+          value: value,
+          monospace: kind == ValueKind.hash || kind == ValueKind.bytes,
+          note: note,
+        );
+
+      case AmountField(:final label, :final planck, :final assetId, :final note):
+        return DetailRow(
+          label: label,
+          value: assetId == null
+              ? '${_formatPlanck(planck)} ${AppConstants.tokenSymbol}'
+              : '$planck raw units of asset #$assetId',
+          note: assetId == null
+              ? note
+              : [
+                  note,
+                  'Asset decimals are not part of this payload, so the raw amount is shown.',
+                ].whereType<String>().join(' '),
+        );
+
+      case FieldGroup(:final label, :final items):
+        return Padding(
+          padding: const EdgeInsets.only(top: 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(label.toUpperCase(), style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel)),
+              Padding(
+                padding: const EdgeInsets.only(left: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [for (final item in items) _CallFieldView(field: item, depth: depth)],
+                ),
+              ),
+            ],
+          ),
+        );
+
+      case NestedCallField(:final label, :final call, :final note):
+        return Padding(
+          padding: const EdgeInsets.only(top: 14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(label.toUpperCase(), style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel)),
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: colors.surfaceCard,
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(color: colors.borderButton),
+                ),
+                child: CallDetailView(call: call, depth: depth + 1),
+              ),
+              if (note != null) ...[
+                const SizedBox(height: 6),
+                Text(note, style: text.detail?.copyWith(color: colors.textMuted)),
+              ],
+            ],
+          ),
+        );
+    }
+  }
+
+  String _formatPlanck(BigInt planck) =>
+      NumberFormattingService().formatBalance(planck, smartDecimals: 4, maxDecimals: AppConstants.decimals);
+}
+
+/// An address plus its checkphrase, so the signer can verify it out loud rather
+/// than character by character.
+class _AddressField extends ConsumerWidget {
+  final String label;
+  final String address;
+  final String? note;
+
+  const _AddressField({required this.label, required this.address, this.note});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final checkphrase = ref.watch(_checkphraseProvider(address));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        DetailRow(label: label, value: address, monospace: true, note: note),
+        checkphrase.maybeWhen(
+          data: (phrase) => phrase.isEmpty
+              ? const SizedBox.shrink()
+              : DetailRow(label: '$label checkphrase', value: phrase, valueColor: colors.checksum),
+          orElse: () => const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+}

--- a/cold-wallet-app/lib/components/detail_row.dart
+++ b/cold-wallet-app/lib/components/detail_row.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:quantus_cold_wallet/theme/app_colors.dart';
+import 'package:quantus_cold_wallet/theme/app_text_styles.dart';
+
+/// Label-above-value row used throughout the signing review screen.
+///
+/// Values wrap rather than ellipsize: a signer must be able to read a full
+/// address or hash, so nothing on this screen is ever visually truncated.
+class DetailRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  /// Monospace value, for addresses, hashes and byte blobs.
+  final bool monospace;
+
+  final Color? valueColor;
+
+  /// Caveat shown under the value, e.g. that a hash-referenced proposal's
+  /// contents are not part of the payload.
+  final String? note;
+
+  const DetailRow({
+    super.key,
+    required this.label,
+    required this.value,
+    this.monospace = false,
+    this.valueColor,
+    this.note,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final text = context.themeText;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label.toUpperCase(), style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel)),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: monospace
+                ? text.transactionDetailRowValue?.copyWith(color: valueColor ?? colors.textPrimary)
+                : text.smallParagraph?.copyWith(color: valueColor ?? colors.textPrimary),
+          ),
+          if (note != null) ...[
+            const SizedBox(height: 4),
+            Text(note!, style: text.detail?.copyWith(color: colors.textMuted)),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/cold-wallet-app/lib/debug/debug_payloads.dart
+++ b/cold-wallet-app/lib/debug/debug_payloads.dart
@@ -1,0 +1,78 @@
+import 'dart:typed_data';
+
+import 'package:convert/convert.dart';
+import 'package:polkadart/scale_codec.dart';
+import 'package:quantus_sdk/generated/planck/pallets/balances.dart' as balances_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/multisig.dart' as multisig_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/tech_collective.dart' as collective_pallet;
+import 'package:quantus_sdk/generated/planck/types/sp_runtime/multiaddress/multi_address.dart' as multi_address;
+import 'package:quantus_sdk/quantus_sdk.dart';
+
+/// Sample signing payloads for exercising the scan → review → sign flow on a
+/// simulator, where there is no camera to scan a real QR with.
+///
+/// These are byte-identical in shape to what the hot wallet produces: a SCALE
+/// `RuntimeCall` followed by the signed extensions, exactly as
+/// `QuantusSigningPayload.encodeRaw` emits. Only reachable behind [kDebugMode]
+/// from the scanner screen.
+class DebugPayloads {
+  const DebugPayloads._();
+
+  /// A plain transfer — the everyday case.
+  static Uint8List transfer() {
+    return _withExtensions(
+      const balances_pallet.Txs().transferAllowDeath(
+        dest: _address(AppConstants.debugTestAddress),
+        value: BigInt.from(1500000000000), // 1.5 QUAN
+      ),
+    );
+  }
+
+  /// A multisig approval carrying the transfer it authorises, so the review
+  /// screen has a nested call to expand and an amount to lift into the hero.
+  static Uint8List multisigApproveTransfer() {
+    final inner = const balances_pallet.Txs().transferAllowDeath(
+      dest: _address(AppConstants.debugTestAddress),
+      value: BigInt.from(4200000000000), // 4.2 QUAN
+    );
+    return _withExtensions(
+      const multisig_pallet.Txs().approve(multisigAddress: _debugMultisigAccount, proposalId: 12, call: inner.encode()),
+    );
+  }
+
+  /// An aye vote on a tech-collective referendum — the governance path a core dev
+  /// uses to enact a runtime upgrade. Moves no value, so the review screen must
+  /// name the call instead of showing an amount.
+  static Uint8List governanceVoteAye() {
+    return _withExtensions(const collective_pallet.Txs().vote(poll: 7, aye: true));
+  }
+
+  /// Synthetic multisig account; renders as a valid ss58 address with a
+  /// checkphrase without needing a real on-chain multisig.
+  static final Uint8List _debugMultisigAccount = Uint8List.fromList(List.filled(32, 0xA7));
+
+  static multi_address.MultiAddress _address(String ss58) =>
+      multi_address.MultiAddress.values.id(ss58ToAccountId(s: ss58));
+
+  /// Appends the signed extensions the runtime expects, using the spec and
+  /// transaction versions this build's metadata was generated from — so these
+  /// payloads do not trip the spec-drift warning.
+  static Uint8List _withExtensions(RuntimeCall call) {
+    final out = ByteOutput();
+    out.write(call.encode());
+    out.write(const [0x55, 0x01]); // mortal era: period 64, phase 21
+    CompactCodec.codec.encodeTo(0, out); // nonce
+    CompactBigIntCodec.codec.encodeTo(BigInt.zero, out); // tip
+    out.pushByte(0); // CheckMetadataHash mode: disabled
+    U32Codec.codec.encodeTo(AppConstants.bundledSpecVersion, out);
+    U32Codec.codec.encodeTo(AppConstants.bundledTransactionVersion, out);
+    out.write(hex.decode(_planckGenesisHex));
+    out.write(List.filled(32, 0x11)); // block hash (not validated by the signer)
+    out.pushByte(0); // metadata hash: None
+    return out.toBytes();
+  }
+
+  /// Read back from the signer's own network table, so these payloads stay valid
+  /// if the Planck genesis hash there ever changes.
+  static String get _planckGenesisHex => knownNetworks.entries.firstWhere((e) => e.value == 'Planck').key;
+}

--- a/cold-wallet-app/lib/screens/scan_transaction_screen.dart
+++ b/cold-wallet-app/lib/screens/scan_transaction_screen.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:quantus_cold_wallet/debug/debug_payloads.dart';
 import 'package:quantus_cold_wallet/screens/sign_transaction_screen.dart';
 import 'package:quantus_cold_wallet/theme/app_colors.dart';
 import 'package:quantus_cold_wallet/theme/app_text_styles.dart';
@@ -59,6 +61,49 @@ class _ScanTransactionScreenState extends State<ScanTransactionScreen> {
       _done = false;
       setState(() => _error = 'Failed to decode QR: $e');
     }
+  }
+
+  /// Simulators have no camera, so debug builds can inject a payload directly and
+  /// exercise the same review → sign path a scan would reach.
+  void _loadDebugPayload(Uint8List payload) {
+    _controller.stop();
+    Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => SignTransactionScreen(payload: payload)));
+  }
+
+  Widget _debugPayloadButtons(BuildContext context) {
+    final text = context.themeText;
+
+    Widget button(String label, Uint8List Function() build) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.white24,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            visualDensity: VisualDensity.compact,
+          ),
+          onPressed: () => _loadDebugPayload(build()),
+          child: Text(label, style: text.detail?.copyWith(color: Colors.white)),
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('DEBUG PAYLOADS', style: text.detail?.copyWith(color: Colors.white38, letterSpacing: 1.2)),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            button('Send', DebugPayloads.transfer),
+            button('Msig approve', DebugPayloads.multisigApproveTransfer),
+            button('Vote aye', DebugPayloads.governanceVoteAye),
+          ],
+        ),
+        const SizedBox(height: 20),
+      ],
+    );
   }
 
   Widget _cameraError(BuildContext context, MobileScannerException error) {
@@ -141,6 +186,7 @@ class _ScanTransactionScreenState extends State<ScanTransactionScreen> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
+                if (kDebugMode) _debugPayloadButtons(context),
                 Text(
                   _error ?? 'Scan the transaction QR from your hot wallet',
                   style: text.paragraph?.copyWith(color: _error != null ? colors.error : Colors.white),

--- a/cold-wallet-app/lib/screens/sign_transaction_screen.dart
+++ b/cold-wallet-app/lib/screens/sign_transaction_screen.dart
@@ -1,9 +1,12 @@
 import 'dart:typed_data';
 
+import 'package:convert/convert.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:quantus_cold_wallet/components/animated_ur_qr.dart';
+import 'package:quantus_cold_wallet/components/call_detail_view.dart';
+import 'package:quantus_cold_wallet/components/detail_row.dart';
 import 'package:quantus_cold_wallet/components/quantus_button.dart';
 import 'package:quantus_cold_wallet/components/scaffold_base.dart';
 import 'package:quantus_cold_wallet/components/scaffold_base_bottom_content.dart';
@@ -12,6 +15,13 @@ import 'package:quantus_cold_wallet/providers/wallet_providers.dart';
 import 'package:quantus_cold_wallet/theme/app_colors.dart';
 import 'package:quantus_cold_wallet/theme/app_text_styles.dart';
 
+/// Reviews a scanned signing payload and, on approval, produces the signature QR.
+///
+/// Every parameter of the call — nested calls included — is on screen before the
+/// Sign button becomes usable. There is no summarised or collapsed view: if a
+/// byte is being signed, it is displayed. The Sign button stays disabled until
+/// the parameter list has been scrolled to the end, so "I read it" is an action
+/// rather than an assumption.
 class SignTransactionScreen extends ConsumerStatefulWidget {
   final Uint8List payload;
   const SignTransactionScreen({super.key, required this.payload});
@@ -21,30 +31,56 @@ class SignTransactionScreen extends ConsumerStatefulWidget {
 }
 
 class _SignTransactionScreenState extends ConsumerState<SignTransactionScreen> {
+  final ScrollController _scrollController = ScrollController();
+
   ParsedPayload? _parsed;
   String? _parseError;
-  String? _toCheckphrase;
   List<String>? _signatureUr;
   bool _signing = false;
+  bool _reviewedToEnd = false;
+  bool _showRawPayload = false;
   String? _error;
 
   @override
   void initState() {
     super.initState();
     try {
-      final parsed = QuantusPayloadParser.parsePayload(widget.payload);
-      _parsed = parsed;
-      _loadCheckphrase(parsed.call.toAddress);
+      _parsed = QuantusPayloadParser.parsePayload(widget.payload);
     } catch (e) {
       debugPrint('Rejected signing payload: $e');
       _parseError = e is FormatException ? e.message : e.toString();
     }
+    _scrollController.addListener(_onScroll);
   }
 
-  Future<void> _loadCheckphrase(String address) async {
-    final phrase = await HumanReadableChecksumService().getHumanReadableName(address);
-    if (!mounted) return;
-    setState(() => _toCheckphrase = phrase);
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_reviewedToEnd || !_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    if (!position.hasContentDimensions) return;
+    if (position.pixels >= position.maxScrollExtent - 16) {
+      setState(() => _reviewedToEnd = true);
+    }
+  }
+
+  /// A payload short enough to fit on one screen has nothing to scroll, so the
+  /// gate would never open — release it once layout confirms there is no overflow.
+  ///
+  /// Runs after the frame: during build the scroll position exists but has no
+  /// content dimensions yet, and asking for its extent then throws.
+  void _scheduleReviewGateCheck() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _reviewedToEnd || !_scrollController.hasClients) return;
+      final position = _scrollController.position;
+      if (!position.hasContentDimensions) return;
+      if (position.maxScrollExtent <= 0) setState(() => _reviewedToEnd = true);
+    });
   }
 
   void _sign() {
@@ -78,12 +114,8 @@ class _SignTransactionScreenState extends ConsumerState<SignTransactionScreen> {
     }
   }
 
-  String _formatAmount(BigInt planck) {
-    final divisor = BigInt.from(10).pow(AppConstants.decimals);
-    final whole = planck ~/ divisor;
-    final frac = (planck % divisor).toString().padLeft(AppConstants.decimals, '0').substring(0, 4);
-    return '$whole.$frac';
-  }
+  String _formatAmount(BigInt planck) =>
+      NumberFormattingService().formatBalance(planck, smartDecimals: 4, maxDecimals: AppConstants.decimals);
 
   @override
   Widget build(BuildContext context) {
@@ -105,7 +137,8 @@ class _SignTransactionScreenState extends ConsumerState<SignTransactionScreen> {
           Text('Could not read transaction', style: text.mediumTitle?.copyWith(color: colors.textPrimary)),
           const SizedBox(height: 12),
           Text(
-            'This QR code is not a transaction this wallet can sign. Nothing was signed.',
+            'This QR code is not a transaction this wallet can read in full, so it will not be signed. '
+            'Nothing was signed.',
             style: text.smallParagraph?.copyWith(color: colors.textSecondary),
             textAlign: TextAlign.center,
           ),
@@ -126,53 +159,61 @@ class _SignTransactionScreenState extends ConsumerState<SignTransactionScreen> {
   Widget _reviewView(BuildContext context, ParsedPayload parsed) {
     final colors = context.colors;
     final text = context.themeText;
-    final info = parsed.call;
     final ext = parsed.extensions;
+    final signerAddress = ref.watch(addressProvider);
+    final signerCheckphrase = ref.watch(checkphraseProvider);
+
+    _scheduleReviewGateCheck();
 
     return ScaffoldBase(
       appBar: const V2AppBar(title: 'Review & Sign'),
       mainContent: SingleChildScrollView(
+        controller: _scrollController,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             const SizedBox(height: 8),
-            Center(
-              child: Column(
-                children: [
-                  Text('You are signing', style: text.smallParagraph?.copyWith(color: colors.textSecondary)),
-                  const SizedBox(height: 8),
-                  RichText(
-                    text: TextSpan(
-                      children: [
-                        TextSpan(
-                          text: _formatAmount(info.amount),
-                          style: text.transactionDetailAmountPrimary?.copyWith(color: colors.textPrimary),
-                        ),
-                        TextSpan(
-                          text: ' ${AppConstants.tokenSymbol}',
-                          style: text.transactionDetailAmountSymbol?.copyWith(color: colors.textSecondary),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
+            if (!parsed.specMatchesBundled) _specDriftBanner(context, ext),
+            _hero(context, parsed),
+            const SizedBox(height: 24),
+
+            // Which key signs is part of what is happening, and the payload does
+            // not name it — so show it.
+            if (signerAddress != null) DetailRow(label: 'Signing as', value: signerAddress, monospace: true),
+            signerCheckphrase.maybeWhen(
+              data: (phrase) => phrase.isEmpty
+                  ? const SizedBox.shrink()
+                  : DetailRow(label: 'Signing as checkphrase', value: phrase, valueColor: colors.checksum),
+              orElse: () => const SizedBox.shrink(),
             ),
-            const SizedBox(height: 32),
-            _detailRow(context, 'To', info.toAddress, monospace: true),
-            if (_toCheckphrase != null && _toCheckphrase!.isNotEmpty)
-              _detailRow(context, 'Checkphrase', _toCheckphrase!, valueColor: colors.checksum),
-            _detailRow(context, 'Network', parsed.network),
-            _detailRow(context, 'Reversible', info.isReversible ? 'Yes' : 'No'),
-            if (info.isReversible && info.reversibleTimeframe != null)
-              _detailRow(
-                context,
-                'Reversible window',
-                DatetimeFormattingService.formatDuration(Duration(milliseconds: info.reversibleTimeframe!)).formatted,
-              ),
-            _detailRow(context, 'Tip', '${_formatAmount(ext.tip)} ${AppConstants.tokenSymbol}'),
-            _detailRow(context, 'Nonce', '${ext.nonce}'),
-            _detailRow(context, 'Era', '${ext.era}'),
+
+            const SizedBox(height: 8),
+            Divider(color: colors.borderButton),
+            const SizedBox(height: 8),
+            Text('CALL', style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel)),
+            const SizedBox(height: 8),
+            CallDetailView(call: parsed.call),
+
+            const SizedBox(height: 16),
+            Divider(color: colors.borderButton),
+            const SizedBox(height: 8),
+            Text('SIGNED EXTENSIONS', style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel)),
+            DetailRow(label: 'Network', value: parsed.network),
+            DetailRow(label: 'Runtime', value: 'spec ${ext.specVersion}, tx version ${ext.transactionVersion}'),
+            DetailRow(label: 'Nonce', value: '${ext.nonce}'),
+            DetailRow(label: 'Era', value: '${ext.era}'),
+            DetailRow(label: 'Tip', value: '${_formatAmount(ext.tip)} ${AppConstants.tokenSymbol}'),
+            DetailRow(label: 'Genesis hash', value: '0x${hex.encode(ext.genesisHash)}', monospace: true),
+            DetailRow(label: 'Block hash', value: '0x${hex.encode(ext.blockHash)}', monospace: true),
+            DetailRow(
+              label: 'Metadata hash',
+              value: ext.metadataHash == null ? 'None (check disabled)' : '0x${hex.encode(ext.metadataHash!)}',
+              monospace: ext.metadataHash != null,
+            ),
+
+            const SizedBox(height: 16),
+            _rawPayloadSection(context, parsed),
+
             if (_error != null) ...[
               const SizedBox(height: 16),
               Text(
@@ -181,26 +222,172 @@ class _SignTransactionScreenState extends ConsumerState<SignTransactionScreen> {
                 textAlign: TextAlign.center,
               ),
             ],
+            const SizedBox(height: 8),
           ],
         ),
       ),
       bottomContent: ScaffoldBaseBottomContent(
-        child: Row(
+        child: Column(
           children: [
-            Expanded(
-              child: QuantusButton.simple(
-                label: 'Cancel',
-                variant: ButtonVariant.secondary,
-                onTap: () => Navigator.popUntil(context, (r) => r.isFirst),
+            if (!_reviewedToEnd)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  'Scroll through every parameter to enable signing.',
+                  style: text.detail?.copyWith(color: colors.textMuted),
+                  textAlign: TextAlign.center,
+                ),
               ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: QuantusButton.simple(label: 'Sign', isLoading: _signing, onTap: _signing ? null : _sign),
+            Row(
+              children: [
+                Expanded(
+                  child: QuantusButton.simple(
+                    label: 'Cancel',
+                    variant: ButtonVariant.secondary,
+                    onTap: () => Navigator.popUntil(context, (r) => r.isFirst),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: QuantusButton.simple(
+                    label: 'Sign',
+                    isLoading: _signing,
+                    isDisabled: !_reviewedToEnd,
+                    onTap: (_signing || !_reviewedToEnd) ? null : _sign,
+                  ),
+                ),
+              ],
             ),
           ],
         ),
       ),
+    );
+  }
+
+  /// The call decoded, but possibly against shifted pallet or call indices — the
+  /// labels below may belong to a different call than the one that will execute.
+  Widget _specDriftBanner(BuildContext context, SignedExtensions ext) {
+    final colors = context.colors;
+    final text = context.themeText;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 20),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.error.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: colors.error),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.warning_amber_rounded, color: colors.error, size: 22),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Built for a different runtime',
+                  style: text.smallParagraph?.copyWith(color: colors.error, fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'This payload targets spec ${ext.specVersion} / tx version ${ext.transactionVersion}, but this '
+                  'wallet decodes spec ${AppConstants.bundledSpecVersion} / tx version '
+                  '${AppConstants.bundledTransactionVersion}. Across runtime versions the same index can mean a '
+                  'different call, so the parameters below may be mislabelled. Update the cold wallet before signing '
+                  'anything you cannot verify another way.',
+                  style: text.detail?.copyWith(color: colors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Amount hero for value transfers — including one wrapped in a multisig
+  /// proposal or approval — and the call's identity for everything else.
+  Widget _hero(BuildContext context, ParsedPayload parsed) {
+    final colors = context.colors;
+    final text = context.themeText;
+    final summary = parsed.call.summary;
+
+    return Center(
+      child: Column(
+        children: [
+          Text('You are signing', style: text.smallParagraph?.copyWith(color: colors.textSecondary)),
+          const SizedBox(height: 8),
+          if (summary != null && summary.assetId == null)
+            RichText(
+              text: TextSpan(
+                children: [
+                  TextSpan(
+                    text: _formatAmount(summary.amount),
+                    style: text.transactionDetailAmountPrimary?.copyWith(color: colors.textPrimary),
+                  ),
+                  TextSpan(
+                    text: ' ${AppConstants.tokenSymbol}',
+                    style: text.transactionDetailAmountSymbol?.copyWith(color: colors.textSecondary),
+                  ),
+                ],
+              ),
+            )
+          else if (summary != null)
+            Text(
+              '${summary.amount} of asset #${summary.assetId}',
+              style: text.mediumTitle?.copyWith(color: colors.textPrimary),
+              textAlign: TextAlign.center,
+            )
+          else
+            Text(
+              parsed.call.humanCall,
+              style: text.mediumTitle?.copyWith(color: colors.textPrimary),
+              textAlign: TextAlign.center,
+            ),
+          const SizedBox(height: 6),
+          Text(
+            parsed.call.displayTitle,
+            style: text.detail?.copyWith(color: colors.textMuted),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// The exact bytes being signed, for anyone who wants to check the decode by
+  /// hand or against another tool.
+  Widget _rawPayloadSection(BuildContext context, ParsedPayload parsed) {
+    final colors = context.colors;
+    final text = context.themeText;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        GestureDetector(
+          onTap: () => setState(() => _showRawPayload = !_showRawPayload),
+          child: Row(
+            children: [
+              Text(
+                'RAW PAYLOAD (${parsed.raw.length} BYTES)',
+                style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel),
+              ),
+              const SizedBox(width: 6),
+              Icon(_showRawPayload ? Icons.expand_less : Icons.expand_more, size: 18, color: colors.textLabel),
+            ],
+          ),
+        ),
+        if (_showRawPayload) ...[
+          const SizedBox(height: 8),
+          Text(
+            '0x${hex.encode(parsed.raw)}',
+            style: text.detail?.copyWith(color: colors.textMuted, fontFamily: AppTextTheme.fontFamilySecondary),
+          ),
+        ],
+      ],
     );
   }
 
@@ -234,27 +421,6 @@ class _SignTransactionScreenState extends ConsumerState<SignTransactionScreen> {
       ),
       bottomContent: ScaffoldBaseBottomContent(
         child: QuantusButton.simple(label: 'Done', onTap: () => Navigator.popUntil(context, (r) => r.isFirst)),
-      ),
-    );
-  }
-
-  Widget _detailRow(BuildContext context, String label, String value, {bool monospace = false, Color? valueColor}) {
-    final colors = context.colors;
-    final text = context.themeText;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(label.toUpperCase(), style: text.transactionDetailRowLabel?.copyWith(color: colors.textLabel)),
-          const SizedBox(height: 6),
-          Text(
-            value,
-            style: monospace
-                ? text.transactionDetailRowValue?.copyWith(color: valueColor ?? colors.textPrimary)
-                : text.smallParagraph?.copyWith(color: valueColor ?? colors.textPrimary),
-          ),
-        ],
       ),
     );
   }

--- a/cold-wallet-app/test/transaction_signing_test.dart
+++ b/cold-wallet-app/test/transaction_signing_test.dart
@@ -2,7 +2,11 @@ import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:quantus_sdk/generated/planck/pallets/balances.dart' as balances_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/multisig.dart' as multisig_pallet;
+import 'package:quantus_sdk/generated/planck/types/sp_runtime/multiaddress/multi_address.dart' as multi_address;
 import 'package:quantus_sdk/quantus_sdk.dart';
+import 'package:quantus_cold_wallet/debug/debug_payloads.dart';
 
 void main() {
   // The 0.1 QUAN keystone transfer call with a Planck extension suffix (era 5501 =
@@ -10,6 +14,14 @@ void main() {
   // cold wallet is verified against the exact byte layout the hot wallet produces.
   const planckHex =
       '0200007416854906f03a9dff66e3270a736c44e15970ac03a638471523a03069f276ca0700e876481755010000008300000002000000'
+      '4901bf5c57fd3f9e726af399c763de6670dbdb115a91c0237e173f16eef65e72'
+      '111111111111111111111111111111111111111111111111111111111111111100';
+
+  // The extension suffix from the vector above, reused when building payloads
+  // around a live runtime call: era 5501, nonce 0, tip 0, metadata mode disabled,
+  // spec 131, tx version 2, Planck genesis, block hash 0x11…, metadata hash None.
+  const planckExtensionSuffixHex =
+      '55010000008300000002000000'
       '4901bf5c57fd3f9e726af399c763de6670dbdb115a91c0237e173f16eef65e72'
       '111111111111111111111111111111111111111111111111111111111111111100';
 
@@ -39,14 +51,60 @@ void main() {
       final payload = Uint8List.fromList(hex.decode(planckHex));
       final parsed = QuantusPayloadParser.parsePayload(payload);
 
-      expect(parsed.call.isReversible, isFalse);
-      expect(parsed.call.reversibleTimeframe, isNull);
-      expect(parsed.call.toAddress, startsWith('qz'));
-      expect(parsed.call.amount, BigInt.parse('100000000000')); // 0.1 QUAN at 12 decimals
+      expect(parsed.call.pallet, 'Balances');
+      expect(parsed.call.call, 'transfer_allow_death');
+      final destination = parsed.call.fields.whereType<ValueField>().firstWhere((f) => f.label == 'Destination');
+      expect(destination.kind, ValueKind.address);
+      expect(destination.value, startsWith('qz'));
+      final amount = parsed.call.fields.whereType<AmountField>().firstWhere((f) => f.label == 'Amount');
+      expect(amount.planck, BigInt.parse('100000000000')); // 0.1 QUAN at 12 decimals
+      expect(parsed.call.summary?.amount, BigInt.parse('100000000000'));
       expect(parsed.network, 'Planck');
       expect(parsed.extensions.era.toString(), '64 blocks');
       expect(parsed.extensions.nonce, 0);
       expect(parsed.extensions.tip, BigInt.zero);
+      // Captured on spec 131; the signer still decodes it, and flags the drift.
+      expect(parsed.extensions.specVersion, 131);
+      expect(parsed.specMatchesBundled, isFalse);
+    });
+
+    test('multisig approve shows the transfer it authorises, end to end', () {
+      // A cold signer approving a proposal must see the call it approves, not just
+      // a proposal id. The chain enforces that these bytes match the stored
+      // proposal, so what is displayed here is what gets authorised.
+      final inner = const balances_pallet.Txs().transferAllowDeath(
+        dest: multi_address.MultiAddress.values.id(Uint8List.fromList(List.filled(32, 0xBB))),
+        value: BigInt.from(4200000000000),
+      );
+      final approve = const multisig_pallet.Txs().approve(
+        multisigAddress: Uint8List.fromList(List.filled(32, 0xAA)),
+        proposalId: 12,
+        call: inner.encode(),
+      );
+      final payload = Uint8List.fromList([...approve.encode(), ...hex.decode(planckExtensionSuffixHex)]);
+
+      final parsed = QuantusPayloadParser.parsePayload(payload);
+
+      expect(parsed.call.displayTitle, 'Multisig · approve');
+      expect(parsed.call.fields.whereType<ValueField>().firstWhere((f) => f.label == 'Proposal id').value, '12');
+
+      final approved = parsed.call.fields
+          .whereType<NestedCallField>()
+          .firstWhere((f) => f.label == 'Call being approved')
+          .call;
+      expect(approved.call, 'transfer_allow_death');
+      expect(
+        approved.fields.whereType<AmountField>().firstWhere((f) => f.label == 'Amount').planck,
+        BigInt.from(4200000000000),
+      );
+      // Hero amount comes from the authorised transfer.
+      expect(parsed.call.summary?.amount, BigInt.from(4200000000000));
+
+      // An approve wrapping a plain transfer still fits under the 256-byte rule,
+      // so it is signed as-is; larger inner calls (batches, inline governance
+      // proposals) cross over and get hashed. Both sides apply the same rule.
+      expect(payload.length, lessThanOrEqualTo(256));
+      expect(QuantusSigningPayload.signablePayload(payload), payload);
     });
 
     test('retired devnet payload is rejected with unknown genesis (never signed)', () {
@@ -60,6 +118,24 @@ void main() {
     test('non-transaction bytes are rejected (never signed)', () {
       final garbage = Uint8List.fromList(List<int>.generate(40, (i) => 0xff - i));
       expect(() => QuantusPayloadParser.parsePayload(garbage), throwsFormatException);
+    });
+  });
+
+  group('DebugPayloads (simulator scan substitutes)', () {
+    // The three debug buttons share one extension encoder, so if it drifts they
+    // all fail with "could not read transaction" on the simulator. Only the vote
+    // payload is checkable here — the others resolve addresses through the Rust
+    // bridge, which unit tests do not initialise.
+    test('governance vote payload parses with no spec drift', () {
+      final parsed = QuantusPayloadParser.parsePayload(DebugPayloads.governanceVoteAye());
+
+      expect(parsed.call.displayTitle, 'TechCollective · vote');
+      expect(parsed.call.fields.whereType<ValueField>().firstWhere((f) => f.label == 'Vote').value, contains('Aye'));
+      expect(parsed.call.summary, isNull, reason: 'a vote moves no value, so there is no amount hero');
+      expect(parsed.network, 'Planck');
+      expect(parsed.specMatchesBundled, isTrue, reason: 'debug payloads must not trip the drift warning');
+      expect(parsed.extensions.era.toString(), '64 blocks');
+      expect(parsed.extensions.tip, BigInt.zero);
     });
   });
 }

--- a/quantus_sdk/lib/src/quantus_payload_parser.dart
+++ b/quantus_sdk/lib/src/quantus_payload_parser.dart
@@ -1,21 +1,20 @@
 /// A parser for Quantus blockchain signing payloads.
 ///
-/// Mirrors the Keystone firmware parser (rust/apps/quantus/src/parser.rs): the
-/// full signed payload — call plus every signed-extension field — is decoded
-/// with nothing left over, so what the signer displays is exactly what it
-/// signs. Any pallet, call, address type, or network not declared here
-/// hard-fails with a [FormatException]; nothing is silently ignored.
+/// The full signed payload — call plus every signed-extension field — is decoded
+/// with nothing left over, so what the signer displays is exactly what it signs.
+/// Anything that cannot be decoded exactly hard-fails with a [FormatException];
+/// nothing is silently ignored, and no call is ever presented partially.
 ///
-/// Supported calls (runtime pallet/call indices, chain `main`, spec >= 133):
-/// - Balances (pallet 2): transfer_allow_death (0), transfer_keep_alive (3)
-/// - ReversibleTransfers (pallet 11): schedule_transfer (3),
-///   schedule_transfer_with_delay (4)
+/// The call itself decodes through [CallDecoder], i.e. the generated polkadart
+/// codecs, so **every** call the bundled metadata declares is supported and
+/// displayed field by field — there is no allowlist of signable pallets to fall
+/// behind the runtime. An unknown pallet or call index throws.
 ///
 /// Usage:
 /// ```dart
 /// final payload = signingPayload.encodeRaw(registry);
 /// final parsed = QuantusPayloadParser.parsePayload(payload); // throws on rejection
-/// print('${parsed.call} on ${parsed.network}');
+/// print('${parsed.call.displayTitle} on ${parsed.network}');
 /// ```
 library;
 
@@ -24,8 +23,10 @@ import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
 import 'package:polkadart/scale_codec.dart';
+import 'package:quantus_sdk/generated/planck/types/quantus_runtime/runtime_call.dart';
+import 'package:quantus_sdk/src/chain/call_decoder.dart';
+import 'package:quantus_sdk/src/chain/decoded_call.dart';
 import 'package:quantus_sdk/src/constants/app_constants.dart';
-import 'package:ss58/ss58.dart';
 
 /// Hard cap on the raw signing payload; every supported call is far below this.
 const int maxPayloadBytes = 8 * 1024;
@@ -86,53 +87,35 @@ class SignedExtensions {
   });
 }
 
-class TransactionInfo {
-  final String toAddress;
-  final BigInt amount;
-  final bool isReversible;
-  final int? reversibleTimeframe; // in milliseconds
-
-  TransactionInfo({
-    required this.toAddress,
-    required this.amount,
-    required this.isReversible,
-    this.reversibleTimeframe,
-  });
-
-  @override
-  String toString() {
-    final amountStr = (amount / BigInt.from(10).pow(AppConstants.decimals)).toStringAsFixed(4);
-    return '''
-Transaction Details:
-  To Address: $toAddress
-  Amount: $amountStr ${AppConstants.tokenSymbol}
-  Reversible: $isReversible
-  ${isReversible && reversibleTimeframe != null ? 'Reversible Timeframe: $reversibleTimeframe ms' : ''}
-''';
-  }
-}
-
 /// A fully decoded signing payload: the call plus every signed-extension field, with no
 /// bytes left over. Everything that gets signed is either displayed or validated.
 class ParsedPayload {
-  final TransactionInfo call;
+  /// The call, with every parameter, nested calls included.
+  final DecodedCall call;
+
   final SignedExtensions extensions;
   final String network;
 
-  ParsedPayload({required this.call, required this.extensions, required this.network});
+  /// The raw payload bytes, so a signer can offer them for inspection.
+  final Uint8List raw;
+
+  ParsedPayload({required this.call, required this.extensions, required this.network, required this.raw});
+
+  /// Whether the payload targets the runtime the bundled metadata came from.
+  ///
+  /// When false the call decoded, but against possibly-shifted pallet or call
+  /// indices — the field labels may belong to a different call than the one that
+  /// will execute. Signers must say so prominently.
+  bool get specMatchesBundled =>
+      extensions.specVersion == AppConstants.bundledSpecVersion &&
+      extensions.transactionVersion == AppConstants.bundledTransactionVersion;
 }
 
 class QuantusPayloadParser {
-  static String bytesToSs58(Uint8List bytes) {
-    if (bytes.length != 32) {
-      throw FormatException('AccountId32 must be 32 bytes, got ${bytes.length}');
-    }
-    return Address(prefix: AppConstants.ss58prefix, pubkey: bytes).encode();
-  }
-
   /// Decodes a full signing payload. Throws [FormatException] on any rejection:
-  /// unknown pallet/call/address type, malformed extensions, trailing bytes,
-  /// metadata-mode inconsistency, or a genesis hash not in [knownNetworks].
+  /// unknown pallet/call index, an inner call that does not decode exactly,
+  /// malformed extensions, trailing bytes, metadata-mode inconsistency, or a
+  /// genesis hash not in [knownNetworks].
   static ParsedPayload parsePayload(Uint8List payload) {
     if (payload.length > maxPayloadBytes) {
       throw FormatException('Payload too large: ${payload.length} bytes');
@@ -159,7 +142,7 @@ class QuantusPayloadParser {
       throw FormatException('Unknown genesis hash: 0x${hex.encode(extensions.genesisHash)}');
     }
 
-    return ParsedPayload(call: call, extensions: extensions, network: network);
+    return ParsedPayload(call: call, extensions: extensions, network: network, raw: payload);
   }
 
   static T _section<T>(String section, T Function() decode) {
@@ -172,75 +155,13 @@ class QuantusPayloadParser {
     }
   }
 
-  // Mirror of the runtime call enums; indices must match the runtime pallet/call
-  // declarations and compact encoding must match `#[pallet::compact]` usage.
-  static TransactionInfo _decodeCall(Input input) {
-    final palletIndex = U8Codec.codec.decode(input);
-    switch (palletIndex) {
-      case 2:
-        return _decodeBalancesCall(input);
-      case 11:
-        return _decodeReversibleTransfersCall(input);
-      default:
-        throw FormatException('Unknown pallet index: $palletIndex');
-    }
-  }
-
-  static TransactionInfo _decodeBalancesCall(Input input) {
-    final callIndex = U8Codec.codec.decode(input);
-    switch (callIndex) {
-      case 0: // transfer_allow_death
-      case 3: // transfer_keep_alive
-        final dest = _decodeMultiAddress(input);
-        final amount = CompactBigIntCodec.codec.decode(input); // #[pallet::compact] value
-        return TransactionInfo(toAddress: dest, amount: amount, isReversible: false);
-      default:
-        throw FormatException('Balances: unsupported call index $callIndex');
-    }
-  }
-
-  static TransactionInfo _decodeReversibleTransfersCall(Input input) {
-    final callIndex = U8Codec.codec.decode(input);
-    switch (callIndex) {
-      case 3: // schedule_transfer
-        final dest = _decodeMultiAddress(input);
-        final amount = U128Codec.codec.decode(input); // fixed u128, not compact
-        return TransactionInfo(
-          toAddress: dest,
-          amount: amount,
-          isReversible: true,
-          reversibleTimeframe: null, // Uses configured delay
-        );
-      case 4: // schedule_transfer_with_delay
-        final dest = _decodeMultiAddress(input);
-        final amount = U128Codec.codec.decode(input);
-        final delay = _decodeTimestampDelay(input);
-        return TransactionInfo(toAddress: dest, amount: amount, isReversible: true, reversibleTimeframe: delay);
-      default:
-        throw FormatException('ReversibleTransfers: unsupported call index $callIndex');
-    }
-  }
-
-  static String _decodeMultiAddress(Input input) {
-    final addressType = U8Codec.codec.decode(input);
-    if (addressType != 0) {
-      throw FormatException('Unsupported MultiAddress type: $addressType (only Id is accepted)');
-    }
-    return bytesToSs58(input.readBytes(32));
-  }
-
-  // qp_scheduler::BlockNumberOrTimestamp<u32, u64>
-  static int _decodeTimestampDelay(Input input) {
-    final variant = U8Codec.codec.decode(input);
-    switch (variant) {
-      case 0:
-        final block = U32Codec.codec.decode(input);
-        throw FormatException('Block-number delays are not supported (got block $block)');
-      case 1:
-        return U64Codec.codec.decode(input).toInt();
-      default:
-        throw FormatException('Unknown BlockNumberOrTimestamp variant: $variant');
-    }
+  /// Decodes the call through the generated runtime codecs.
+  ///
+  /// The codec consumes exactly the call's bytes and leaves the extensions for
+  /// [_decodeExtensions], so an over- or under-read surfaces as a malformed
+  /// extension or trailing bytes rather than passing silently.
+  static DecodedCall _decodeCall(Input input) {
+    return CallDecoder.describe(RuntimeCall.codec.decode(input));
   }
 
   static Era _decodeEra(Input input) {

--- a/quantus_sdk/test/quantus_payload_parser_test.dart
+++ b/quantus_sdk/test/quantus_payload_parser_test.dart
@@ -3,6 +3,12 @@ import 'dart:typed_data';
 import 'package:convert/convert.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:polkadart/scale_codec.dart';
+import 'package:quantus_sdk/generated/planck/pallets/balances.dart' as balances_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/multisig.dart' as multisig_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/preimage.dart' as preimage_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/system.dart' as system_pallet;
+import 'package:quantus_sdk/generated/planck/pallets/tech_collective.dart' as collective_pallet;
+import 'package:quantus_sdk/generated/planck/types/sp_runtime/multiaddress/multi_address.dart' as multi_address;
 import 'package:quantus_sdk/quantus_sdk.dart';
 
 const planckGenesisHex = '4901bf5c57fd3f9e726af399c763de6670dbdb115a91c0237e173f16eef65e72';
@@ -22,26 +28,63 @@ const oldNetworkTransfer =
 const oldNetworkReversible =
     '0d04007416854906f03a9dff66e3270a736c44e15970ac03a638471523a03069f276ca0040b0464f010000000000000000000001e093040000000000d5010c00007400000002000000826beefbe2be72645ff376f18de745ac196dc77637436090de4174180706118efeebb9b31159a679a1e49ccc34d363b5d4a00b836ad4f85cbba8c6274ac2566800';
 
-Uint8List extSuffix({List<int> era = const [0x00], int nonce = 0, BigInt? tip, String genesisHex = planckGenesisHex}) {
+Uint8List extSuffix({
+  List<int> era = const [0x00],
+  int nonce = 0,
+  BigInt? tip,
+  String genesisHex = planckGenesisHex,
+  int specVersion = AppConstants.bundledSpecVersion,
+  int transactionVersion = AppConstants.bundledTransactionVersion,
+}) {
   final out = ByteOutput();
   out.write(era);
   CompactCodec.codec.encodeTo(nonce, out);
   CompactBigIntCodec.codec.encodeTo(tip ?? BigInt.zero, out);
   out.pushByte(0); // metadata hash mode: disabled
-  U32Codec.codec.encodeTo(131, out); // spec_version
-  U32Codec.codec.encodeTo(2, out); // transaction_version
+  U32Codec.codec.encodeTo(specVersion, out);
+  U32Codec.codec.encodeTo(transactionVersion, out);
   out.write(hex.decode(genesisHex));
   out.write(List.filled(32, 0x11)); // block hash (not validated)
   out.pushByte(0); // metadata hash: None
   return out.toBytes();
 }
 
-Uint8List payloadWithSuffix(String callHex, {List<int> era = const [0x00], int nonce = 0, BigInt? tip}) {
-  return Uint8List.fromList([...hex.decode(callHex), ...extSuffix(era: era, nonce: nonce, tip: tip)]);
+Uint8List payloadWithSuffix(
+  String callHex, {
+  List<int> era = const [0x00],
+  int nonce = 0,
+  BigInt? tip,
+  int specVersion = AppConstants.bundledSpecVersion,
+}) {
+  return Uint8List.fromList([
+    ...hex.decode(callHex),
+    ...extSuffix(era: era, nonce: nonce, tip: tip, specVersion: specVersion),
+  ]);
+}
+
+/// Builds a full signing payload around a live runtime call, so the call vectors
+/// track the metadata instead of being hand-rolled hex.
+Uint8List payloadForCall(RuntimeCall call, {int nonce = 0, int specVersion = AppConstants.bundledSpecVersion}) {
+  return Uint8List.fromList([...call.encode(), ...extSuffix(nonce: nonce, specVersion: specVersion)]);
 }
 
 Matcher throwsRejection(String needle) =>
     throwsA(isA<FormatException>().having((e) => e.message, 'message', contains(needle)));
+
+final bobId = Uint8List.fromList(List.filled(32, 0xBB));
+final multisigId = Uint8List.fromList(List.filled(32, 0xAA));
+final codeHash = Uint8List.fromList(List.filled(32, 0xCC));
+
+multi_address.MultiAddress dest(Uint8List id) => multi_address.MultiAddress.values.id(id);
+
+ValueField valueField(DecodedCall call, String label) =>
+    call.fields.whereType<ValueField>().firstWhere((f) => f.label == label);
+
+AmountField amountField(DecodedCall call, String label) =>
+    call.fields.whereType<AmountField>().firstWhere((f) => f.label == label);
+
+NestedCallField nestedField(DecodedCall call, String label) =>
+    call.fields.whereType<NestedCallField>().firstWhere((f) => f.label == label);
 
 void main() {
   group('QuantusPayloadParser', () {
@@ -50,17 +93,19 @@ void main() {
       final payload = payloadWithSuffix(transferCall1, era: const [0x85, 0x01], nonce: 10);
       final parsed = QuantusPayloadParser.parsePayload(payload);
 
-      expect(parsed.call.toAddress, 'qzps6MnSixszZAWiwcpjtw6uXBjWg2aEyrXBdp9thijzY1g86');
-      expect(parsed.call.amount, BigInt.from(900000000000));
-      expect(parsed.call.isReversible, false);
-      expect(parsed.call.reversibleTimeframe, null);
+      expect(parsed.call.pallet, 'Balances');
+      expect(parsed.call.call, 'transfer_allow_death');
+      expect(valueField(parsed.call, 'Destination').value, 'qzps6MnSixszZAWiwcpjtw6uXBjWg2aEyrXBdp9thijzY1g86');
+      expect(amountField(parsed.call, 'Amount').planck, BigInt.from(900000000000));
+      expect(parsed.call.summary?.amount, BigInt.from(900000000000));
       expect(parsed.extensions.era, const Era.mortal(64, 24));
       expect(parsed.extensions.era.toString(), '64 blocks');
       expect(parsed.extensions.nonce, 10);
       expect(parsed.extensions.tip, BigInt.zero);
-      expect(parsed.extensions.specVersion, 131);
-      expect(parsed.extensions.transactionVersion, 2);
+      expect(parsed.extensions.specVersion, AppConstants.bundledSpecVersion);
       expect(parsed.network, 'Planck');
+      expect(parsed.specMatchesBundled, isTrue);
+      expect(parsed.raw, payload);
     });
 
     test('parses transfer with tip and immortal era', () {
@@ -68,8 +113,8 @@ void main() {
       final payload = payloadWithSuffix(transferCall2, tip: tip);
       final parsed = QuantusPayloadParser.parsePayload(payload);
 
-      expect(parsed.call.toAddress, 'qzn5St24cMsjE4JKYdXLBctusWj5zom67dnrW22SweAahLGeG');
-      expect(parsed.call.amount, BigInt.from(100000000000));
+      expect(valueField(parsed.call, 'Destination').value, 'qzn5St24cMsjE4JKYdXLBctusWj5zom67dnrW22SweAahLGeG');
+      expect(amountField(parsed.call, 'Amount').planck, BigInt.from(100000000000));
       expect(parsed.extensions.era, const Era.immortal());
       expect(parsed.extensions.era.toString(), 'Immortal');
       expect(parsed.extensions.tip, tip);
@@ -79,72 +124,154 @@ void main() {
       final payload = payloadWithSuffix(reversibleCall, nonce: 3);
       final parsed = QuantusPayloadParser.parsePayload(payload);
 
-      expect(parsed.call.toAddress, 'qzn5St24cMsjE4JKYdXLBctusWj5zom67dnrW22SweAahLGeG');
-      expect(parsed.call.amount, BigInt.from(1440000000000));
-      expect(parsed.call.isReversible, true);
-      expect(parsed.call.reversibleTimeframe, 300000); // 5 minutes in milliseconds
+      expect(parsed.call.pallet, 'ReversibleTransfers');
+      expect(parsed.call.call, 'schedule_transfer_with_delay');
+      expect(valueField(parsed.call, 'Destination').value, 'qzn5St24cMsjE4JKYdXLBctusWj5zom67dnrW22SweAahLGeG');
+      expect(amountField(parsed.call, 'Amount').planck, BigInt.from(1440000000000));
+      expect(valueField(parsed.call, 'Delay').value, contains('300000 ms')); // 5 minutes
       expect(parsed.extensions.nonce, 3);
     });
 
-    test('rejects old devnet transfer with unknown genesis (regression)', () {
-      // Proves the parser walks all the way to the genesis hash and rejects unknown networks.
-      final payload = Uint8List.fromList(hex.decode(oldNetworkTransfer));
-      expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('Unknown genesis hash'));
+    // Every call the runtime declares must be signable, and every parameter shown.
+    group('calls beyond transfers', () {
+      test('multisig approve shows the call being approved and its amount', () {
+        final inner = const balances_pallet.Txs().transferAllowDeath(
+          dest: dest(bobId),
+          value: BigInt.from(2500000000000),
+        );
+        final parsed = QuantusPayloadParser.parsePayload(
+          payloadForCall(
+            const multisig_pallet.Txs().approve(multisigAddress: multisigId, proposalId: 9, call: inner.encode()),
+          ),
+        );
+
+        expect(parsed.call.displayTitle, 'Multisig · approve');
+        expect(valueField(parsed.call, 'Proposal id').value, '9');
+
+        final approved = nestedField(parsed.call, 'Call being approved').call;
+        expect(approved.call, 'transfer_allow_death');
+        expect(amountField(approved, 'Amount').planck, BigInt.from(2500000000000));
+        expect(parsed.call.summary?.amount, BigInt.from(2500000000000));
+      });
+
+      test('multisig propose shows the proposed call', () {
+        final inner = const balances_pallet.Txs().transferKeepAlive(dest: dest(bobId), value: BigInt.one);
+        final parsed = QuantusPayloadParser.parsePayload(
+          payloadForCall(
+            const multisig_pallet.Txs().propose(multisigAddress: multisigId, call: inner.encode(), expiry: 999),
+          ),
+        );
+
+        expect(parsed.call.call, 'propose');
+        expect(valueField(parsed.call, 'Expires at block').value, '999');
+        expect(nestedField(parsed.call, 'Proposed call').call.call, 'transfer_keep_alive');
+      });
+
+      test('governance vote decodes with its direction', () {
+        final parsed = QuantusPayloadParser.parsePayload(
+          payloadForCall(const collective_pallet.Txs().vote(poll: 41, aye: true)),
+        );
+
+        expect(parsed.call.displayTitle, 'TechCollective · vote');
+        expect(valueField(parsed.call, 'Referendum').value, '#41');
+        expect(valueField(parsed.call, 'Vote').value, contains('Aye'));
+        expect(parsed.call.summary, isNull);
+      });
+
+      test('runtime upgrade authorisation decodes with its code hash', () {
+        final parsed = QuantusPayloadParser.parsePayload(
+          payloadForCall(const system_pallet.Txs().authorizeUpgrade(codeHash: codeHash)),
+        );
+
+        expect(parsed.call.displayTitle, 'System · authorize_upgrade');
+        final field = valueField(parsed.call, 'Runtime code hash');
+        expect(field.value, '0x${hex.encode(codeHash)}');
+        expect(field.note, contains('not part of this payload'));
+      });
+
+      test('note_preimage wrapping an upgrade call decodes recursively', () {
+        final upgrade = const system_pallet.Txs().authorizeUpgrade(codeHash: codeHash);
+        final parsed = QuantusPayloadParser.parsePayload(
+          payloadForCall(const preimage_pallet.Txs().notePreimage(bytes: upgrade.encode())),
+        );
+
+        expect(parsed.call.call, 'note_preimage');
+        expect(nestedField(parsed.call, 'Preimage').call.call, 'authorize_upgrade');
+      });
     });
 
-    test('rejects old devnet reversible transfer (regression)', () {
-      // Rejected at call decode: ReversibleTransfers moved from pallet index 13 to 11 when
-      // the devnet was retired, so this never reaches the (equally retired) genesis hash.
-      final payload = Uint8List.fromList(hex.decode(oldNetworkReversible));
-      expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('Unknown pallet index: 13'));
+    group('spec drift', () {
+      test('flags a payload built for a different runtime but still decodes it', () {
+        final payload = payloadWithSuffix(transferCall1, specVersion: 999);
+        final parsed = QuantusPayloadParser.parsePayload(payload);
+
+        expect(parsed.extensions.specVersion, 999);
+        expect(parsed.specMatchesBundled, isFalse);
+        // Still fully decoded: the signer warns rather than hiding the call.
+        expect(parsed.call.call, 'transfer_allow_death');
+      });
+
+      test('a matching spec but mismatched transaction version also counts as drift', () {
+        final payload = Uint8List.fromList([...hex.decode(transferCall1), ...extSuffix(transactionVersion: 99)]);
+        expect(QuantusPayloadParser.parsePayload(payload).specMatchesBundled, isFalse);
+      });
     });
 
-    test('rejects trailing bytes after signed payload', () {
-      final payload = payloadWithSuffix(transferCall1, era: const [0x85, 0x01], nonce: 10);
-      final tampered = Uint8List.fromList([...payload, 0xde, 0xad, 0xbe, 0xef]);
-      expect(() => QuantusPayloadParser.parsePayload(tampered), throwsRejection('trailing bytes'));
-    });
+    group('rejections', () {
+      test('rejects old devnet transfer with unknown genesis (regression)', () {
+        // Proves the parser walks all the way to the genesis hash and rejects unknown networks.
+        final payload = Uint8List.fromList(hex.decode(oldNetworkTransfer));
+        expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('Unknown genesis hash'));
+      });
 
-    test('rejects bare call without extensions', () {
-      final payload = Uint8List.fromList(hex.decode(transferCall1));
-      expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('extensions'));
-    });
+      test('rejects old devnet reversible transfer (regression)', () {
+        // Rejected, but note *where*: pallet index 13 was ReversibleTransfers on the
+        // retired devnet and is TechCollective on this runtime, so these bytes now
+        // decode as a plausible-looking `vote` that consumes a different number of
+        // bytes — and the mismatch only surfaces when the extensions fail to parse.
+        //
+        // This is exactly why a payload whose spec version differs from the bundled
+        // metadata gets a prominent warning: across runtimes, an index can mean a
+        // different call. The payload still fails closed either way.
+        final payload = Uint8List.fromList(hex.decode(oldNetworkReversible));
+        expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('extensions'));
+      });
 
-    test('rejects metadata mode mismatch', () {
-      final suffix = extSuffix();
-      suffix[3] = 1; // mode: enabled, but metadata hash stays None
-      final payload = Uint8List.fromList([...hex.decode(transferCall1), ...suffix]);
-      expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('inconsistent'));
-    });
+      test('rejects trailing bytes after signed payload', () {
+        final payload = payloadWithSuffix(transferCall1, era: const [0x85, 0x01], nonce: 10);
+        final tampered = Uint8List.fromList([...payload, 0xde, 0xad, 0xbe, 0xef]);
+        expect(() => QuantusPayloadParser.parsePayload(tampered), throwsRejection('trailing bytes'));
+      });
 
-    test('rejects oversized payload', () {
-      final payload = Uint8List(maxPayloadBytes + 1);
-      expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('too large'));
-    });
+      test('rejects bare call without extensions', () {
+        final payload = Uint8List.fromList(hex.decode(transferCall1));
+        expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('extensions'));
+      });
 
-    test('rejects unknown pallet and unknown call', () {
-      expect(() => QuantusPayloadParser.parsePayload(payloadWithSuffix('0500')), throwsRejection('Unknown pallet'));
-      expect(() => QuantusPayloadParser.parsePayload(payloadWithSuffix('0202')), throwsRejection('call'));
-    });
+      test('rejects metadata mode mismatch', () {
+        final suffix = extSuffix();
+        suffix[3] = 1; // mode: enabled, but metadata hash stays None
+        final payload = Uint8List.fromList([...hex.decode(transferCall1), ...suffix]);
+        expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('inconsistent'));
+      });
 
-    test('rejects multisig payloads (pallet 19 not displayable here)', () {
-      final payload = payloadWithSuffix('1300');
-      expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('Unknown pallet index: 19'));
-    });
+      test('rejects oversized payload', () {
+        final payload = Uint8List(maxPayloadBytes + 1);
+        expect(() => QuantusPayloadParser.parsePayload(payload), throwsRejection('too large'));
+      });
 
-    test('TransactionInfo toString formats with 12 decimals', () {
-      final tx = TransactionInfo(
-        toAddress: 'qzps6MnSixszZAWiwcpjtw6uXBjWg2aEyrXBdp9thijzY1g86',
-        amount: BigInt.from(10000000000000), // 10 QUAN at 12 decimals
-        isReversible: true,
-        reversibleTimeframe: 300000,
-      );
+      test('rejects unknown pallet and unknown call index', () {
+        // Pallet 250 and Balances call 200 do not exist on this runtime.
+        expect(() => QuantusPayloadParser.parsePayload(payloadWithSuffix('fa00')), throwsRejection('call'));
+        expect(() => QuantusPayloadParser.parsePayload(payloadWithSuffix('02c8')), throwsRejection('call'));
+      });
 
-      final output = tx.toString();
-      expect(output, contains('To Address: qzps6MnSixszZAWiwcpjtw6uXBjWg2aEyrXBdp9thijzY1g86'));
-      expect(output, contains('Amount: 10.0000 ${AppConstants.tokenSymbol}'));
-      expect(output, contains('Reversible: true'));
-      expect(output, contains('Reversible Timeframe: 300000 ms'));
+      test('rejects a multisig proposal whose inner call cannot be decoded', () {
+        // No blind signing: an unreadable inner call fails the whole payload
+        // rather than being shown as an opaque blob next to a Sign button.
+        final propose = const multisig_pallet.Txs().propose(multisigAddress: multisigId, call: [250, 0], expiry: 10);
+        expect(() => QuantusPayloadParser.parsePayload(payloadForCall(propose)), throwsRejection('call'));
+      });
     });
   });
 }


### PR DESCRIPTION
> **Stacked on #585** — base is `fix/multisig-approve-with-call`. Review that one first; this PR's diff is only the cold-wallet layer.

## Why

The cold wallet could decode **two pallets**. `QuantusPayloadParser` carried a hand-written pallet-index switch for Balances and ReversibleTransfers, so every other call hard-failed with `Unknown pallet index` — the core dev team could not use a cold wallet for multisig approvals or governance at all.

## Parser

The call now decodes through the generated polkadart codecs (`CallDecoder`, added in #585), so coverage follows the metadata instead of an allowlist that falls behind the runtime.

Every existing hardening check stays: 8 KB cap, strict whole-payload decode, zero trailing bytes, era/nonce/tip/metadata-mode bounds, mode↔hash consistency, known genesis hash. An inner call that does not decode exactly **rejects the whole payload** rather than appearing as an opaque blob next to a Sign button.

`ParsedPayload` now carries the `DecodedCall` tree, the raw bytes, and `specMatchesBundled`.

## Review screen

Rebuilt around showing everything that gets signed:

- **Amount hero** comes from the call's transfer summary, which propagates up from a nested call — a multisig approve of a transfer still reads as an amount and a recipient, while a governance vote names the call instead of claiming zero.
- **Every parameter** in signed order; nested calls as boxed sub-lists, recursively. Addresses get a checkphrase — all of them, not just a destination. Hashes and byte blobs shown in full, wrapped, never truncated.
- **Signing key** address + checkphrase: the payload does not name the signer, and which key signs is part of what is happening.
- **Signed extensions** (network, runtime versions, nonce, era, tip, genesis / block / metadata hashes) plus a collapsible **raw payload hex**.
- **Sign is gated on scrolling** to the end of the parameter list, so "I read it" is an action rather than an assumption. Payloads short enough to fit on one screen release the gate after layout.
- **Spec-drift warning** instead of silent acceptance. This is not theoretical: the parser test covers a retired-devnet vector whose pallet index 13 was ReversibleTransfers and is TechCollective on this runtime — those bytes now decode as a plausible-looking `vote` and only fail when the extensions don't parse. Across runtime versions an index can mean a different call, so a mismatched spec gets a red banner naming both versions. Per the agreed policy this warns rather than blocks.

## Debug buttons

Three `kDebugMode`-only buttons on the scanner (send, multisig approve wrapping a transfer, governance aye vote) inject a payload directly, so the scan → review → sign path can be exercised on a simulator, which has no camera. They share one extension encoder, covered by a test so they can't rot silently into "could not read transaction".

## Testing

- `melos analyze` clean across all four packages.
- `quantus_sdk`: 160 tests. `quantus_payload_parser_test.dart` rewritten on the new model — every prior hardening case kept, plus multisig approve/propose, `TechCollective.vote`, `System.authorize_upgrade`, `note_preimage` wrapping an upgrade, spec-drift, and an undecodable inner call.
- `cold-wallet-app`: 7 tests, including the byte-exact hot→cold transfer vector and an approve-with-inner-transfer end to end.
- **Ran on the iOS simulator** and reviewed the rendered screen: hero showed `4.2 QUAN` lifted from the transfer nested inside a `Multisig · approve`, both the multisig account and the inner destination resolved checkphrases offline, extensions and raw-payload sections rendered, and Sign correctly stayed disabled until the page had been read. Running it also caught a real crash — `maxScrollExtent` read during `build` before the scroll position had content dimensions — now fixed and guarded.

Not yet exercised against a live chain end to end (hot wallet proposes → cold wallet approves → broadcast); worth doing with #585 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)