### PR TITLE
Send minimum is the wormhole quantum (0.01 QUAN)

### DIFF
--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -1571,9 +1571,17 @@
     "@sendLogicInvalidAmount": {
       "description": "Button label when amount is negative"
     },
-    "sendLogicBelowExistentialDeposit": "Below Existential Deposit",
-    "@sendLogicBelowExistentialDeposit": {
-      "description": "Button label when amount is below existential deposit"
+    "sendLogicBelowMinimum": "Minimum is {amount} {tokenSymbol}",
+    "@sendLogicBelowMinimum": {
+      "description": "Button label when amount is below the minimum send amount (one wormhole leaf quantum)",
+      "placeholders": {
+        "amount": {
+          "type": "String"
+        },
+        "tokenSymbol": {
+          "type": "String"
+        }
+      }
     },
     "sendLogicInsufficientBalance": "Insufficient Balance",
     "@sendLogicInsufficientBalance": {

--- a/mobile-app/lib/l10n/app_id.arb
+++ b/mobile-app/lib/l10n/app_id.arb
@@ -296,7 +296,7 @@
   "sendLogicCantSelfTransfer": "Tidak Bisa Transfer ke Diri Sendiri",
   "sendLogicEnterAmount": "Masukkan Jumlah",
   "sendLogicInvalidAmount": "Jumlah Tidak Valid",
-  "sendLogicBelowExistentialDeposit": "Di Bawah Deposit Eksistensial",
+  "sendLogicBelowMinimum": "Minimum {amount} {tokenSymbol}",
   "sendLogicInsufficientBalance": "Saldo Tidak Cukup",
   "sendLogicReviewSend": "Tinjau Pengiriman",
   "activityTitle": "Aktivitas",

--- a/mobile-app/lib/l10n/app_localizations.dart
+++ b/mobile-app/lib/l10n/app_localizations.dart
@@ -2096,11 +2096,11 @@ abstract class AppLocalizations {
   /// **'Invalid Amount'**
   String get sendLogicInvalidAmount;
 
-  /// Button label when amount is below existential deposit
+  /// Button label when amount is below the minimum send amount (one wormhole leaf quantum)
   ///
   /// In en, this message translates to:
-  /// **'Below Existential Deposit'**
-  String get sendLogicBelowExistentialDeposit;
+  /// **'Minimum is {amount} {tokenSymbol}'**
+  String sendLogicBelowMinimum(String amount, String tokenSymbol);
 
   /// Button label when balance is insufficient
   ///

--- a/mobile-app/lib/l10n/app_localizations_en.dart
+++ b/mobile-app/lib/l10n/app_localizations_en.dart
@@ -1105,7 +1105,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sendLogicInvalidAmount => 'Invalid Amount';
 
   @override
-  String get sendLogicBelowExistentialDeposit => 'Below Existential Deposit';
+  String sendLogicBelowMinimum(String amount, String tokenSymbol) {
+    return 'Minimum is $amount $tokenSymbol';
+  }
 
   @override
   String get sendLogicInsufficientBalance => 'Insufficient Balance';

--- a/mobile-app/lib/l10n/app_localizations_id.dart
+++ b/mobile-app/lib/l10n/app_localizations_id.dart
@@ -1108,7 +1108,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get sendLogicInvalidAmount => 'Jumlah Tidak Valid';
 
   @override
-  String get sendLogicBelowExistentialDeposit => 'Di Bawah Deposit Eksistensial';
+  String sendLogicBelowMinimum(String amount, String tokenSymbol) {
+    return 'Minimum $amount $tokenSymbol';
+  }
 
   @override
   String get sendLogicInsufficientBalance => 'Saldo Tidak Cukup';

--- a/mobile-app/lib/v2/screens/send/send_screen_logic.dart
+++ b/mobile-app/lib/v2/screens/send/send_screen_logic.dart
@@ -1,10 +1,15 @@
 import 'package:quantus_sdk/quantus_sdk.dart';
-import 'package:quantus_sdk/generated/planck/pallets/balances.dart' as balances;
 import 'package:resonance_network_wallet/l10n/app_localizations.dart';
 
-enum AmountStatus { valid, negative, zero, belowExistential, insufficientBalance }
+enum AmountStatus { valid, negative, zero, belowMinimum, insufficientBalance }
 
 class SendScreenLogic {
+  /// Smallest amount any send may move: one wormhole leaf quantum (0.01 token).
+  /// A recipient can be a wormhole address, and anything below the quantum is
+  /// committed as a zero-value leaf there — so it is rejected on the way in
+  /// rather than at proving time. Sits above the existential deposit.
+  static BigInt get minimumSendAmount => wormholeScaleFactor;
+
   static bool _isSelfTransfer(String recipient, String activeAccountId) {
     return recipient.isNotEmpty && recipient == activeAccountId;
   }
@@ -12,14 +17,14 @@ class SendScreenLogic {
   static AmountStatus getAmountStatus(BigInt amount, BigInt balance, BigInt networkFee) {
     if (amount < BigInt.zero) return AmountStatus.negative;
     if (amount == BigInt.zero) return AmountStatus.zero;
-    if (amount < balances.Constants().existentialDeposit) return AmountStatus.belowExistential;
+    if (amount < minimumSendAmount) return AmountStatus.belowMinimum;
     if ((amount + networkFee) > balance) return AmountStatus.insufficientBalance;
     return AmountStatus.valid;
   }
 
   static bool hasAmountError({required BigInt amount, required BigInt balance, required BigInt networkFee}) {
     final status = getAmountStatus(amount, balance, networkFee);
-    return status == AmountStatus.belowExistential ||
+    return status == AmountStatus.belowMinimum ||
         status == AmountStatus.insufficientBalance ||
         status == AmountStatus.negative;
   }
@@ -53,8 +58,8 @@ class SendScreenLogic {
         return l10n.sendLogicEnterAmount;
       case AmountStatus.negative:
         return l10n.sendLogicInvalidAmount;
-      case AmountStatus.belowExistential:
-        return l10n.sendLogicBelowExistentialDeposit;
+      case AmountStatus.belowMinimum:
+        return l10n.sendLogicBelowMinimum(formattingService.formatAmount(minimumSendAmount), AppConstants.tokenSymbol);
       case AmountStatus.insufficientBalance:
         return l10n.sendLogicInsufficientBalance;
       case AmountStatus.valid:

--- a/mobile-app/test/unit/send_screen_logic_test.dart
+++ b/mobile-app/test/unit/send_screen_logic_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:quantus_sdk/quantus_sdk.dart';
 import 'package:resonance_network_wallet/l10n/app_localizations.dart';
 import 'package:resonance_network_wallet/v2/screens/send/send_screen_logic.dart';
-import 'package:quantus_sdk/generated/planck/pallets/balances.dart' as balances;
 
 void main() {
   group('SendScreenLogic', () {
@@ -21,23 +20,28 @@ void main() {
         expect(status, AmountStatus.zero);
       });
 
-      test('returns belowExistential when < ED', () {
+      test('returns belowMinimum below one wormhole quantum', () {
         final status = SendScreenLogic.getAmountStatus(
-          balances.Constants().existentialDeposit - BigInt.one,
+          SendScreenLogic.minimumSendAmount - BigInt.one,
           BigInt.from(5000000000000),
           BigInt.from(100),
         );
-        expect(status, AmountStatus.belowExistential);
+        expect(status, AmountStatus.belowMinimum);
+      });
+
+      test('minimum send amount is the wormhole quantum (0.01 token)', () {
+        expect(SendScreenLogic.minimumSendAmount, wormholeScaleFactor);
+        expect(SendScreenLogic.minimumSendAmount, BigInt.from(10000000000));
       });
 
       test('returns insufficientBalance when amount + fee > balance', () {
-        final status = SendScreenLogic.getAmountStatus(BigInt.from(1_000_000_000), BigInt.from(1000), BigInt.from(10));
+        final status = SendScreenLogic.getAmountStatus(BigInt.from(10_000_000_000), BigInt.from(1000), BigInt.from(10));
         expect(status, AmountStatus.insufficientBalance);
       });
 
-      test('returns valid for correct inputs', () {
+      test('returns valid at exactly the minimum', () {
         final status = SendScreenLogic.getAmountStatus(
-          BigInt.from(1_000_000_000),
+          SendScreenLogic.minimumSendAmount,
           BigInt.from(1_000_000_000_000),
           BigInt.from(10),
         );
@@ -79,7 +83,7 @@ void main() {
       test('returns true when amount has error', () {
         final result = SendScreenLogic.isButtonDisabled(
           hasAddressError: false,
-          amountStatus: AmountStatus.belowExistential,
+          amountStatus: AmountStatus.belowMinimum,
           recipientText: 'valid_address',
           activeAccountId: 'sender_address',
         );
@@ -170,17 +174,17 @@ void main() {
         expect(result, equals(l10n.sendLogicCantSelfTransfer));
       });
 
-      test('returns "Below Existential Deposit" when status matches', () {
+      test('returns the minimum amount when status is belowMinimum', () {
         final result = SendScreenLogic.getButtonText(
           l10n: l10n,
           hasAddressError: false,
-          amountStatus: AmountStatus.belowExistential,
+          amountStatus: AmountStatus.belowMinimum,
           recipientText: 'valid_address',
           amount: BigInt.from(1),
           activeAccountId: 'sender_address',
           formattingService: formattingService,
         );
-        expect(result, equals(l10n.sendLogicBelowExistentialDeposit));
+        expect(result, equals(l10n.sendLogicBelowMinimum('0.01', AppConstants.tokenSymbol)));
       });
 
       test('returns Review Send for valid status', () {

--- a/quantus_sdk/lib/src/services/wormhole_coin_selection.dart
+++ b/quantus_sdk/lib/src/services/wormhole_coin_selection.dart
@@ -1,3 +1,4 @@
+import 'package:quantus_sdk/generated/planck/pallets/vesting.dart' as vesting_pallet;
 import 'package:quantus_sdk/generated/planck/pallets/wormhole.dart' as wormhole_pallet;
 import 'package:quantus_sdk/src/services/wormhole_utxo_service.dart';
 
@@ -13,10 +14,14 @@ String wormholeVolumeFeePercentText() {
   return percent == percent.truncateToDouble() ? percent.toInt().toString() : percent.toString();
 }
 
-/// Scaled-down → token multiplier; matches `SCALE_DOWN_FACTOR` in the Rust
-/// wormhole API. Proofs commit to amounts in scaled-down units (0.01 tokens) and
-/// the chain dispatches `outputAmount * scaleFactor` token units.
-final BigInt wormholeScaleFactor = BigInt.from(10000000000);
+/// Scaled-down → token multiplier (`SCALE_DOWN_FACTOR` in the Rust wormhole
+/// API). Proofs commit to amounts in scaled-down units (0.01 tokens) and the
+/// chain dispatches `outputAmount * scaleFactor` token units. The wormhole
+/// pallet exposes no constant for it, so this comes from the shipped metadata's
+/// `Vesting::PayoutQuantum`, which the runtime defines as
+/// `pallet_wormhole::SCALE_DOWN_FACTOR` — same rule as the volume fee above,
+/// never a hand-edited value.
+final BigInt wormholeScaleFactor = vesting_pallet.Constants().payoutQuantum;
 
 /// Chain's `MinimumTransferAmount` (0.1 token) in scaled units, enforced per
 /// aggregated batch on the total exit amount.


### PR DESCRIPTION
## What

The send screen's minimum amount was the existential deposit (0.001 QUAN). Any recipient can be a wormhole address, and the wormhole circuit quantizes amounts to 0.01 QUAN — below one quantum a transfer is committed as a zero-value leaf. The floor is now that quantum, so a too-small send is rejected at input rather than becoming unrecoverable dust.

- `SendScreenLogic.minimumSendAmount` = `wormholeScaleFactor`; `AmountStatus.belowExistential` → `belowMinimum`.
- Button label `Below Existential Deposit` → `Minimum is 0.01 QUAN`, with the amount and symbol as placeholders so the text follows the constant (en + id).

## Where the value comes from

Not hardcoded. The wormhole pallet exposes no constant for `SCALE_DOWN_FACTOR`, but the runtime defines

```rust
pub const VestingPayoutQuantum: Balance = pallet_wormhole::SCALE_DOWN_FACTOR;
```

which *is* in the metadata, so `wormholeScaleFactor` now reads `Vesting::PayoutQuantum` from the shipped generated bindings — the same rule as `wormholeVolumeFeeBps` in #610. A runtime that changes the quantum needs regenerated bindings, never a hand-edited literal.

## Testing

- `flutter test test/unit` (mobile-app, 272 tests) and `flutter test test/services/wormhole_coin_selection_test.dart` (quantus_sdk) pass.
- `flutter analyze . --fatal-infos` clean in both packages.