### PR TITLE
fix ZK proofs

### DIFF
--- a/miner-app/lib/features/withdrawal/claim_rewards_dialog.dart
+++ b/miner-app/lib/features/withdrawal/claim_rewards_dialog.dart
@@ -307,7 +307,7 @@ class _ClaimRewardsDialogState extends State<_ClaimRewardsDialog> {
           const SizedBox(height: 12),
           _confirmRow('Destination', _addressController.text.trim(), mono: true),
           const SizedBox(height: 12),
-          _confirmRow('Fee', '0.1% volume fee'),
+          _confirmRow('Fee', '${wormholeVolumeFeePercentText()}% volume fee'),
           const SizedBox(height: 24),
           Container(
             padding: const EdgeInsets.all(12),

--- a/miner-app/lib/features/withdrawal/claim_rewards_dialog.dart
+++ b/miner-app/lib/features/withdrawal/claim_rewards_dialog.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:quantus_miner/src/services/binary_manager.dart';
 import 'package:quantus_miner/src/services/miner_settings_service.dart';
 import 'package:quantus_miner/src/services/miner_wallet_service.dart';
 import 'package:quantus_miner/src/utils/app_logger.dart';
@@ -117,9 +114,7 @@ class _ClaimRewardsDialogState extends State<_ClaimRewardsDialog> {
       }
 
       final chainConfig = await _settingsService.getChainConfig();
-      final binsDir = '${await BinaryManager.getQuantusHomeDirectoryPath()}/generated-bins';
-      await Directory(binsDir).create(recursive: true);
-
+      final circuitDir = await CircuitManager.getCircuitDirectory();
       final rpcUrl = chainConfig.rpcUrl;
       _log.i('Starting claim for ${keyPair.address} to ${_addressController.text.trim()}');
 
@@ -128,7 +123,7 @@ class _ClaimRewardsDialogState extends State<_ClaimRewardsDialog> {
         secretHex: keyPair.secretHex,
         destinationAddress: _addressController.text.trim(),
         rpcUrl: rpcUrl,
-        circuitBinsDir: binsDir,
+        circuitBinsDir: circuitDir,
         onProgress: (progress) {
           if (!mounted) return;
           setState(() {

--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -2810,9 +2810,14 @@
     "@redeemConfirmFee": {
       "description": "Fee row label on redeem confirmation"
     },
-    "redeemFeeValue": "0.1% volume fee",
+    "redeemFeeValue": "{rate}% volume fee",
     "@redeemFeeValue": {
-      "description": "Volume fee value on redeem confirmation"
+      "description": "Volume fee value on redeem confirmation",
+      "placeholders": {
+        "rate": {
+          "type": "String"
+        }
+      }
     },
     "redeemProgressTitle": "Redeeming...",
     "@redeemProgressTitle": {

--- a/mobile-app/lib/l10n/app_id.arb
+++ b/mobile-app/lib/l10n/app_id.arb
@@ -598,7 +598,7 @@
   "redeemConfirmAmount": "Jumlah",
   "redeemConfirmTo": "Ke",
   "redeemConfirmFee": "Biaya",
-  "redeemFeeValue": "Biaya volume 0,1%",
+  "redeemFeeValue": "Biaya volume {rate}%",
   "redeemProgressTitle": "Menukar...",
   "redeemCompleteTitle": "Penukaran Selesai",
   "redeemFailedTitle": "Penukaran Gagal",

--- a/mobile-app/lib/l10n/app_localizations.dart
+++ b/mobile-app/lib/l10n/app_localizations.dart
@@ -3599,8 +3599,8 @@ abstract class AppLocalizations {
   /// Volume fee value on redeem confirmation
   ///
   /// In en, this message translates to:
-  /// **'0.1% volume fee'**
-  String get redeemFeeValue;
+  /// **'{rate}% volume fee'**
+  String redeemFeeValue(String rate);
 
   /// App bar title while a redeem is in progress
   ///

--- a/mobile-app/lib/l10n/app_localizations_en.dart
+++ b/mobile-app/lib/l10n/app_localizations_en.dart
@@ -1944,7 +1944,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get redeemConfirmFee => 'Fee';
 
   @override
-  String get redeemFeeValue => '0.1% volume fee';
+  String redeemFeeValue(String rate) {
+    return '$rate% volume fee';
+  }
 
   @override
   String get redeemProgressTitle => 'Redeeming...';

--- a/mobile-app/lib/l10n/app_localizations_id.dart
+++ b/mobile-app/lib/l10n/app_localizations_id.dart
@@ -1941,7 +1941,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get redeemConfirmFee => 'Biaya';
 
   @override
-  String get redeemFeeValue => 'Biaya volume 0,1%';
+  String redeemFeeValue(String rate) {
+    return 'Biaya volume $rate%';
+  }
 
   @override
   String get redeemProgressTitle => 'Menukar...';

--- a/mobile-app/lib/v2/screens/settings/redeem_address_screen.dart
+++ b/mobile-app/lib/v2/screens/settings/redeem_address_screen.dart
@@ -195,7 +195,7 @@ class _RedeemConfirmSheet extends StatelessWidget {
           Divider(color: colors.separator, height: 32),
           _row(l10n.redeemConfirmTo, AddressFormattingService.formatAddress(destination), colors, text),
           Divider(color: colors.separator, height: 32),
-          _row(l10n.redeemConfirmFee, l10n.redeemFeeValue, colors, text),
+          _row(l10n.redeemConfirmFee, l10n.redeemFeeValue(wormholeVolumeFeePercentText()), colors, text),
           const SizedBox(height: 32),
           QuantusButton.simple(label: l10n.redeemAmountCta(formatted), onTap: () => Navigator.of(context).pop(true)),
         ],

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -2,7 +2,7 @@ name: resonance_network_wallet
 description: A Flutter wallet for the Quantus blockchain.
 publish_to: "none"
 
-version: 1.5.10+125
+version: 1.5.10+126
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/quantus_sdk/lib/src/services/circuit_manager.dart
+++ b/quantus_sdk/lib/src/services/circuit_manager.dart
@@ -1,39 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
+import 'package:quantus_sdk/src/rust/api/wormhole.dart' as wormhole_ffi;
 
-typedef CircuitProgressCallback = void Function(double progress, String message);
-
-/// Information about circuit binary status.
-class CircuitStatus {
-  final bool isAvailable;
-  final String? circuitDir;
-  final int? totalSizeBytes;
-  final String? version;
-
-  /// Number of leaf proofs per aggregation batch (read from config.json).
-  final int? numLeafProofs;
-
-  const CircuitStatus({
-    required this.isAvailable,
-    this.circuitDir,
-    this.totalSizeBytes,
-    this.version,
-    this.numLeafProofs,
-  });
-
-  static const unavailable = CircuitStatus(isAvailable: false);
-}
-
-/// Manages circuit binary files for ZK proof generation.
-///
-/// Circuit binaries are bundled as SDK assets and extracted to the app's
-/// support directory on first use. Rust FFI requires file paths.
 class CircuitManager {
-  static const List<String> requiredFiles = [
+  static const List<String> _requiredFiles = [
     'common.bin',
     'verifier.bin',
     'dummy_proof.bin',
@@ -42,104 +16,48 @@ class CircuitManager {
     'config.json',
   ];
 
-  static const String _assetPrefix = 'packages/quantus_sdk/assets/circuits';
-
   static Future<String> getCircuitDirectory() async {
     final appDir = await getApplicationSupportDirectory();
     return path.join(appDir.path, 'circuits');
   }
 
-  Future<CircuitStatus> checkStatus() async {
-    try {
-      final circuitDir = await getCircuitDirectory();
-      final dir = Directory(circuitDir);
-      if (!await dir.exists()) return CircuitStatus.unavailable;
+  static String getVersionedCircuitDirectory(String circuitBaseDir, {String? version}) {
+    final resolvedVersion = version ?? wormhole_ffi.zkCircuitsVersion();
+    if (resolvedVersion.isEmpty) throw StateError('ZK circuit version is empty');
+    return path.join(circuitBaseDir, 'v$resolvedVersion');
+  }
 
-      int totalSize = 0;
-      for (final fileName in requiredFiles) {
-        final file = File(path.join(circuitDir, fileName));
-        if (!await file.exists()) return CircuitStatus.unavailable;
-        totalSize += await file.length();
+  Future<({String circuitDir, String version, int numLeafProofs})> ensureAt(String circuitBaseDir) async {
+    final version = wormhole_ffi.zkCircuitsVersion();
+    final circuitDir = getVersionedCircuitDirectory(circuitBaseDir, version: version);
+    final generatedConfig = await wormhole_ffi.ensureCircuitBinaries(binsDir: circuitBaseDir);
+    for (final fileName in _requiredFiles) {
+      final file = File(path.join(circuitDir, fileName));
+      if (!await file.exists()) {
+        throw StateError('Circuit generation completed without $fileName in $circuitDir');
       }
+    }
 
-      String? version;
-      int? numLeafProofs;
-      try {
-        final configFile = File(path.join(circuitDir, 'config.json'));
-        if (await configFile.exists()) {
-          final config = jsonDecode(await configFile.readAsString()) as Map<String, dynamic>;
-          version = config['version'] as String?;
-          numLeafProofs = config['num_leaf_proofs'] as int?;
-        }
-      } catch (_) {
-        // Ignore config read errors
-      }
-
-      return CircuitStatus(
-        isAvailable: true,
-        circuitDir: circuitDir,
-        totalSizeBytes: totalSize,
-        version: version,
-        numLeafProofs: numLeafProofs,
+    final generatedNumLeafProofs = parseNumLeafProofs(generatedConfig);
+    final persistedConfig = await File(path.join(circuitDir, 'config.json')).readAsString();
+    final persistedNumLeafProofs = parseNumLeafProofs(persistedConfig);
+    if (persistedNumLeafProofs != generatedNumLeafProofs) {
+      throw StateError(
+        'Circuit config changed during generation: expected $generatedNumLeafProofs leaf proofs, '
+        'found $persistedNumLeafProofs',
       );
-    } catch (_) {
-      return CircuitStatus.unavailable;
     }
+    return (circuitDir: circuitDir, version: version, numLeafProofs: persistedNumLeafProofs);
   }
 
-  /// Copy bundled SDK asset circuit files onto the filesystem.
-  Future<bool> extractCircuitsFromAssets({CircuitProgressCallback? onProgress}) async {
-    try {
-      final circuitDir = await getCircuitDirectory();
-      final dir = Directory(circuitDir);
-      if (!await dir.exists()) await dir.create(recursive: true);
-
-      onProgress?.call(0.0, 'Extracting circuit files...');
-
-      int extracted = 0;
-      for (final fileName in requiredFiles) {
-        onProgress?.call(extracted / requiredFiles.length, 'Extracting $fileName...');
-        try {
-          final byteData = await rootBundle.load('$_assetPrefix/$fileName');
-          final targetFile = File(path.join(circuitDir, fileName));
-          await targetFile.writeAsBytes(
-            byteData.buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes),
-            flush: true,
-          );
-        } catch (_) {
-          await deleteCircuits();
-          onProgress?.call(0.0, 'Failed to extract $fileName');
-          return false;
-        }
-        extracted++;
-      }
-
-      onProgress?.call(1.0, 'Circuit files ready!');
-      return true;
-    } catch (e) {
-      onProgress?.call(0.0, 'Extraction failed: $e');
-      return false;
+  @visibleForTesting
+  static int parseNumLeafProofs(String configJson) {
+    final config = jsonDecode(configJson);
+    if (config is! Map<String, dynamic>) throw const FormatException('Circuit config must be a JSON object');
+    final numLeafProofs = config['num_leaf_proofs'];
+    if (numLeafProofs is! int || numLeafProofs <= 0) {
+      throw FormatException('Invalid num_leaf_proofs: $numLeafProofs');
     }
-  }
-
-  Future<void> deleteCircuits() async {
-    try {
-      final circuitDir = await getCircuitDirectory();
-      final dir = Directory(circuitDir);
-      if (await dir.exists()) {
-        await dir.delete(recursive: true);
-      }
-    } catch (_) {
-      // Ignore deletion errors
-    }
-  }
-
-  static String formatBytes(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) {
-      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    }
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+    return numLeafProofs;
   }
 }

--- a/quantus_sdk/lib/src/services/wormhole_coin_selection.dart
+++ b/quantus_sdk/lib/src/services/wormhole_coin_selection.dart
@@ -1,8 +1,13 @@
 import 'package:quantus_sdk/src/services/wormhole_utxo_service.dart';
 
 /// Wormhole circuit economics, shared by coin selection and the send service.
-/// Values must match the chain runtime and the Rust wormhole API.
-const int wormholeVolumeFeeBps = 10;
+/// The fee must match the chain runtime and is passed unchanged to the Rust proof API.
+const int wormholeVolumeFeeBps = 4;
+
+String wormholeVolumeFeePercentText() {
+  final percent = wormholeVolumeFeeBps / 100;
+  return percent == percent.truncateToDouble() ? percent.toInt().toString() : percent.toString();
+}
 
 /// Scaled-down → token multiplier; matches `SCALE_DOWN_FACTOR` in the Rust
 /// wormhole API. Proofs commit to amounts in scaled-down units (0.01 tokens) and
@@ -41,7 +46,7 @@ class WormholeSpendPlan {
   final BigInt changeToken;
 
   /// Everything consumed that neither the recipient nor the change receives:
-  /// the 10 bps volume fee plus sub-0.01-tokens quantization dust.
+  /// the 4 bps volume fee plus sub-0.01-tokens quantization dust.
   final BigInt feeToken;
 
   const WormholeSpendPlan({

--- a/quantus_sdk/lib/src/services/wormhole_send_service.dart
+++ b/quantus_sdk/lib/src/services/wormhole_send_service.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:polkadart/scale_codec.dart' show ByteOutput, CompactCodec;
 import 'package:quantus_sdk/generated/planck/pallets/wormhole.dart' as wormhole_pallet;
 import 'package:quantus_sdk/src/rust/api/wormhole.dart' as wormhole_ffi;
+import 'package:quantus_sdk/src/services/circuit_manager.dart';
 import 'package:quantus_sdk/src/services/network/redundant_endpoint.dart';
 import 'package:quantus_sdk/src/services/substrate_service.dart' show getAccountId32;
 import 'package:quantus_sdk/src/services/wormhole_coin_selection.dart';
@@ -226,11 +227,12 @@ class WormholeSendService {
     op.checkCancelled();
     _reportProgress(onProgress, 1, 0);
     _log('Ensuring circuit binaries at: $circuitBinsDir');
-    final circuitConfig =
-        jsonDecode(await wormhole_ffi.ensureCircuitBinaries(binsDir: circuitBinsDir)) as Map<String, dynamic>;
-    // Batch size must match the circuits' aggregation arity (chain expects 7).
-    final maxProofsPerBatch = circuitConfig['num_leaf_proofs'] as int;
-    _log('Circuit binaries ready (num_leaf_proofs=$maxProofsPerBatch)');
+    final artifacts = await CircuitManager().ensureAt(circuitBinsDir);
+    final maxProofsPerBatch = artifacts.numLeafProofs;
+    _log(
+      'Circuit binaries ${artifacts.version} ready at ${artifacts.circuitDir} '
+      '(num_leaf_proofs=$maxProofsPerBatch)',
+    );
     _reportProgress(onProgress, 1, 1);
     op.checkCancelled();
     return maxProofsPerBatch;

--- a/quantus_sdk/rust/src/api/wormhole.rs
+++ b/quantus_sdk/rust/src/api/wormhole.rs
@@ -83,8 +83,6 @@ pub fn compute_address_hash_hex(raw_address: Vec<u8>) -> Result<String, String> 
     Ok(hex::encode(hash.as_bytes()))
 }
 
-pub const NATIVE_ASSET_ID: u32 = 0;
-pub const VOLUME_FEE_BPS: u32 = 10;
 pub const SCALE_DOWN_FACTOR: u128 = 10_000_000_000;
 // Must match the chain's aggregation batch size (num_n=7 since v0.7.1-q-day-2).
 pub const DEFAULT_NUM_LEAF_PROOFS: usize = 7;

--- a/quantus_sdk/test/services/circuit_manager_test.dart
+++ b/quantus_sdk/test/services/circuit_manager_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+import 'package:quantus_sdk/src/services/circuit_manager.dart';
+
+void main() {
+  test('versioned directory isolates each circuit release', () {
+    expect(
+      CircuitManager.getVersionedCircuitDirectory('/circuits', version: '4.2.0'),
+      path.join('/circuits', 'v4.2.0'),
+    );
+  });
+
+  test('circuit config requires a positive aggregation arity', () {
+    expect(CircuitManager.parseNumLeafProofs('{"num_leaf_proofs":7}'), 7);
+    expect(() => CircuitManager.parseNumLeafProofs('{}'), throwsFormatException);
+    expect(() => CircuitManager.parseNumLeafProofs('{"num_leaf_proofs":0}'), throwsFormatException);
+    expect(() => CircuitManager.parseNumLeafProofs('[]'), throwsFormatException);
+  });
+}

--- a/quantus_sdk/test/services/wormhole_coin_selection_test.dart
+++ b/quantus_sdk/test/services/wormhole_coin_selection_test.dart
@@ -20,6 +20,12 @@ WormholeUtxo utxo(int scaled) => WormholeUtxo(
 BigInt tokens(String v) => wormholeTokenFromScaled((double.parse(v) * 100).round());
 
 void main() {
+  test('uses the live runtime volume fee', () {
+    expect(wormholeVolumeFeeBps, 4);
+    expect(wormholeVolumeFeePercentText(), '0.04');
+    expect(wormholeNetScaled(2500), 2499);
+  });
+
   group('selectWormholeInputs', () {
     test('plan worked example: 10 tokens from 1.1 + 5.8 + 4.0', () {
       final plan = selectWormholeInputs(utxos: [utxo(110), utxo(580), utxo(400)], amountToken: tokens('10'));


### PR DESCRIPTION
## Summary
- **align Wormhole claim proofs with the live 4 bps runtime fee and derive miner/mobile fee labels from the proof constant**
- isolate generated v4.2.0 circuit artifacts in app-support storage and validate the versioned manifest before proving
- route both claim consumers through the shared SDK circuit manager
- remove obsolete circuit-manager APIs and unused Rust fee/asset constants
- add regression coverage for circuit versioning, config validation, and the live fee calculation

## Diagnosis
The screenshot failure is not a Wormhole call-shape or prover-version mismatch. The live runtime is spec 144 / transaction version 3, and both the app and chain use Wormhole circuits 4.2.0. The encoded call remains Wormhole pallet index 20 and verify_private_batch call index 2.

The app was still committing volume_fee_bps = 10 into every proof while the runtime requires 4. Runtime pre-validation rejects that public input before proof verification and maps the rejection to InvalidTransaction::Call, which surfaces through author_submitExtrinsic as Transaction call is not expected.

## Verification
- melos run format
- melos run analyze
- cargo fmt --check in quantus_sdk/rust
- flutter test test/services/wormhole_coin_selection_test.dart test/services/wormhole_utxo_service_test.dart test/services/circuit_manager_test.dart test/services/wormhole_send_service_test.dart (18 passed)