### PR TITLE
ci: let wallet APK releases build mobile, cold, or both

### DIFF
--- a/.github/workflows/build_wallet_apk.yml
+++ b/.github/workflows/build_wallet_apk.yml
@@ -1,0 +1,175 @@
+# Builds a signed (or debug) APK for one wallet app.
+# Called by create_wallet_android_build.yml; not meant to be run directly.
+name: Build Wallet APK
+
+on:
+  workflow_call:
+    inputs:
+      app:
+        description: "Which wallet to build"
+        required: true
+        type: string
+      build_mode:
+        description: "Build mode"
+        required: true
+        type: string
+    outputs:
+      version:
+        description: "pubspec version (e.g. 1.5.10+127)"
+        value: ${{ jobs.build.outputs.version }}
+      tag:
+        description: "Git tag for this APK"
+        value: ${{ jobs.build.outputs.tag }}
+      artifact_name:
+        description: "Uploaded artifact name"
+        value: ${{ jobs.build.outputs.artifact_name }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ inputs.app }} APK
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      MOBILE_APP_ENV: ${{ secrets.MOBILE_APP_ENV }}
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve app paths
+        id: meta
+        run: |
+          set -euo pipefail
+          case "${{ inputs.app }}" in
+            mobile)
+              DIR=mobile-app
+              ARTIFACT=quantus_wallet
+              TAG_PREFIX=wallet-v
+              ;;
+            cold)
+              DIR=cold-wallet-app
+              ARTIFACT=quantus_cold_wallet
+              TAG_PREFIX=cold-wallet-v
+              ;;
+            *)
+              echo "Unknown app: ${{ inputs.app }} (expected mobile or cold)" >&2
+              exit 1
+              ;;
+          esac
+          VERSION=$(grep '^version:' "$DIR/pubspec.yaml" | head -1 | sed 's/version:[[:space:]]*//')
+          if [ -z "$VERSION" ]; then
+            echo "Error: could not read version from $DIR/pubspec.yaml" >&2
+            exit 1
+          fi
+          {
+            echo "dir=$DIR"
+            echo "artifact=$ARTIFACT"
+            echo "version=$VERSION"
+            echo "tag=${TAG_PREFIX}${VERSION}"
+            echo "artifact_name=${ARTIFACT}-android-${{ inputs.build_mode }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Cache Rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.rustup/toolchains
+          key: ${{ runner.os }}-rust-nightly-android-${{ hashFiles('quantus_sdk/rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-nightly-android-
+            ${{ runner.os }}-rust-
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      # cargokit.yaml builds with nightly + -Zbuild-std. Installing that
+      # toolchain here (once) avoids two parallel Gradle cargokit tasks
+      # racing rustup toolchain install nightly, which fails CI with a
+      # "could not rename downloaded file" error.
+      - name: Set up Rust nightly (Android + rust-src)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
+      - name: Install Melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap Melos
+        run: melos bootstrap
+
+      - name: Create mobile-app .env
+        if: inputs.app == 'mobile'
+        run: echo "$MOBILE_APP_ENV" > mobile-app/.env
+
+      - name: Create google-services.json
+        if: inputs.app == 'mobile'
+        run: echo "$GOOGLE_SERVICES_JSON" > mobile-app/android/app/google-services.json
+
+      - name: Decode Android keystore
+        if: inputs.build_mode == 'release'
+        run: echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "${{ steps.meta.outputs.dir }}/android/upload-keystore.jks"
+
+      - name: Create key.properties
+        if: inputs.build_mode == 'release'
+        env:
+          APP_DIR: ${{ steps.meta.outputs.dir }}
+        run: |
+          cat > "$APP_DIR/android/key.properties" << EOF
+          storeFile=../upload-keystore.jks
+          storePassword=$ANDROID_STORE_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          keyPassword=$ANDROID_KEY_PASSWORD
+          EOF
+
+      - name: Generate splash screen
+        working-directory: ${{ steps.meta.outputs.dir }}
+        run: |
+          flutter pub get
+          dart run flutter_native_splash:create
+
+      - name: Build APK
+        working-directory: ${{ steps.meta.outputs.dir }}
+        run: flutter build apk --${{ inputs.build_mode }}
+
+      - name: Rename APK
+        id: rename_apk
+        env:
+          APP_DIR: ${{ steps.meta.outputs.dir }}
+          ARTIFACT: ${{ steps.meta.outputs.artifact }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          MODE: ${{ inputs.build_mode }}
+        run: |
+          set -euo pipefail
+          SRC="$APP_DIR/build/app/outputs/flutter-apk/app-${MODE}.apk"
+          DEST="$APP_DIR/build/app/outputs/flutter-apk/${ARTIFACT}_${VERSION}_${MODE}.apk"
+          mv "$SRC" "$DEST"
+          echo "apk_path=$DEST" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: ${{ steps.rename_apk.outputs.apk_path }}

--- a/.github/workflows/create_wallet_android_build.yml
+++ b/.github/workflows/create_wallet_android_build.yml
@@ -3,6 +3,15 @@ name: Create Wallet Android Build
 on:
   workflow_dispatch:
     inputs:
+      apps:
+        description: "Which APKs to build"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - mobile
+          - cold
+          - both
       build_mode:
         description: "Build mode"
         required: true
@@ -12,124 +21,37 @@ on:
           - release
           - debug
       create_release:
-        description: "Create a GitHub release"
+        description: "Create a public GitHub release for each built app"
         required: false
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
-  build-android:
-    name: Build Android APK
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
-      tag: ${{ steps.get_version.outputs.tag }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-      ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
-      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-      MOBILE_APP_ENV: ${{ secrets.MOBILE_APP_ENV }}
-      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  build-mobile:
+    name: Build mobile wallet
+    if: ${{ inputs.apps == 'mobile' || inputs.apps == 'both' }}
+    uses: ./.github/workflows/build_wallet_apk.yml
+    with:
+      app: mobile
+      build_mode: ${{ inputs.build_mode }}
+    secrets: inherit
 
-      - name: Cache Cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            quantus_sdk/native/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+  build-cold:
+    name: Build cold wallet
+    if: ${{ inputs.apps == 'cold' || inputs.apps == 'both' }}
+    uses: ./.github/workflows/build_wallet_apk.yml
+    with:
+      app: cold
+      build_mode: ${{ inputs.build_mode }}
+    secrets: inherit
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "17"
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          cache: true
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
-
-      - name: Install Melos
-        run: dart pub global activate melos
-
-      - name: Bootstrap Melos
-        run: melos bootstrap
-
-      - name: Create .env file
-        run: echo "$MOBILE_APP_ENV" > mobile-app/.env
-
-      - name: Create google-services.json
-        run: echo "$GOOGLE_SERVICES_JSON" > mobile-app/android/app/google-services.json
-
-      - name: Decode Android keystore
-        if: inputs.build_mode == 'release'
-        run: echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > mobile-app/android/upload-keystore.jks
-
-      - name: Create key.properties
-        if: inputs.build_mode == 'release'
-        run: |
-          cat > mobile-app/android/key.properties << EOF
-          storeFile=../upload-keystore.jks
-          storePassword=$ANDROID_STORE_PASSWORD
-          keyAlias=$ANDROID_KEY_ALIAS
-          keyPassword=$ANDROID_KEY_PASSWORD
-          EOF
-
-      - name: Generate Splash Screen
-        working-directory: ./mobile-app
-        run: |
-          flutter pub get
-          dart run flutter_native_splash:create
-
-      - name: Build APK
-        run: flutter build apk --${{ inputs.build_mode }}
-        working-directory: ./mobile-app
-
-      - name: Read version from pubspec.yaml
-        id: get_version
-        run: |
-          VERSION=$(grep '^version:' mobile-app/pubspec.yaml | head -1 | sed 's/version:[[:space:]]*//')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=wallet-v$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Rename APK
-        id: rename_apk
-        run: |
-          MODE="${{ inputs.build_mode }}"
-          VERSION="${{ steps.get_version.outputs.version }}"
-          SRC="mobile-app/build/app/outputs/flutter-apk/app-${MODE}.apk"
-          DEST="mobile-app/build/app/outputs/flutter-apk/quantus_wallet_${VERSION}_${MODE}.apk"
-          mv "$SRC" "$DEST"
-          echo "apk_path=$DEST" >> "$GITHUB_OUTPUT"
-          echo "apk_name=quantus_wallet_${VERSION}_${MODE}.apk" >> "$GITHUB_OUTPUT"
-
-      - name: Upload APK Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: quantus_wallet-android-${{ inputs.build_mode }}
-          path: ${{ steps.rename_apk.outputs.apk_path }}
-
-  create-release:
-    name: Create Release
-    if: ${{ inputs.create_release && inputs.build_mode == 'release' }}
-    needs: [build-android]
+  release-mobile:
+    name: Release mobile wallet
+    if: ${{ inputs.create_release && inputs.build_mode == 'release' && (inputs.apps == 'mobile' || inputs.apps == 'both') }}
+    needs: [build-mobile]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -140,47 +62,104 @@ jobs:
       - name: Download APK artifact
         uses: actions/download-artifact@v4
         with:
-          name: quantus_wallet-android-release
+          name: ${{ needs.build-mobile.outputs.artifact_name }}
           path: ./artifacts
 
       - name: Create and push git tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.build-mobile.outputs.tag }}
         run: |
-          TAG="${{ needs.build-android.outputs.tag }}"
+          set -euo pipefail
           echo "Tag to create: $TAG"
 
           if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
             echo "Error: Tag $TAG already exists on remote."
             echo "Please update the version in mobile-app/pubspec.yaml before creating a new release."
             exit 1
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-
-            git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}
-
-            git tag "$TAG" "$GITHUB_SHA"
-            git push origin "$TAG"
           fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.build-android.outputs.tag }}
-          name: Quantus Wallet ${{ needs.build-android.outputs.version }}
+          tag_name: ${{ needs.build-mobile.outputs.tag }}
+          name: Quantus Wallet ${{ needs.build-mobile.outputs.version }}
           generate_release_notes: true
           body: |
             ## Quantus Wallet - Android Release
-            
-            **Version:** ${{ needs.build-android.outputs.version }}
-            
+
+            **Version:** ${{ needs.build-mobile.outputs.version }}
+
             ### Installation
             1. Download the `.apk` file below
             2. Enable "Install from unknown sources"
             3. Install
           files: ./artifacts/quantus_wallet_*.apk
+          draft: false
+          prerelease: false
+
+  release-cold:
+    name: Release cold wallet
+    if: ${{ inputs.create_release && inputs.build_mode == 'release' && (inputs.apps == 'cold' || inputs.apps == 'both') }}
+    needs: [build-cold]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-cold.outputs.artifact_name }}
+          path: ./artifacts
+
+      - name: Create and push git tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.build-cold.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "Tag to create: $TAG"
+
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Error: Tag $TAG already exists on remote."
+            echo "Please update the version in cold-wallet-app/pubspec.yaml before creating a new release."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.build-cold.outputs.tag }}
+          name: Quantus Cold Wallet ${{ needs.build-cold.outputs.version }}
+          generate_release_notes: true
+          body: |
+            ## Quantus Cold Wallet - Android Release
+
+            **Version:** ${{ needs.build-cold.outputs.version }}
+
+            ### Installation
+            1. Download the `.apk` file below
+            2. Enable "Install from unknown sources"
+            3. Install
+          files: ./artifacts/quantus_cold_wallet_*.apk
           draft: false
           prerelease: false


