### PR TITLE
refactor: centralize mnemonic generation in the SDK

### DIFF
--- a/miner-app/lib/features/setup/rewards_address_setup_screen.dart
+++ b/miner-app/lib/features/setup/rewards_address_setup_screen.dart
@@ -73,9 +73,10 @@ class _RewardsAddressSetupScreenState extends State<RewardsAddressSetupScreen> {
   }
 
   /// Generate a new 24-word mnemonic.
-  void _generateNewMnemonic() {
+  Future<void> _generateNewMnemonic() async {
+    final mnemonic = await _walletService.generateMnemonic();
     setState(() {
-      _generatedMnemonic = _walletService.generateMnemonic();
+      _generatedMnemonic = mnemonic;
       _mnemonicConfirmed = false;
     });
   }

--- a/miner-app/lib/src/services/miner_wallet_service.dart
+++ b/miner-app/lib/src/services/miner_wallet_service.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 
 import 'package:quantus_miner/src/services/binary_manager.dart';
 import 'package:quantus_miner/src/utils/app_logger.dart';
@@ -33,11 +32,8 @@ class MinerWalletService {
       File('${await BinaryManager.getQuantusHomeDirectoryPath()}/$_legacyRewardsAddressFileName');
 
   /// Generate a new 24-word mnemonic (256 bits of entropy).
-  String generateMnemonic() {
-    final random = Random.secure();
-    final entropy = List<int>.generate(32, (_) => random.nextInt(256));
-    return Mnemonic(entropy, Language.english).sentence;
-  }
+  /// Delegates to the SDK so all seed generation lives in one place.
+  Future<String> generateMnemonic() => SubstrateService().generateMnemonic();
 
   /// Normalize user-entered mnemonic input: lowercase + collapse whitespace.
   /// The BIP-39 English wordlist is lowercase only.

--- a/quantus_sdk/lib/src/services/substrate_service.dart
+++ b/quantus_sdk/lib/src/services/substrate_service.dart
@@ -406,7 +406,8 @@ class SubstrateService {
   Future<String> generateMnemonic() async {
     try {
       // Generate a random entropy
-      final entropy = List<int>.generate(32, (i) => Random.secure().nextInt(256));
+      final random = Random.secure();
+      final entropy = List<int>.generate(32, (_) => random.nextInt(256));
       // Generate mnemonic from entropy
       final mnemonic = Mnemonic(entropy, Language.english);
 


### PR DESCRIPTION
## Why

Seed generation lived in two places: `SubstrateService.generateMnemonic()` (used by the mobile and cold-wallet apps) and a duplicated copy in `MinerWalletService`. Duplicated entropy-generation code is a maintenance and audit risk — a future change to one path could silently diverge from the other.

## What

- `MinerWalletService.generateMnemonic()` now delegates to `SubstrateService().generateMnemonic()`, so all mnemonic/seed generation lives in one spot in `quantus_sdk`.
- The SDK generator now reuses a single `Random.secure()` instance instead of constructing one per entropy byte (no behavior change — each instance was freshly OS-seeded anyway).

Both paths were and remain OS-CSPRNG-backed (`Random.secure()` → SecRandomCopyBytes / getrandom / BCryptGenRandom); this is a consolidation, not a security fix.

## Verification

- `melos run format` — clean
- `melos run analyze` — clean for quantus_sdk, miner-app, cold-wallet-app (mobile-app's analysis server crashes with SIGKILL on this machine, unrelated to this change; mobile-app is untouched)