### PR TITLE
Fix swap button icon color to match send/receive

### DIFF
--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -440,7 +440,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         label: label,
         onTap: onTap,
         isDisabled: isDisabled,
-        icon: SvgPicture.asset(iconAsset, width: 24, height: 24),
+        icon: SvgPicture.asset(
+          iconAsset,
+          width: 24,
+          height: 24,
+          colorFilter: ColorFilter.mode(context.colors.accentOrange, BlendMode.srcIn),
+        ),
         iconPlacement: IconPlacement.top,
         padding: const EdgeInsets.all(14),
         variant: ButtonVariant.secondary,


### PR DESCRIPTION
The home screen swap icon SVG has near-white strokes (#F4F6F9) while the send/receive icons are orange (#FF6B35), so the swap button looked different from the other action buttons.

All three action icons now get a `ColorFilter` tint from the theme's `accentOrange` (which is exactly #FF6B35), so send/receive render unchanged, swap matches them, and the icons follow the theme instead of colors baked into the SVGs.