### PR TITLE
ci: fix miner release proposal workflow token

### DIFF
--- a/.github/workflows/create_miner_release_proposal.yml
+++ b/.github/workflows/create_miner_release_proposal.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Create version bump branch and PR
         env:
           NEW_VERSION: ${{ needs.calculate-next-version.outputs.new_version }}
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_BRANCH: ${{ needs.calculate-next-version.outputs.source_branch }}
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
@@ -153,7 +153,7 @@ jobs:
           fi
 
           git checkout "$SOURCE_BRANCH"
-          git checkout -b "$branch_name"
+          git checkout -B "$branch_name"
 
           current_pubspec=$(grep -E '^version:' miner-app/pubspec.yaml | head -n 1 | sed -E 's/^version:[[:space:]]*//' | cut -d+ -f1)
           lower=$(printf '%s\n%s\n' "$new_pubspec_version" "$current_pubspec" | sort -V | head -n 1)
@@ -176,11 +176,7 @@ jobs:
           git add miner-app/pubspec.yaml
           # --allow-empty: pubspec may already be at the target version (manual pre-bump)
           git commit --allow-empty -m "ci: Miner version bump to $NEW_VERSION"
-          git push origin "$branch_name"
-
-          gh label create "automated" --force --color "ededed" --description "Created by CI"
-          gh label create "miner-release-proposal" --force --color "0e8a16" --description "Miner release proposal PR"
-          gh label create "draft-release" --force --color "d4c5f9" --description "Release will be created as draft"
+          git push --force-with-lease origin "$branch_name"
 
           PR_TITLE="ci: Miner version bump to $NEW_VERSION"
           PR_LABELS="automated,miner-release-proposal"
@@ -202,9 +198,14 @@ jobs:
           Bump type: ${VERSION_TYPE}
           EOF
 
-          gh pr create \
-            --title "$PR_TITLE" \
-            --body-file pr_body.md \
-            --base "$TARGET_BRANCH" \
-            --head "$branch_name" \
-            --label "$PR_LABELS"
+          existing_pr=$(gh pr list --head "$branch_name" --base "$TARGET_BRANCH" --json number --jq '.[0].number // empty')
+          if [[ -n "$existing_pr" ]]; then
+            gh pr edit "$existing_pr" --title "$PR_TITLE" --body-file pr_body.md --add-label "$PR_LABELS"
+          else
+            gh pr create \
+              --title "$PR_TITLE" \
+              --body-file pr_body.md \
+              --base "$TARGET_BRANCH" \
+              --head "$branch_name" \
+              --label "$PR_LABELS"
+          fi


### PR DESCRIPTION
## Overview
The [Miner - Create Release Proposal](https://github.com/Quantus-Network/quantus-apps/actions/runs/31790994267) run failed at `gh label create` with `HTTP 401: Bad credentials`. The job used `secrets.PAT_TOKEN`, which is expired; git push already succeeded with the default checkout token.

## What changed
- Use `secrets.GITHUB_TOKEN` with the job's existing `contents: write` / `pull-requests: write` permissions.
- Stop creating labels in CI. `miner-release-proposal`, `automated`, and `draft-release` already exist on the repo.
- Reuse the release branch/PR on re-run (`checkout -B`, `--force-with-lease`, `gh pr edit` if a PR already exists).

## Validation
- Confirmed the failed step was `gh label create` against `PAT_TOKEN`.
- Labels created on the repo: `miner-release-proposal`, `automated`, `draft-release`.
- Re-run of **Miner - Create Release Proposal** after merge should open the version-bump PR.

## Risks and mitigations
- Default `GITHUB_TOKEN` events do not trigger other workflows. A human merge of the proposal PR still fires **Miner - Publish Release**.
- `release/miner-v0.6.1` already exists from the failed run; the workflow now resets it with `--force-with-lease`.