### PR TITLE
fix: hide local notifications from lock screen (L14)

### DIFF
--- a/mobile-app/lib/services/local_notifications_service.dart
+++ b/mobile-app/lib/services/local_notifications_service.dart
@@ -33,6 +33,9 @@ class LocalNotificationsService {
         channelDescription: 'Wallet notification channel',
         importance: Importance.high,
         priority: Priority.high,
+        // Do not reveal any part of the notification on a secure lock screen: titles/bodies
+        // contain transaction amounts and addresses (security audit finding L14).
+        visibility: NotificationVisibility.secret,
       ),
       iOS: DarwinNotificationDetails(),
     );


### PR DESCRIPTION
Sets `visibility: NotificationVisibility.secret` on the single `AndroidNotificationDetails` construction site in `LocalNotificationsService._notificationDetails()` (covers both immediate and scheduled notifications, including FCM-foreground pushes routed through the same path).

`.secret` hides the notification entirely on a secure lock screen, enforced at the notification level regardless of the device's global lock-screen content setting. (`.private` — as in #578 — is a no-op: it equals the builder default, and its redaction only applies when the user's global setting already hides sensitive content.)

iOS lock-screen previews remain a per-user system setting that apps cannot control.

Addresses finding L14 of the 2026-07-22 mobile wallet security audit. Supersedes #578.