### PR TITLE
fix: scope hide-balances to the home screen

### DIFF
--- a/mobile-app/lib/providers/currency_display_provider.dart
+++ b/mobile-app/lib/providers/currency_display_provider.dart
@@ -239,16 +239,17 @@ class CurrencyDisplayState {
 // Balance display provider
 // ---------------------------------------------------------------------------
 
-final _hiddenAmountText = '-----';
-
-/// Combines balance, hidden state, flip state, selected fiat, and exchange
-/// rate into [CurrencyDisplayState] ready for widgets to render.
+/// Combines balance, flip state, selected fiat, and exchange rate into
+/// [CurrencyDisplayState] ready for widgets to render.
+///
+/// Hiding balances is a UX concern owned by the screen that offers the toggle,
+/// which passes it into AmountDisplayWithConversion; it is deliberately absent
+/// here so unrelated screens never inherit it.
 final balanceDisplayProvider = Provider<AsyncValue<CurrencyDisplayState>>((ref) {
   final active = ref.watch(activeAccountProvider).value;
   final balanceAsync = active != null && isEncryptedAccount(active.account)
       ? ref.watch(encryptedBalanceProvider((active.account as Account).walletIndex))
       : ref.watch(balanceProvider);
-  final isHidden = ref.watch(isBalanceHiddenProvider);
   final isFlipped = ref.watch(isCurrencyFlippedProvider);
   final selectedFiat = ref.watch(selectedFiatCurrencyProvider);
   final xRate = ref.watch(exchangeRateServiceProvider);
@@ -264,10 +265,8 @@ final balanceDisplayProvider = Provider<AsyncValue<CurrencyDisplayState>>((ref) 
         selectedFiat,
         xRate,
         fmt,
-        _hiddenAmountText,
         tokenDecimals: 3,
         isFlipped: isFlipped,
-        isHidden: isHidden,
         withTokenSymbol: false,
         localeConfig: localeConfig,
       );
@@ -280,59 +279,53 @@ final balanceDisplayProvider = Provider<AsyncValue<CurrencyDisplayState>>((ref) 
 // Per-amount display provider (for transaction items)
 // ---------------------------------------------------------------------------
 
-final txAmountDisplayProvider =
-    Provider<
-      CurrencyDisplayState Function(
-        BigInt, {
-        required bool isSend,
-        int tokenDecimals,
-        bool withTokenSymbol,
-        bool withSignPrefix,
-        String? customHiddenText,
-      })
-    >((ref) {
-      final isHidden = ref.watch(isBalanceHiddenProvider);
-      final isFlipped = ref.watch(isCurrencyFlippedProvider);
-      final selectedFiat = ref.watch(selectedFiatCurrencyProvider);
-      final xRate = ref.watch(exchangeRateServiceProvider);
-      final fmt = ref.watch(numberFormattingServiceProvider);
-      final localeConfig = ref.watch(localeNumberConfigProvider);
-
-      return (
-        BigInt amount, {
-        required bool isSend,
-        bool withTokenSymbol = true,
-        bool withSignPrefix = true,
-        int tokenDecimals = 2,
-        String? customHiddenText,
-      }) {
-        final hiddenText = customHiddenText ?? _hiddenAmountText;
-        final prefix = isSend ? '-' : '+';
-
-        CurrencyDisplayState data = _toFiatDisplayState(
-          amount,
-          selectedFiat,
-          xRate,
-          fmt,
-          hiddenText,
-          tokenDecimals: tokenDecimals,
-          isHidden: isHidden,
-          withTokenSymbol: withTokenSymbol,
-          isFlipped: isFlipped,
-          localeConfig: localeConfig,
-        );
-
-        if (!isHidden) {
-          data = data.copyWith(primaryAmount: withSignPrefix ? '$prefix${data.primaryAmount}' : data.primaryAmount);
-        }
-
-        if (!withTokenSymbol && isFlipped && !isHidden) {
-          data = data.copyWith(secondaryAmount: '${data.secondaryAmount} ${AppConstants.tokenSymbol}');
-        }
-
-        return data;
-      };
+typedef TxAmountFormatter =
+    CurrencyDisplayState Function(
+      BigInt, {
+      required bool isSend,
+      int tokenDecimals,
+      bool withTokenSymbol,
+      bool withSignPrefix,
     });
+
+final txAmountDisplayProvider = Provider<TxAmountFormatter>((ref) {
+  final isFlipped = ref.watch(isCurrencyFlippedProvider);
+  final selectedFiat = ref.watch(selectedFiatCurrencyProvider);
+  final xRate = ref.watch(exchangeRateServiceProvider);
+  final fmt = ref.watch(numberFormattingServiceProvider);
+  final localeConfig = ref.watch(localeNumberConfigProvider);
+
+  return (
+    BigInt amount, {
+    required bool isSend,
+    bool withTokenSymbol = true,
+    bool withSignPrefix = true,
+    int tokenDecimals = 2,
+  }) {
+    final prefix = isSend ? '-' : '+';
+
+    CurrencyDisplayState data = _toFiatDisplayState(
+      amount,
+      selectedFiat,
+      xRate,
+      fmt,
+      tokenDecimals: tokenDecimals,
+      withTokenSymbol: withTokenSymbol,
+      isFlipped: isFlipped,
+      localeConfig: localeConfig,
+    );
+
+    if (withSignPrefix) {
+      data = data.copyWith(primaryAmount: '$prefix${data.primaryAmount}');
+    }
+
+    if (!withTokenSymbol && isFlipped) {
+      data = data.copyWith(secondaryAmount: '${data.secondaryAmount} ${AppConstants.tokenSymbol}');
+    }
+
+    return data;
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -357,27 +350,19 @@ CurrencyDisplayState _toFiatDisplayState(
   BigInt amount,
   FiatCurrency selectedFiat,
   ExchangeRateService xRate,
-  NumberFormattingService fmt,
-  String hiddenText, {
+  NumberFormattingService fmt, {
   required int tokenDecimals,
   required bool isFlipped,
-  required bool isHidden,
   required bool withTokenSymbol,
   required LocaleNumberConfig localeConfig,
 }) {
   final tokenFormatted = fmt.formatBalance(amount, smartDecimals: tokenDecimals, addSymbol: withTokenSymbol);
   final fiatFormatted = selectedFiat.format(_toFiatNumeric(amount, selectedFiat, xRate, localeConfig: localeConfig));
 
-  CurrencyDisplayState data = CurrencyDisplayState(
+  return CurrencyDisplayState(
     primaryAmount: isFlipped ? fiatFormatted : tokenFormatted,
     secondaryAmount: isFlipped ? tokenFormatted : fiatFormatted,
     isFlipped: isFlipped,
     selectedFiat: selectedFiat,
   );
-
-  if (isHidden) {
-    data = data.copyWith(primaryAmount: hiddenText, secondaryAmount: hiddenText);
-  }
-
-  return data;
 }

--- a/mobile-app/lib/v2/components/amount_display_with_conversion.dart
+++ b/mobile-app/lib/v2/components/amount_display_with_conversion.dart
@@ -3,6 +3,9 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/providers/currency_display_provider.dart';
 
+/// Placeholder rendered in place of an amount the screen has chosen to hide.
+const String hiddenAmountText = '-----';
+
 class AmountDisplayWithConversion extends StatelessWidget {
   final CurrencyDisplayState amountDisplay;
   final VoidCallback? onFlip;
@@ -10,6 +13,10 @@ class AmountDisplayWithConversion extends StatelessWidget {
   final bool colorizeAmount;
   final Color? amountColor;
   final bool useTokenLogo;
+
+  /// Masks both amounts with [hiddenAmountText]. Owned by the screen that
+  /// offers the hide toggle — never read from a global setting here.
+  final bool isHidden;
 
   const AmountDisplayWithConversion({
     super.key,
@@ -19,12 +26,16 @@ class AmountDisplayWithConversion extends StatelessWidget {
     this.colorizeAmount = false,
     this.amountColor,
     this.useTokenLogo = false,
+    this.isHidden = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final text = context.themeText;
     final colors = context.colors;
+
+    final primaryAmount = isHidden ? hiddenAmountText : amountDisplay.primaryAmount;
+    final secondaryAmount = isHidden ? hiddenAmountText : amountDisplay.secondaryAmount;
 
     final primaryAmountColor = amountColor ?? (colorizeAmount ? colors.success : colors.textPrimary);
     final tokenLogoPrimarySize = 32.0;
@@ -60,7 +71,7 @@ class AmountDisplayWithConversion extends StatelessWidget {
               TextSpan(
                 children: [
                   TextSpan(
-                    text: amountDisplay.primaryAmount,
+                    text: primaryAmount,
                     style: text.conversionAmountPrimary?.copyWith(color: primaryAmountColor),
                   ),
                   if (!useTokenLogo && !amountDisplay.isFlipped) ...[
@@ -91,9 +102,9 @@ class AmountDisplayWithConversion extends StatelessWidget {
                 colorFilter: ColorFilter.mode(secondaryAmountColor, BlendMode.srcIn),
               ),
               const SizedBox(width: 2),
-              Text(amountDisplay.secondaryAmount, style: secondaryAmountBaseStyle),
+              Text(secondaryAmount, style: secondaryAmountBaseStyle),
             ] else
-              Text('≈ ${amountDisplay.secondaryAmount}', style: secondaryAmountBaseStyle),
+              Text('≈ $secondaryAmount', style: secondaryAmountBaseStyle),
             if (onFlip != null) ...[
               const SizedBox(width: 8),
               QuantusIconButton.circular(

--- a/mobile-app/lib/v2/screens/activity/activity_screen.dart
+++ b/mobile-app/lib/v2/screens/activity/activity_screen.dart
@@ -174,9 +174,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
                             colors,
                             text,
                             l10n,
-                            formattedAmount: itemData.hideAmount
-                                ? '—'
-                                : formatTxAmount(itemData.amount, isSend: itemData.isSend).primaryAmount,
+                            formattedAmount: txItemAmountText(itemData, formatTxAmount),
                             isLastItem: isLastItem,
                             onTap: () {
                               showTransactionDetailSheet(context, tx, active.account.accountId);

--- a/mobile-app/lib/v2/screens/activity/transaction_detail_sheet.dart
+++ b/mobile-app/lib/v2/screens/activity/transaction_detail_sheet.dart
@@ -176,12 +176,7 @@ class _AmountSection extends ConsumerWidget {
       return Text('—', style: text.transactionDetailAmountPrimary?.copyWith(color: colors.textTertiary));
     }
 
-    final amount = ref.watch(txAmountDisplayProvider)(
-      displayAmount,
-      isSend: true,
-      withTokenSymbol: false,
-      customHiddenText: '-----',
-    );
+    final amount = ref.watch(txAmountDisplayProvider)(displayAmount, isSend: true, withTokenSymbol: false);
 
     return AmountDisplayWithConversion(
       amountDisplay: amount,

--- a/mobile-app/lib/v2/screens/activity/tx_item.dart
+++ b/mobile-app/lib/v2/screens/activity/tx_item.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/l10n/app_localizations.dart';
+import 'package:resonance_network_wallet/providers/currency_display_provider.dart';
 import 'package:resonance_network_wallet/shared/extensions/transaction_event_extension.dart';
+import 'package:resonance_network_wallet/v2/components/amount_display_with_conversion.dart';
 
 class TxItemData {
   final String label;
@@ -323,6 +325,17 @@ class TxItemData {
       counterpartyAddr: AddressFormattingService.formatAddress(isSend ? tx.to : tx.from, prefix: 5, postFix: 3),
     );
   }
+}
+
+/// Amount text for a transaction row.
+///
+/// [isHidden] is passed down by the screen that owns the hide-balances toggle;
+/// the amount formatter has no notion of hidden balances.
+String txItemAmountText(TxItemData data, TxAmountFormatter format, {bool isHidden = false}) {
+  if (isHidden) return hiddenAmountText;
+  if (data.hideAmount) return '—';
+
+  return format(data.amount, isSend: data.isSend).primaryAmount;
 }
 
 Widget buildTxItem(

--- a/mobile-app/lib/v2/screens/home/activity_section.dart
+++ b/mobile-app/lib/v2/screens/home/activity_section.dart
@@ -20,7 +20,17 @@ class ActivitySection extends ConsumerStatefulWidget {
   final BaseAccount activeAccount;
   final Future<void> Function()? onRetry;
 
-  const ActivitySection({super.key, required this.txAsync, required this.activeAccount, this.onRetry});
+  /// Masks the listed amounts. Passed down by the home screen, which owns the
+  /// hide-balances toggle.
+  final bool isHidden;
+
+  const ActivitySection({
+    super.key,
+    required this.txAsync,
+    required this.activeAccount,
+    this.onRetry,
+    this.isHidden = false,
+  });
 
   @override
   ConsumerState<ActivitySection> createState() => _ActivitySectionState();
@@ -85,7 +95,7 @@ class _ActivitySectionState extends ConsumerState<ActivitySection> {
                 colors,
                 text,
                 l10n,
-                formattedAmount: data.hideAmount ? '—' : formatTxAmount(data.amount, isSend: data.isSend).primaryAmount,
+                formattedAmount: txItemAmountText(data, formatTxAmount, isHidden: widget.isHidden),
                 isLastItem: isLastItem,
                 itemKey: itemKey,
                 onTap: () {

--- a/mobile-app/lib/v2/screens/home/home_screen.dart
+++ b/mobile-app/lib/v2/screens/home/home_screen.dart
@@ -191,6 +191,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final l10n = ref.watch(l10nProvider);
     final accountAsync = ref.watch(activeAccountProvider);
     final txAsync = ref.watch(activeAccountTransactionsProvider(TransactionFilter.all));
+    final isBalanceHidden = ref.watch(isBalanceHiddenProvider);
     final colors = context.colors;
     final text = context.themeText;
 
@@ -210,11 +211,21 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           return ScaffoldBase.refreshable(
             onRefresh: _refresh,
             slivers: [
-              _buildContent(active, colors, text, l10n),
+              _buildContent(active, colors, text, l10n, isBalanceHidden),
               if (active is MultisigDisplayAccount)
-                MultisigActivitySection(msig: active.account, txAsync: txAsync, onRetry: _refresh)
+                MultisigActivitySection(
+                  msig: active.account,
+                  txAsync: txAsync,
+                  onRetry: _refresh,
+                  isHidden: isBalanceHidden,
+                )
               else
-                ActivitySection(txAsync: txAsync, activeAccount: active.account, onRetry: _refresh),
+                ActivitySection(
+                  txAsync: txAsync,
+                  activeAccount: active.account,
+                  onRetry: _refresh,
+                  isHidden: isBalanceHidden,
+                ),
               const SizedBox(height: 58),
             ],
             bottomContent: _buildBottomContent(l10n),
@@ -224,16 +235,22 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     );
   }
 
-  Widget _buildContent(DisplayAccount active, AppColorsV2 colors, AppTextTheme text, AppLocalizations l10n) {
+  Widget _buildContent(
+    DisplayAccount active,
+    AppColorsV2 colors,
+    AppTextTheme text,
+    AppLocalizations l10n,
+    bool isBalanceHidden,
+  ) {
     final backupWalletIndex = ref.watch(backupReminderWalletIndexProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 16),
-        _buildTopBar(),
+        _buildTopBar(isBalanceHidden),
         const SizedBox(height: 40),
-        _buildBalance(colors, text, l10n),
+        _buildBalance(colors, text, l10n, isBalanceHidden),
         const SizedBox(height: 40),
         if (active is MultisigDisplayAccount) ...[
           _buildMultisigActionButtons(l10n, active.account),
@@ -294,9 +311,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         .value;
   }
 
-  Widget _buildTopBar() {
-    final isBalanceHidden = ref.watch(isBalanceHiddenProvider);
-
+  Widget _buildTopBar(bool isBalanceHidden) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -324,7 +339,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     );
   }
 
-  Widget _buildBalance(AppColorsV2 colors, AppTextTheme text, AppLocalizations l10n) {
+  Widget _buildBalance(AppColorsV2 colors, AppTextTheme text, AppLocalizations l10n, bool isBalanceHidden) {
     final currencyAsync = ref.watch(balanceDisplayProvider);
 
     return Column(
@@ -337,6 +352,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               onFlip: _toggleFlip,
               alignment: CrossAxisAlignment.center,
               useTokenLogo: true,
+              isHidden: isBalanceHidden,
             );
           },
           loading: () => const Column(

--- a/mobile-app/lib/v2/screens/multisig/multisig_activity_section.dart
+++ b/mobile-app/lib/v2/screens/multisig/multisig_activity_section.dart
@@ -26,7 +26,18 @@ class MultisigActivitySection extends ConsumerWidget {
   final AsyncValue<CombinedTransactionsList> txAsync;
   final Future<void> Function()? onRetry;
 
-  const MultisigActivitySection({super.key, required this.msig, required this.txAsync, this.onRetry});
+  /// Masks the amounts in the activity feed. Passed down by the home screen,
+  /// which owns the hide-balances toggle. Open proposals are never masked:
+  /// they are pending decisions, not balance disclosure.
+  final bool isHidden;
+
+  const MultisigActivitySection({
+    super.key,
+    required this.msig,
+    required this.txAsync,
+    this.onRetry,
+    this.isHidden = false,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -164,9 +175,7 @@ class MultisigActivitySection extends ConsumerWidget {
                   colors,
                   text,
                   l10n,
-                  formattedAmount: itemData.hideAmount
-                      ? '—'
-                      : formatTxAmount(itemData.amount, isSend: itemData.isSend).primaryAmount,
+                  formattedAmount: txItemAmountText(itemData, formatTxAmount, isHidden: isHidden),
                   isLastItem: index == recent.length - 1,
                   onTap: () => _onTap(context, tx),
                 );


### PR DESCRIPTION
## Problem

`isBalanceHiddenProvider` was read *inside* the amount formatters — `balanceDisplayProvider` and `txAmountDisplayProvider` in `currency_display_provider.dart`. Every screen that formats an amount goes through that provider, so the eye toggle on home masked amounts that have nothing to do with the account balance:

- multisig open proposals (`ProposalListTile`) and decoded calls in the approve/execute/cancel confirm sheets
- POS charge + QR screens
- send input amount, review send
- transaction detail sheet

## Change

The formatter no longer has any notion of hidden balances. The home screen owns the flag and passes it explicitly to the components it contains:

- `AmountDisplayWithConversion.isHidden` → masks the main balance
- `ActivitySection.isHidden` / `MultisigActivitySection.isHidden` → masks the amounts in the home transaction list

Everything else formats amounts normally, always. Open multisig proposals are **not** masked even on a multisig home — they are pending decisions to review, not balance disclosure.

The toggle itself still persists via `SettingsService`; only the home screen reads it now.

## DRY

- `txItemAmountText(data, format, {isHidden})` in `tx_item.dart` replaces three copies of the `hideAmount ? '—' : format(...).primaryAmount` ternary (home, multisig, activity screen)
- the formatter's inline function type is now a `TxAmountFormatter` typedef
- `customHiddenText` is gone — its only caller passed the same `'-----'` the default already used; the placeholder now lives once, next to the component that renders it
- `_toFiatDisplayState` lost two parameters and its post-hoc mutation, so it just builds and returns the state

## Verification

- `dart analyze lib test` in `mobile-app`: no issues
- `flutter test` in `mobile-app`: 291 tests pass
- `melos run format` clean

(`melos run analyze` can't complete locally — it dies in `flutter pub get` on a firebase_messaging plugin rsync error unrelated to this change.)