### PR TITLE
fix(miner-app): pass node auth token and TLS cert pin to the external miner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ mobile-app/android/app/google-services.json
 mobile-app/patrol_test/test_bundle.dart
 # Google Play upload credentials (cold wallet / mobile)
 **/android/play-service-account.json
+/miner-app/macos/Runner.xcworkspace/xcshareddata

--- a/miner-app/lib/src/config/miner_config.dart
+++ b/miner-app/lib/src/config/miner_config.dart
@@ -40,6 +40,10 @@ class MinerConfig {
   /// Number of consecutive metrics failures before resetting hashrate to zero
   static const int maxConsecutiveMetricsFailures = 5;
 
+  /// Time to wait for the node to write its miner auth token file and log the
+  /// miner TLS cert fingerprint before giving up on starting the miner
+  static const Duration minerAuthReadyTimeout = Duration(seconds: 30);
+
   /// Delay after killing a process before checking if port is free
   static const Duration portCleanupDelay = Duration(seconds: 1);
 
@@ -81,6 +85,11 @@ class MinerConfig {
   /// Emitted by the node from `service.rs` on both local and external mining paths
   /// (e.g. "🥇 Successfully mined and submitted a new block ...").
   static const String blockSubmittedLogMarker = 'Successfully mined and submitted a new block';
+
+  /// Prefix of the node log line that publishes the miner TLS cert fingerprint
+  /// (e.g. "⛏️ Miner TLS cert SHA-256: <64 hex chars>"). The miner must pin
+  /// this fingerprint to connect.
+  static const String minerTlsFingerprintLogMarker = 'Miner TLS cert SHA-256';
 
   // ============================================================
   // Hardware Detection

--- a/miner-app/lib/src/services/log_filter_service.dart
+++ b/miner-app/lib/src/services/log_filter_service.dart
@@ -36,6 +36,7 @@ class LogFilterService {
       'sealed',
       'proposed',
       MinerConfig.blockSubmittedLogMarker,
+      MinerConfig.minerTlsFingerprintLogMarker,
       // Keep existing keywords
       '[peers]',
     ],

--- a/miner-app/lib/src/services/miner_process_manager.dart
+++ b/miner-app/lib/src/services/miner_process_manager.dart
@@ -15,6 +15,13 @@ class ExternalMinerConfig {
   /// Address and port of the node's QUIC endpoint (e.g., "127.0.0.1:9833").
   final String nodeAddress;
 
+  /// Path to the node's miner auth token file (shared secret, required by the node).
+  final String authTokenFile;
+
+  /// SHA-256 fingerprint of the node's miner TLS certificate (64 hex chars),
+  /// parsed from the node's startup logs.
+  final String tlsCertSha256;
+
   /// Number of CPU worker threads.
   final int cpuWorkers;
 
@@ -27,6 +34,8 @@ class ExternalMinerConfig {
   ExternalMinerConfig({
     required this.binary,
     required this.nodeAddress,
+    required this.authTokenFile,
+    required this.tlsCertSha256,
     this.cpuWorkers = 8,
     this.gpuDevices = 0,
     this.metricsPort = 9900,
@@ -122,6 +131,10 @@ class MinerProcessManager extends BaseProcessManager {
       'serve', // Subcommand required by new miner CLI
       '--node-addr',
       config.nodeAddress,
+      '--auth-token-file',
+      config.authTokenFile,
+      '--tls-cert-sha256',
+      config.tlsCertSha256,
       '--cpu-workers',
       config.cpuWorkers.toString(),
       '--gpu-devices',

--- a/miner-app/lib/src/services/mining_orchestrator.dart
+++ b/miner-app/lib/src/services/mining_orchestrator.dart
@@ -121,6 +121,12 @@ class MiningOrchestrator {
   Timer? _prometheusTimer;
   int _actualMetricsPort = MinerConfig.defaultMinerMetricsPort;
 
+  // TLS cert fingerprint of the node's miner server, captured from node logs.
+  // The node regenerates the cert on temp storage (dev mode), so the log line
+  // is the only reliable source across all chains and platforms.
+  static final _tlsFingerprintPattern = RegExp('${MinerConfig.minerTlsFingerprintLogMarker}: ([0-9a-fA-F]{64})');
+  String? _minerTlsCertSha256;
+
   // Hashrate tracking for resilience
   double _lastValidHashrate = 0.0;
   int _consecutiveMetricsFailures = 0;
@@ -223,6 +229,7 @@ class MiningOrchestrator {
 
       // Perform pre-start cleanup
       _setState(MiningState.startingNode);
+      _minerTlsCertSha256 = null;
       await ProcessCleanupService.performPreStartCleanup(config.chainId);
 
       // Ensure ports are available
@@ -312,10 +319,15 @@ class MiningOrchestrator {
     try {
       _setState(MiningState.startingMiner);
 
+      final authTokenFile = File(await NodeProcessManager.minerAuthTokenPath());
+      final tlsCertSha256 = await _waitForMinerAuth(authTokenFile);
+
       await _minerManager.start(
         ExternalMinerConfig(
           binary: config.minerBinary,
           nodeAddress: '${MinerConfig.localhost}:${config.minerListenPort}',
+          authTokenFile: authTokenFile.path,
+          tlsCertSha256: tlsCertSha256,
           cpuWorkers: config.cpuWorkers,
           gpuDevices: config.gpuDevices,
           metricsPort: _actualMetricsPort,
@@ -448,8 +460,13 @@ class MiningOrchestrator {
   }
 
   void _subscribeToProcessEvents() {
-    // Forward node logs
+    // Forward node logs, capturing the miner TLS cert fingerprint on the way
     _nodeLogsSubscription = _nodeManager.logs.listen((entry) {
+      final match = _tlsFingerprintPattern.firstMatch(entry.message);
+      if (match != null) {
+        _minerTlsCertSha256 = match.group(1);
+        _log.i('Captured miner TLS cert fingerprint from node logs');
+      }
       _logsController.add(entry);
     });
 
@@ -483,6 +500,27 @@ class MiningOrchestrator {
       _minerApiClient.onMetricsUpdate = _handleMinerMetrics;
       _minerApiClient.onError = _handleMinerMetricsError;
     }
+  }
+
+  /// Wait until the node has written its miner auth token file and logged the
+  /// miner TLS cert fingerprint. Both are required to start the miner.
+  Future<String> _waitForMinerAuth(File authTokenFile) async {
+    final deadline = DateTime.now().add(MinerConfig.minerAuthReadyTimeout);
+    while (DateTime.now().isBefore(deadline)) {
+      final fingerprint = _minerTlsCertSha256;
+      if (fingerprint != null && await authTokenFile.exists()) {
+        return fingerprint;
+      }
+      await Future.delayed(const Duration(milliseconds: 250));
+    }
+
+    final missing = [
+      if (_minerTlsCertSha256 == null) 'TLS cert fingerprint not seen in node logs',
+      if (!await authTokenFile.exists()) 'auth token file missing: ${authTokenFile.path}',
+    ].join('; ');
+    final error = MinerError.minerStartupFailed('Node did not publish miner auth credentials ($missing)');
+    _errorController.add(error);
+    throw Exception(error.message);
   }
 
   Future<void> _waitForNodeRpc() async {

--- a/miner-app/lib/src/services/node_process_manager.dart
+++ b/miner-app/lib/src/services/node_process_manager.dart
@@ -86,8 +86,7 @@ class NodeProcessManager extends BaseProcessManager {
   }
 
   /// Node data directory used as --base-path for non-dev chains.
-  static Future<String> nodeDataPath() async =>
-      p.join(await BinaryManager.getQuantusHomeDirectoryPath(), 'node_data');
+  static Future<String> nodeDataPath() async => p.join(await BinaryManager.getQuantusHomeDirectoryPath(), 'node_data');
 
   /// Fixed miner auth token location, passed to the node via
   /// --miner-auth-token-file so the path is known even in dev mode, where the

--- a/miner-app/lib/src/services/node_process_manager.dart
+++ b/miner-app/lib/src/services/node_process_manager.dart
@@ -85,6 +85,15 @@ class NodeProcessManager extends BaseProcessManager {
     initLogProcessor('node', getSyncState: () => getSyncState?.call() ?? false);
   }
 
+  /// Node data directory used as --base-path for non-dev chains.
+  static Future<String> nodeDataPath() async =>
+      p.join(await BinaryManager.getQuantusHomeDirectoryPath(), 'node_data');
+
+  /// Fixed miner auth token location, passed to the node via
+  /// --miner-auth-token-file so the path is known even in dev mode, where the
+  /// node runs on temp storage and the default token path is unpredictable.
+  static Future<String> minerAuthTokenPath() async => p.join(await nodeDataPath(), 'miner-auth-token');
+
   /// Start the node process.
   ///
   /// Throws an exception if startup fails.
@@ -111,12 +120,11 @@ class NodeProcessManager extends BaseProcessManager {
     }
 
     // Prepare data directory
-    final quantusHome = await BinaryManager.getQuantusHomeDirectoryPath();
-    final basePath = p.join(quantusHome, 'node_data');
+    final basePath = await nodeDataPath();
     await Directory(basePath).create(recursive: true);
 
     // Build command arguments
-    final args = _buildArgs(config, basePath);
+    final args = _buildArgs(config, basePath, await minerAuthTokenPath());
 
     log.i('Starting node...');
     log.d('Command: ${config.binary.path} ${args.join(' ')}');
@@ -137,7 +145,7 @@ class NodeProcessManager extends BaseProcessManager {
     }
   }
 
-  List<String> _buildArgs(NodeConfig config, String basePath) {
+  List<String> _buildArgs(NodeConfig config, String basePath, String minerAuthTokenPath) {
     return [
       // Only use --base-path for non-dev chains (dev uses temp storage for fresh state)
       if (config.chainId != 'dev') ...['--base-path', basePath],
@@ -153,6 +161,7 @@ class NodeProcessManager extends BaseProcessManager {
       'listen-addr=${MinerConfig.localhost}:${config.rpcPort},methods=unsafe,cors=all',
       '--name', 'QuantusMinerGUI',
       '--miner-listen-port', config.minerListenPort.toString(),
+      '--miner-auth-token-file', minerAuthTokenPath,
       '--enable-peer-sharing',
     ];
   }


### PR DESCRIPTION
Since the node started authenticating miners (shared token in the `Ready { token }` handshake plus TLS cert SHA-256 pinning), the GUI-spawned miner exits immediately with:

```
Error: miner auth token required: pass --auth-token-file <PATH> to the node's miner-auth-token file (or --auth-token <TOKEN>)
```

## What this does

- **Node launch:** passes `--miner-auth-token-file <quantus-home>/node_data/miner-auth-token` so the token lives at a path the app controls. This matters for dev mode, where the node runs on temp storage and the default `<base-path>/chains/<chain>/miner-auth-token` location is unpredictable. The node creates the file (and parent dirs) on first start.
- **TLS pin:** the orchestrator watches the node log stream for `Miner TLS cert SHA-256: <64 hex>` and captures the fingerprint. Log-based capture works across all chains and platforms, including dev mode where the cert is regenerated each run. The marker is registered in `LogFilterService` keywords so the line can never be filtered out.
- **Miner launch:** `quantus-miner serve` now gets `--auth-token-file` and `--tls-cert-sha256`. `startMiner()` waits (30s timeout) for both the token file and the fingerprint, and emits a clear `minerStartupFailed` error naming whichever is missing.
- **Windows:** no paths are parsed from logs (only the hex fingerprint), and all constructed paths go through `package:path`, so `C:\Users\...` style base paths work unchanged.

Tested: `flutter analyze` clean; unit tests pass (the `widget_test.dart` load failure predates this change).