### PR TITLE
slower defaults

### DIFF
--- a/cold-wallet-app/lib/providers/settings_providers.dart
+++ b/cold-wallet-app/lib/providers/settings_providers.dart
@@ -6,14 +6,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ColdSettings {
   static const minQrFps = 5;
   static const maxQrFps = 50;
-  static const defaultQrFps = 15;
-  static const minQrBytes = 300;
+  static const defaultQrFps = 10;
+  static const minQrBytes = 50;
 
   // 1400 payload bytes encode to ~2870 UR chars, under the 2953-char capacity
   // of a version-40 byte-mode QR at error correction L; encodeUrForQr measures
   // the final strings and shrinks fragments if they would still overflow.
   static const maxQrBytes = 1400;
-  static const defaultQrBytes = 1100;
+  static const defaultQrBytes = 300;
 
   final bool wifiOverrideEnabled;
   final int qrFps;


### PR DESCRIPTION
the CLI / laptop camera can't parse more than 300 bytes in the QR code, it's low res. 10 fps is a safe floor that works well.