### PR TITLE
ci: Miner version bump to miner-v0.6.1

### DIFF
--- a/miner-app/pubspec.yaml
+++ b/miner-app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quantus_miner
 description: Quantus PoW miner (desktop / mobile)
-version: 0.6.0
+version: 0.6.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Miner Release Proposal

This PR proposes releasing **Quantus Miner** version `0.6.1` (tag `miner-v0.6.1`).

Merging this PR will automatically tag the merge commit, build macOS/Linux/Windows binaries, and publish a GitHub release.

### Changes
- Updated `miner-app/pubspec.yaml` version to `0.6.1`

Triggered by workflow run: https://github.com/Quantus-Network/quantus-apps/actions/runs/31791734200
Bump type: patch
