### PR TITLE
ci: repair CocoaPods on macos-26 before the miner macOS build

### DIFF
--- a/.github/workflows/create_miner_build.yml
+++ b/.github/workflows/create_miner_build.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Enable macOS desktop
         run: flutter config --enable-macos-desktop
 
+      # The CocoaPods gem preinstalled on the macos-26 runner image is broken
+      # (built against a different Ruby), so Flutter skips `pod install` and the
+      # build aborts with "CocoaPods not installed or not in valid state".
+      # Homebrew's CocoaPods ships with its own Ruby and takes PATH precedence.
+      - name: Install working CocoaPods
+        run: |
+          brew install cocoapods || brew reinstall cocoapods
+          pod --version
+
       - name: Import Apple code-signing certificate
         uses: apple-actions/import-codesign-certs@v3
         with:


### PR DESCRIPTION
The [Create Miner Build run](https://github.com/Quantus-Network/quantus-apps/actions/runs/31760425656/job/94645403892) fails only on macOS:

```
Warning: CocoaPods is installed but broken. Skipping pod install.
  This can happen if the version of Ruby that CocoaPods was installed with is different from the one being used to invoke it.
CocoaPods not installed or not in valid state.
```

The `macos-26` runner image ships a CocoaPods gem built against a different Ruby than the image's default, so Flutter's `pod` probe fails and `flutter build macos` aborts before compiling anything. Linux and Windows jobs pass because only macOS needs pods (`rust_lib_quantus_wallet` doesn't support Swift Package Manager yet, so `pod install` is still required).

Fix: install Homebrew's CocoaPods (self-contained, bundles its own Ruby, and `/opt/homebrew/bin` takes PATH precedence over the broken gem binstub) right after Flutter setup, and fail fast with `pod --version` if it's still unhealthy.

Verification is the workflow itself — this job can only be exercised on the hosted runner; trigger `Create Miner Build` via workflow_dispatch on this branch to confirm.