### PR DESCRIPTION

@@ -0,0 +1,13 @@
## Summary
- Wallet APK workflow now lets you pick **mobile**, **cold**, or **both**; each selected app builds in parallel and can publish its own public GitHub Release (`wallet-v…` / `cold-wallet-v…`).
- Shared build lives in `.github/workflows/build_wallet_apk.yml` so a cold-wallet failure does not block a mobile release (and vice versa).
- Fixes the mobile release APK failure: pre-install nightly Rust (`rust-src` + Android targets) before `flutter build apk` so two Gradle cargokit tasks stop racing `rustup toolchain install nightly`.

## Test plan
- [ ] Merge to a branch GitHub Actions can run, then **Actions → Create Wallet Android Build → Run workflow**
- [ ] `apps=mobile`, `build_mode=release`, `create_release=false` — signed APK artifact `quantus_wallet-android-release` uploads; no GitHub Release
- [ ] `apps=cold`, `build_mode=release`, `create_release=false` — signed APK artifact `quantus_cold_wallet-android-release` uploads
- [ ] `apps=both`, `build_mode=debug` — both debug APKs upload; no signing/release jobs
- [ ] `apps=mobile` (or both) with `create_release=true` — public release tagged `wallet-v{mobile-app pubspec version}` with the APK attached
- [ ] Confirm the Rust/cargokit step no longer fails on `rustup toolchain install nightly` / “could not rename downloaded file”
- [ ] Confirm cold wallet reuses the existing `ANDROID_*` signing secrets (same keystore as mobile)